### PR TITLE
Update pay confirmation page

### DIFF
--- a/app/views/layouts/pay/application.html.erb
+++ b/app/views/layouts/pay/application.html.erb
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
-<html>
-<head class="h-full">
+<html class="h-full">
+<head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>Payment Confirmation - <%= Pay.business_name %></title>

--- a/app/views/pay/payments/show.html.erb
+++ b/app/views/pay/payments/show.html.erb
@@ -1,4 +1,4 @@
-<div id="app" class="h-full md:flex md:justify-center md:items-center">
+<div id="app" class="h-screen md:flex md:justify-center md:items-center">
   <div class="w-full max-w-lg">
     <!-- Status Messages -->
     <p class="flex items-center mb-4 bg-red-100 border border-red-200 px-5 py-2 rounded-lg text-red-500" v-if="errorMessage">


### PR DESCRIPTION
This prevents the payment intent confirmation page from "jumping" around as the Stripe modal appears/closes.

I believe the idea was to place the panel vertically central on the page, this pull request fixes it.

Alternatively, the main `application.html.erb` could be tweaked as it also has a few `h-full` css classes.

Rikki