### PR TITLE
Sets status back to active when resuming a subscription

### DIFF
--- a/app/models/pay/subscription.rb
+++ b/app/models/pay/subscription.rb
@@ -82,7 +82,7 @@ module Pay
 
       send("#{processor}_resume")
 
-      update(ends_at: nil)
+      update(ends_at: nil, status: "active")
       self
     end
 


### PR DESCRIPTION
When resuming a subscription that's on a grace period, the status stays `canceled`.

This will set the status back to active when resuming.