### PR TITLE
Configurable default names - Product/Plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ Pay.setup do |config|
 
   config.send_emails = true
 
+  config.default_product_name = "default"
+  config.default_plan_name = "default"
+
   config.automount_routes = true
   config.routes_path = "/pay" # Only when automount_routes is true
 end
@@ -260,7 +263,7 @@ A `card_token` must be provided as an attribute.
 The subscribe method has three optional arguments with default values.
 
 ```ruby
-def subscribe(name: Pay.default_product_name, plan: 'default', **options)
+def subscribe(name: Pay.default_product_name, plan: Pay.default_plan_name, **options)
   ...
 end
 ```
@@ -269,7 +272,7 @@ For example, you can pass the `quantity` option to subscribe to a plan with for 
 
 ```ruby
 
-user.subscribe(name: "default", plan: "default", quantity: 3)
+user.subscribe(name: Pay.default_product_name, plan: Pay.default_plan_name, quantity: 3)
 ```
 
 ###### Name

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ A `card_token` must be provided as an attribute.
 The subscribe method has three optional arguments with default values.
 
 ```ruby
-def subscribe(name: 'default', plan: 'default', **options)
+def subscribe(name: Pay.default_product_name, plan: 'default', **options)
   ...
 end
 ```

--- a/lib/pay.rb
+++ b/lib/pay.rb
@@ -47,6 +47,9 @@ module Pay
   mattr_accessor :automount_routes
   @@automount_routes = true
 
+  mattr_accessor :default_product_name
+  @@default_product_name = "default"
+
   mattr_accessor :routes_path
   @@routes_path = "/pay"
 

--- a/lib/pay.rb
+++ b/lib/pay.rb
@@ -49,6 +49,8 @@ module Pay
 
   mattr_accessor :default_product_name
   @@default_product_name = "default"
+  mattr_accessor :default_plan_name
+  @@default_product_name = "default"
 
   mattr_accessor :routes_path
   @@routes_path = "/pay"

--- a/lib/pay.rb
+++ b/lib/pay.rb
@@ -47,8 +47,10 @@ module Pay
   mattr_accessor :automount_routes
   @@automount_routes = true
 
-  mattr_accessor :default_product_name, default: "default"
-  mattr_accessor :default_plan_name, default: "default"
+  mattr_accessor :default_product_name
+  @@default_product_name = "default"
+  mattr_accessor :default_plan_name
+  @@default_plan_name = "default"
 
   mattr_accessor :routes_path
   @@routes_path = "/pay"

--- a/lib/pay.rb
+++ b/lib/pay.rb
@@ -47,10 +47,8 @@ module Pay
   mattr_accessor :automount_routes
   @@automount_routes = true
 
-  mattr_accessor :default_product_name
-  @@default_product_name = "default"
-  mattr_accessor :default_plan_name
-  @@default_product_name = "default"
+  mattr_accessor :default_product_name, default: "default"
+  mattr_accessor :default_plan_name, default: "default"
 
   mattr_accessor :routes_path
   @@routes_path = "/pay"

--- a/lib/pay/billable.rb
+++ b/lib/pay/billable.rb
@@ -52,7 +52,7 @@ module Pay
       send("create_#{processor}_charge", amount_in_cents, options)
     end
 
-    def subscribe(name: "default", plan: "default", **options)
+    def subscribe(name: Pay.default_product_name, plan: "default", **options)
       check_for_processor
       send("create_#{processor}_subscription", name, plan, options)
     end
@@ -63,7 +63,7 @@ module Pay
       send("update_#{processor}_card", token)
     end
 
-    def on_trial?(name: "default", plan: nil)
+    def on_trial?(name: Pay.default_product_name, plan: nil)
       return true if default_generic_trial?(name, plan)
 
       sub = subscription(name: name)
@@ -81,7 +81,7 @@ module Pay
       send("#{processor}_subscription", subscription_id, options)
     end
 
-    def subscribed?(name: "default", processor_plan: nil)
+    def subscribed?(name: Pay.default_product_name, processor_plan: nil)
       subscription = subscription(name: name)
 
       return false if subscription.nil?
@@ -90,12 +90,12 @@ module Pay
       subscription.active? && subscription.processor_plan == processor_plan
     end
 
-    def on_trial_or_subscribed?(name: "default", processor_plan: nil)
+    def on_trial_or_subscribed?(name: Pay.default_product_name, processor_plan: nil)
       on_trial?(name: name, plan: processor_plan) ||
         subscribed?(name: name, processor_plan: processor_plan)
     end
 
-    def subscription(name: "default")
+    def subscription(name: Pay.default_product_name)
       subscriptions.for_name(name).last
     end
 
@@ -123,7 +123,7 @@ module Pay
       processor == "paddle"
     end
 
-    def has_incomplete_payment?(name: "default")
+    def has_incomplete_payment?(name: Pay.default_product_name)
       subscription(name: name)&.has_incomplete_payment?
     end
 

--- a/lib/pay/billable.rb
+++ b/lib/pay/billable.rb
@@ -52,7 +52,7 @@ module Pay
       send("create_#{processor}_charge", amount_in_cents, options)
     end
 
-    def subscribe(name: Pay.default_product_name, plan: "default", **options)
+    def subscribe(name: Pay.default_product_name, plan: Pay.default_plan_name, **options)
       check_for_processor
       send("create_#{processor}_subscription", name, plan, options)
     end

--- a/lib/pay/paddle/webhooks/subscription_created.rb
+++ b/lib/pay/paddle/webhooks/subscription_created.rb
@@ -22,7 +22,7 @@ module Pay
               return
             end
 
-            subscription = Pay.subscription_model.new(owner: owner, name: "default", processor: "paddle", processor_id: data["subscription_id"], status: :active)
+            subscription = Pay.subscription_model.new(owner: owner, name: Pay.default_product_name, processor: "paddle", processor_id: data["subscription_id"], status: :active)
           end
 
           subscription.quantity = data["quantity"]

--- a/lib/pay/stripe/webhooks/subscription_created.rb
+++ b/lib/pay/stripe/webhooks/subscription_created.rb
@@ -18,7 +18,7 @@ module Pay
               return
             end
 
-            subscription = Pay.subscription_model.new(name: "default", owner: owner, processor: :stripe, processor_id: object.id)
+            subscription = Pay.subscription_model.new(name: Pay.default_product_name, owner: owner, processor: :stripe, processor_id: object.id)
           end
 
           subscription.quantity = object.quantity

--- a/test/pay_test.rb
+++ b/test/pay_test.rb
@@ -45,4 +45,9 @@ class Pay::Test < ActiveSupport::TestCase
     assert Pay.respond_to?(:default_product_name)
     assert Pay.respond_to?(:default_product_name=)
   end
+
+  test "can set default plan name" do
+    assert Pay.respond_to?(:default_plan_name)
+    assert Pay.respond_to?(:default_plan_name=)
+  end
 end

--- a/test/pay_test.rb
+++ b/test/pay_test.rb
@@ -40,4 +40,9 @@ class Pay::Test < ActiveSupport::TestCase
     assert Pay.respond_to?(:support_email)
     assert Pay.respond_to?(:support_email=)
   end
+
+  test "can set default product name" do
+    assert Pay.respond_to?(:default_product_name)
+    assert Pay.respond_to?(:default_product_name=)
+  end
 end


### PR DESCRIPTION
Adds options to configure the default names for product/plan.

closes #220 