### PR TITLE
Allow running migration on Rails 4.2

### DIFF
--- a/db/migrate/20170727235816_create_pay_charges.rb
+++ b/db/migrate/20170727235816_create_pay_charges.rb
@@ -1,4 +1,4 @@
-class CreatePayCharges < ActiveRecord::Migration[5.1]
+class CreatePayCharges < ActiveRecord::Migration[4.2]
   def change
     create_table :pay_charges do |t|
       t.references :owner

--- a/db/migrate/20190816015720_add_status_to_pay_subscriptions.rb
+++ b/db/migrate/20190816015720_add_status_to_pay_subscriptions.rb
@@ -1,4 +1,4 @@
-class AddStatusToPaySubscriptions < ActiveRecord::Migration[5.2]
+class AddStatusToPaySubscriptions < ActiveRecord::Migration[4.2]
   def self.up
     add_column :pay_subscriptions, :status, :string
 


### PR DESCRIPTION
I'm currently integrating into a Rails 5.0 app.  The README mentions that Rails 4.2 and above is supported.

However running the migrations gives `ArgumentError: Unknown migration version "5.1"; expected one of "4.2", "5.0"` since two fo the migrations are targeted to `5.1` and `5.2`

I didn't notice anything 5.x specific in the migrations, so changed their version number to support 4.2