### PR TITLE
Udpate name to customer_name in useer mailer

### DIFF
--- a/app/mailers/pay/user_mailer.rb
+++ b/app/mailers/pay/user_mailer.rb
@@ -44,8 +44,8 @@ module Pay
     private
 
     def to(user)
-      if user.respond_to?(:name)
-        "#{user.name} <#{user.email}>"
+      if user.respond_to?(:customer_name)
+        "#{user.customer_name} <#{user.email}>"
       else
         user.email
       end


### PR DESCRIPTION
Fixes https://github.com/pay-rails/pay/issues/148

The user mailer was incorrectly looking for the `name` attribute but the [billable](https://github.com/pay-rails/pay/blob/master/lib/pay/billable.rb#L45) model only has a `customer_name` attribute.