### PR TITLE
Fix polymorphic querying for charges and subscriptions

### DIFF
--- a/lib/pay/billable.rb
+++ b/lib/pay/billable.rb
@@ -20,8 +20,8 @@ module Pay
       include Pay::Stripe::Billable if defined? ::Stripe
       include Pay::Braintree::Billable if defined? ::Braintree
 
-      has_many :charges, class_name: Pay.chargeable_class, foreign_key: :owner_id, inverse_of: :owner
-      has_many :subscriptions, class_name: Pay.subscription_class, foreign_key: :owner_id, inverse_of: :owner
+      has_many :charges, class_name: Pay.chargeable_class, foreign_key: :owner_id, inverse_of: :owner, as: :owner
+      has_many :subscriptions, class_name: Pay.subscription_class, foreign_key: :owner_id, inverse_of: :owner, as: :owner
 
       attribute :plan, :string
       attribute :quantity, :integer

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -43,6 +43,7 @@ ActiveRecord::Schema.define(version: 2019_08_16_015720) do
   end
 
   create_table "teams", force: :cascade do |t|
+    t.integer "owner_id"
     t.string "email"
     t.string "name"
     t.string "processor"

--- a/test/pay/billable_test.rb
+++ b/test/pay/billable_test.rb
@@ -253,4 +253,17 @@ class Pay::Billable::Test < ActiveSupport::TestCase
     @billable.processor = "braintree"
     assert_equal nil, @billable.processor_id
   end
+
+  test "finds polymorphic subscription" do
+    user_billable = User.create! email: "test@example.com", id: 1001
+    team_billable = Team.create! id: 1001, owner: user_billable
+
+    subscription = Pay.subscription_model.create!(
+      owner: team_billable, name: "default", processor: "stripe", processor_id: "1",
+      processor_plan: "default", quantity: "1", status: "active"
+    )
+
+    assert_equal nil, user_billable.subscription
+    assert_equal subscription, team_billable.subscription
+  end
 end

--- a/test/pay/chargeable_test.rb
+++ b/test/pay/chargeable_test.rb
@@ -17,4 +17,16 @@ class Pay::Charge::Test < ActiveSupport::TestCase
     @charge.card_last4 = 1234
     assert_equal "VISA (**** **** **** 1234)", @charge.charged_to
   end
+
+  test "finds polymorphic charge" do
+    user_chargeable = User.create! email: "test@example.com", id: 1001
+    team_chargeable = Team.create! id: 1001, owner: user_chargeable
+
+    charge = Pay.charge_model.create!(
+      owner: team_chargeable, amount: 1, processor: "stripe", processor_id: "1", card_type: "VISA"
+    )
+
+    assert_equal [], user_chargeable.charges
+    assert_equal [charge], team_chargeable.charges
+  end
 end


### PR DESCRIPTION
Before the change, `as: :owner` was missing from the relations from a billable to charges and subscriptions defined when including Billable into a model.

When two billables from different models had the same id, querying from one of them could return the subscriptions or charges from the other.

Fixes #207 