### PR TITLE
Sync current payment information from paddle

### DIFF
--- a/test/pay/paddle/billable_test.rb
+++ b/test/pay/paddle/billable_test.rb
@@ -26,4 +26,29 @@ class Pay::Paddle::Billable::Test < ActiveSupport::TestCase
     subscription = ::PaddlePay::Subscription::User.list({subscription_id: "3576390"}, {}).try(:first)
     assert_equal @billable.paddle_subscription("3576390").subscription_id, subscription[:subscription_id]
   end
+
+  test "paddle can sync payment information" do
+    subscription_user = {
+      subscription_id: 7654321,
+      plan_id: 123456,
+      user_id: 12345678,
+      user_email: "test@example.com",
+      marketing_consent: false,
+      update_url: "https://example.com",
+      cancel_url: "https://example.com",
+      state: "active",
+      signup_date: "2020-12-08 07:52:22",
+      last_payment: {amount: 0, currency: "USD", date: "2020-12-08"}, linked_subscriptions: [],
+      payment_information: {payment_method: "card", card_type: "visa", last_four_digits: "0020", expiry_date: "06/2022"},
+      next_payment: {amount: 0, currency: "USD", date: "2021-01-08"}
+    }
+    PaddlePay::Subscription::User.stubs(:list).returns([subscription_user])
+
+    @billable.sync_payment_information_from_paddle
+
+    assert_equal "visa", @billable.card_type
+    assert_equal "0020", @billable.card_last4
+    assert_equal "06", @billable.card_exp_month
+    assert_equal "2022", @billable.card_exp_year
+  end
 end

--- a/test/pay/paddle/webhooks/subscription_payment_succeeded_test.rb
+++ b/test/pay/paddle/webhooks/subscription_payment_succeeded_test.rb
@@ -79,6 +79,35 @@ class Pay::Paddle::Webhooks::SubscriptionPaymentSucceededTest < ActiveSupport::T
     assert_nil charge.card_exp_year
   end
 
+  test "a charge is created and user payment information are updated" do
+    user = User.create!(email: "gob@bluth.com", processor: :paddle, processor_id: @data["user_id"])
+
+    subscription_user = {
+      subscription_id: 7654321,
+      plan_id: 123456,
+      user_id: 12345678,
+      user_email: "test@example.com",
+      marketing_consent: false,
+      update_url: "https://example.com",
+      cancel_url: "https://example.com",
+      state: "active",
+      signup_date: "2020-12-08 07:52:22",
+      last_payment: {amount: 0, currency: "USD", date: "2020-12-08"}, linked_subscriptions: [],
+      payment_information: {payment_method: "card", card_type: "visa", last_four_digits: "0020", expiry_date: "06/2022"},
+      next_payment: {amount: 0, currency: "USD", date: "2021-01-08"}
+    }
+
+    assert_difference "Pay.charge_model.count" do
+      PaddlePay::Subscription::User.stubs(:list).returns([subscription_user])
+      Pay::Paddle::Webhooks::SubscriptionPaymentSucceeded.new(@data)
+    end
+
+    assert_equal "visa", user.reload.card_type
+    assert_equal "0020", user.reload.card_last4
+    assert_equal "06", user.reload.card_exp_month
+    assert_equal "2022", user.reload.card_exp_year
+  end
+
   test "a charge isn't created if no corresponding user can be found" do
     @user = User.create!(email: "gob@bluth.com", processor: :paddle, processor_id: "does-not-exist")
 


### PR DESCRIPTION
Synchronizes the current payment information from paddle for billable models.

The sync can be triggered manually with `billable.sync_payment_information_from_paddle` or the current payment infos will be also updated by the payment succeeded webhook.