### PR TITLE
Get rid of ambiguous column with team based scopes.

### DIFF
--- a/app/models/pay/subscription.rb
+++ b/app/models/pay/subscription.rb
@@ -14,7 +14,7 @@ module Pay
 
     # Scopes
     scope :for_name, ->(name) { where(name: name) }
-    scope :on_trial, ->{ where.not(trial_ends_at: nil).where("? < trial_ends_at", Time.zone.now) }
+    scope :on_trial, ->{ where.not(trial_ends_at: nil).where("? < #{table_name}.trial_ends_at", Time.zone.now) }
     scope :cancelled, ->{ where.not(ends_at: nil) }
     scope :on_grace_period, ->{ cancelled.where("? < ends_at", Time.zone.now) }
     scope :active, ->{ where(ends_at: nil).or(on_grace_period).or(on_trial) }

--- a/app/models/pay/subscription.rb
+++ b/app/models/pay/subscription.rb
@@ -16,7 +16,7 @@ module Pay
     scope :for_name, ->(name) { where(name: name) }
     scope :on_trial, ->{ where.not(trial_ends_at: nil).where("? < #{table_name}.trial_ends_at", Time.zone.now) }
     scope :cancelled, ->{ where.not(ends_at: nil) }
-    scope :on_grace_period, ->{ cancelled.where("? < ends_at", Time.zone.now) }
+    scope :on_grace_period, ->{ cancelled.where("? < #{table_name}.ends_at", Time.zone.now) }
     scope :active, ->{ where(ends_at: nil).or(on_grace_period).or(on_trial) }
 
     attribute :prorate, :boolean, default: true


### PR DESCRIPTION
When trying to add scopes to the `Team` class in jumpstart (but applicable in other scenarios) we run into ambiguous column error. This should remove that.