### PR TITLE
Use Stripe payment method ID when setting default

### DIFF
--- a/lib/pay/stripe/billable.rb
+++ b/lib/pay/stripe/billable.rb
@@ -139,8 +139,8 @@ module Pay
 
         # Update the user's card on file if a token was passed in
         if card_token.present?
-          ::Stripe::PaymentMethod.attach(card_token, {customer: customer.id})
-          customer.invoice_settings.default_payment_method = card_token
+          payment_method = ::Stripe::PaymentMethod.attach(card_token, {customer: customer.id})
+          customer.invoice_settings.default_payment_method = payment_method.id
           customer.save
 
           update_stripe_card_on_file ::Stripe::PaymentMethod.retrieve(card_token).card


### PR DESCRIPTION
Generally the payment method ID returned from Stripe::PaymentMethod.attach should match the `card_token` passed into this method however this is not the case when using Stripe test payment tokens (e.g. `pm_card_visa`) - these virtual tokens create a copy of that test card attached to the customer with a new, unique ID. 

Trying to set `invoice_settings.default_payment_method` to the virtual payment method ID subsequently fails as the customer does not have a payment method with that ID. As is done in `update_stripe_card`, the returned payment method ID should be used instead.

I ran into this bug trying to write some integration tests against a Stripe test account (I know automated tests should not generally hit the API, I do plan to swap in a fake server or VCR once I've got them working properly).