### PR TITLE
Fix subscription status scopes

### DIFF
--- a/app/models/pay/subscription.rb
+++ b/app/models/pay/subscription.rb
@@ -17,9 +17,9 @@ module Pay
 
     # Scopes
     scope :for_name, ->(name) { where(name: name) }
-    scope :on_trial, -> { where.not(trial_ends_at: nil).where("trial_ends_at > ?", Time.zone.now) }
+    scope :on_trial, -> { where.not(trial_ends_at: nil).where("#{table_name}.trial_ends_at > ?", Time.zone.now) }
     scope :cancelled, -> { where.not(ends_at: nil) }
-    scope :on_grace_period, -> { cancelled.where("ends_at > ?", Time.zone.now) }
+    scope :on_grace_period, -> { cancelled.where("#{table_name}.ends_at > ?", Time.zone.now) }
     scope :active, -> { where(ends_at: nil).or(on_grace_period).or(on_trial) }
     scope :incomplete, -> { where(status: :incomplete) }
     scope :past_due, -> { where(status: :past_due) }


### PR DESCRIPTION
This adds the scope specificity back in that was introduced in
2f61c38f7c8a55a03d1a3b7ea0f1e4d504a4d73f but lost in 89c590cbbd21c2120ff35b60a75410a10e268fdc.

Originally committed by: @caseyprovost

Related: #94