### PR TITLE
Fix typo in error message

### DIFF
--- a/lib/pay.rb
+++ b/lib/pay.rb
@@ -124,7 +124,7 @@ module Pay
     end
 
     def message
-      "This payment attempt failed beacuse of an invalid payment method."
+      "This payment attempt failed because of an invalid payment method."
     end
   end
 


### PR DESCRIPTION
`beacuse` > `because`