### PR TITLE
Update customer create to use new stripe name column

### DIFF
--- a/lib/pay/stripe/billable.rb
+++ b/lib/pay/stripe/billable.rb
@@ -97,7 +97,7 @@ module Pay
       def update_stripe_email!
         customer = stripe_customer
         customer.email = email
-        customer.description = customer_name
+        customer.name = customer_name
         customer.save
       end
 
@@ -137,7 +137,7 @@ module Pay
       private
 
       def create_stripe_customer
-        customer = ::Stripe::Customer.create(email: email, description: customer_name)
+        customer = ::Stripe::Customer.create(email: email, name: customer_name)
         update(processor: "stripe", processor_id: customer.id)
 
         # Update the user's card on file if a token was passed in


### PR DESCRIPTION
Stripe::Customer objects now have a name field.
This pull request changes storing the customer name from the customer description to name.