### PR TITLE
Allow pay 'Go back' button to be configured via ?back=/path/to/item

### DIFF
--- a/app/controllers/pay/payments_controller.rb
+++ b/app/controllers/pay/payments_controller.rb
@@ -1,6 +1,7 @@
 module Pay
   class PaymentsController < ApplicationController
     def show
+      @redirect_to = params[:back].presence || root_path
       @payment = Payment.from_id(params[:id])
     end
   end

--- a/app/views/pay/payments/show.html.erb
+++ b/app/views/pay/payments/show.html.erb
@@ -51,7 +51,7 @@
         </div>
       <% end %>
 
-      <%= link_to t("back"), root_path, class: "inline-block w-full px-4 py-3 bg-gray-200 hover:bg-gray-300 text-center text-gray-700 rounded-lg" %>
+      <%= link_to t("back"), @redirect_to, class: "inline-block w-full px-4 py-3 bg-gray-200 hover:bg-gray-300 text-center text-gray-700 rounded-lg" %>
     </div>
 
     <p class="text-center text-gray-500 text-sm">


### PR DESCRIPTION
Currently the "Go back" button is linked to `root_path`. This PR allows a `?back=/path/to/item` attribute to be provided to the `/payments/pi_xyz?back=%2Fpath` URL