### PR TITLE
Initialize Subscription with required values (Stripe Webhook)

### DIFF
--- a/lib/pay/stripe/webhooks/subscription_created.rb
+++ b/lib/pay/stripe/webhooks/subscription_created.rb
@@ -18,7 +18,7 @@ module Pay
               return
             end
 
-            subscription = Pay.subscription_model.new(owner: owner)
+            subscription = Pay.subscription_model.new(name: "default", owner: owner, processor: :stripe, processor_id: object.id)
           end
 
           subscription.quantity = object.quantity


### PR DESCRIPTION
When the `customer.subscription.created` event is triggered in Stripe, the subsequent Pay webhook fails when it cannot find an existing subscription and tries to create a new one.

Initialize `Pay.subscription_model` with the required attribute values.

Resolves #184  