### PR TITLE
Subscriptions: Billable model with string as ID will not be saved properly

### DIFF
--- a/db/migrate/20170205020145_create_pay_subscriptions.rb
+++ b/db/migrate/20170205020145_create_pay_subscriptions.rb
@@ -1,7 +1,7 @@
 class CreatePaySubscriptions < ActiveRecord::Migration[4.2]
   def change
     create_table :pay_subscriptions do |t|
-      t.references :owner
+      t.references :owner, type: :string
       t.string :name, null: false
       t.string :processor, null: false
       t.string :processor_id, null: false


### PR DESCRIPTION
# Problem
I have a Billable object called store that uses string as an id:
```
create_table "stores", id: :string, force: :cascade do |t|
    ...
    t.index ["id"], name: "index_stores_on_id", unique: true
  end
```

In my particular case, after user subscribes -- owner_id ends up missing, because of type mismatch..

# Proposed solution
If we change owner_id to string type, it will work in case of ID being a string and integer. I think it's a safer default migration.