### PR TITLE
Add fake processor for testing and internal use

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* [NEW] Fake payment processor for testing and giving users free access to your application
+
 # 2.6.3
 
 * [FIX] Default to empty hash when default_url_options is nil so proper error is raised

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Pay is a payments engine for Ruby on Rails 4.2 and higher.
 - Stripe ([SCA Compatible](https://stripe.com/docs/strong-customer-authentication) using API version `2020-08-27`)
 - Paddle (SCA Compatible & supports PayPal)
 - Braintree (supports PayPal)
+- [Fake Processor](docs/fake_processor.md)
 
 Want to add a new payment provider? Contributions are welcome and the instructions [are here](https://github.com/jasoncharnes/pay/wiki/New-Payment-Provider).
 

--- a/docs/fake_processor.md
+++ b/docs/fake_processor.md
@@ -1,0 +1,44 @@
+# Fake Payment Processor
+
+The fake payment processor is useful for:
+
+* Testing
+* Free subscriptions & charges for users like your team, friends, etc
+
+## Usage
+
+Simply assign `processor: :fake_processor, processor_id: rand(1_000_000), pay_fake_processor_allowed: true` to your user.
+
+```ruby
+user = User.create!(
+  email: "gob@bluth.com",
+  processor: :fake_processor,
+  processor_id: rand(1_000_000),
+  pay_fake_processor_allowed: true
+)
+
+user.charge(25_00)
+user.subscribe("default")
+```
+
+## Security
+
+You don't want malicious users using the fake processor to give themselves free access to your products.
+
+Pay provides a virtual attribute and validation to ensure the fake processor is only assigned when explicitly allowed.
+
+```ruby
+# Inside Pay::Billable
+attribute :pay_fake_processor_allowed, :boolean, default: false
+
+validate :pay_fake_processor_allowed
+
+def pay_fake_processor_is_allowed
+  return unless processor == "fake_processor"
+  errors.add(:processor, "must be a valid payment processor") unless pay_fake_processor_allowed?
+end
+```
+
+`pay_fake_processor_allowed` must be set to `true` before saving. This attribute should *not* included in your permitted_params.
+
+The validation checks if this attribute is enabled and raises a validation error if not. This prevents malicious uses from submitting `user[processor]=fake_processor` in a form.

--- a/lib/pay.rb
+++ b/lib/pay.rb
@@ -10,6 +10,7 @@ module Pay
 
   # Payment processors
   autoload :Braintree, "pay/braintree"
+  autoload :FakeProcessor, "pay/fake_processor"
   autoload :Paddle, "pay/paddle"
   autoload :Stripe, "pay/stripe"
 

--- a/lib/pay/billable.rb
+++ b/lib/pay/billable.rb
@@ -24,6 +24,9 @@ module Pay
       attribute :plan, :string
       attribute :quantity, :integer
       attribute :card_token, :string
+      attribute :pay_fake_processor_allowed, :boolean, default: false
+
+      validate :pay_fake_processor_is_allowed
     end
 
     def payment_processor
@@ -154,6 +157,11 @@ module Pay
     def default_generic_trial?(name, plan)
       # Generic trials don't have plans or custom names
       plan.nil? && name == "default" && on_generic_trial?
+    end
+
+    def pay_fake_processor_is_allowed
+      return unless processor == "fake_processor"
+      errors.add(:processor, "must be a valid payment processor") unless pay_fake_processor_allowed?
     end
   end
 end

--- a/lib/pay/billable.rb
+++ b/lib/pay/billable.rb
@@ -26,7 +26,7 @@ module Pay
       attribute :card_token, :string
       attribute :pay_fake_processor_allowed, :boolean, default: false
 
-      validate :pay_fake_processor_is_allowed
+      validate :pay_fake_processor_is_allowed, if: :processor_changed?
     end
 
     def payment_processor

--- a/lib/pay/fake_processor.rb
+++ b/lib/pay/fake_processor.rb
@@ -1,0 +1,8 @@
+module Pay
+  module FakeProcessor
+    autoload :Billable, "pay/fake_processor/billable"
+    autoload :Charge, "pay/fake_processor/charge"
+    autoload :Subscription, "pay/fake_processor/subscription"
+    autoload :Error, "pay/fake_processor/error"
+  end
+end

--- a/lib/pay/fake_processor/billable.rb
+++ b/lib/pay/fake_processor/billable.rb
@@ -1,0 +1,60 @@
+module Pay
+  module FakeProcessor
+    class Billable
+      attr_reader :billable
+
+      delegate :processor_id,
+        :processor_id?,
+        :email,
+        :customer_name,
+        :card_token,
+        to: :billable
+
+      def initialize(billable)
+        @billable = billable
+      end
+
+      def customer
+        billable
+      end
+
+      def charge(amount, options = {})
+        billable.charges.create(
+          processor: :fake_processor,
+          processor_id: rand(100_000_000),
+          amount: amount,
+          card_type: :fake,
+          card_last4: 1234,
+          card_exp_month: Date.today.month,
+          card_exp_year: Date.today.year
+        )
+      end
+
+      def subscribe(name: Pay.default_product_name, plan: Pay.default_plan_name, **options)
+        subscription = OpenStruct.new id: rand(1_000_000)
+        billable.create_pay_subscription(subscription, :fake_processor, name, plan, status: :active, quantity: options.fetch(:quantity, 1))
+      end
+
+      def update_card(payment_method_id)
+        billable.update(
+          card_type: :fake,
+          card_last4: 1234,
+          card_exp_month: Date.today.month,
+          card_exp_year: Date.today.year
+        )
+      end
+
+      def update_email!
+        # pass
+      end
+
+      def processor_subscription(subscription_id, options = {})
+        billable.subscriptions.find_by(processor: :fake_processor, processor_id: subscription_id)
+      end
+
+      def trial_end_date(subscription)
+        Date.today
+      end
+    end
+  end
+end

--- a/lib/pay/fake_processor/charge.rb
+++ b/lib/pay/fake_processor/charge.rb
@@ -1,0 +1,21 @@
+module Pay
+  module FakeProcessor
+    class Charge
+      attr_reader :pay_charge
+
+      delegate :processor_id, :owner, to: :pay_charge
+
+      def initialize(pay_charge)
+        @pay_charge = pay_charge
+      end
+
+      def charge
+        pay_charge
+      end
+
+      def refund!(amount_to_refund)
+        pay_charge.update(amount_refunded: amount_to_refund)
+      end
+    end
+  end
+end

--- a/lib/pay/fake_processor/error.rb
+++ b/lib/pay/fake_processor/error.rb
@@ -1,0 +1,6 @@
+module Pay
+  module FakeProcessor
+    class Error < Pay::Error
+    end
+  end
+end

--- a/lib/pay/fake_processor/subscription.rb
+++ b/lib/pay/fake_processor/subscription.rb
@@ -1,0 +1,55 @@
+module Pay
+  module FakeProcessor
+    class Subscription
+      attr_reader :pay_subscription
+
+      delegate :canceled?,
+        :ends_at,
+        :on_trial?,
+        :owner,
+        :processor_subscription,
+        :processor_id,
+        :prorate,
+        :processor_plan,
+        :quantity?,
+        :quantity,
+        to: :pay_subscription
+
+      def initialize(pay_subscription)
+        @pay_subscription = pay_subscription
+      end
+
+      def cancel
+        pay_subscription.update(ends_at: Time.current.end_of_month)
+      end
+
+      def cancel_now!
+        pay_subscription.update(ends_at: Time.current, status: :canceled)
+      end
+
+      def on_grace_period?
+        canceled? && Time.zone.now < ends_at
+      end
+
+      def paused?
+        false
+      end
+
+      def pause
+        raise NotImplementedError, "FakeProcessor does not support pausing subscriptions"
+      end
+
+      def resume
+        unless on_grace_period?
+          raise StandardError, "You can only resume subscriptions within their grace period."
+        end
+
+        pay_subscription.update(ends_at: nil, status: :active)
+      end
+
+      def swap(plan)
+        pay_subscription.update(processor_plan: plan)
+      end
+    end
+  end
+end

--- a/lib/pay/fake_processor/subscription.rb
+++ b/lib/pay/fake_processor/subscription.rb
@@ -20,7 +20,7 @@ module Pay
       end
 
       def cancel
-        pay_subscription.update(ends_at: Time.current.end_of_month.end_of_day)
+        pay_subscription.update(ends_at: Time.current.end_of_month)
       end
 
       def cancel_now!

--- a/lib/pay/fake_processor/subscription.rb
+++ b/lib/pay/fake_processor/subscription.rb
@@ -20,7 +20,7 @@ module Pay
       end
 
       def cancel
-        pay_subscription.update(ends_at: Time.current.end_of_month)
+        pay_subscription.update(ends_at: Time.current.end_of_month.end_of_day)
       end
 
       def cancel_now!

--- a/test/pay/fake_processor/billable_test.rb
+++ b/test/pay/fake_processor/billable_test.rb
@@ -3,6 +3,7 @@ require "test_helper"
 class Pay::FakeProcessor::Billable::Test < ActiveSupport::TestCase
   setup do
     @billable = User.create!(email: "gob@bluth.com", processor: :fake_processor, processor_id: "17368056", pay_fake_processor_allowed: true)
+    @billable.reload
   end
 
   test "doesn't allow fake processor by default" do
@@ -11,6 +12,15 @@ class Pay::FakeProcessor::Billable::Test < ActiveSupport::TestCase
 
   test "allows fake processor if enabled" do
     assert User.new(email: "gob@bluth.com", processor: :fake_processor, processor_id: "17368056", pay_fake_processor_allowed: true).valid?
+  end
+
+  test "doesn't validate fake processor if processor didn't change" do
+    assert @billable.update(email: "michael@bluth.com")
+  end
+
+  test "validates fake processor if processor changed" do
+    @billable.update(processor: :stripe)
+    assert_not @billable.update(processor: :fake_processor, processor_id: 12345)
   end
 
   test "fake processor customer" do

--- a/test/pay/fake_processor/billable_test.rb
+++ b/test/pay/fake_processor/billable_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class Pay::FakeProcessor::Billable::Test < ActiveSupport::TestCase
+  setup do
+    @billable = User.create!(email: "gob@bluth.com", processor: :fake_processor, processor_id: "17368056")
+  end
+
+  test "fake processor customer" do
+    assert_equal @billable, @billable.payment_processor.customer
+  end
+
+  test "fake processor charge" do
+    assert_difference "Pay::Charge.count" do
+      @billable.charge(10_00)
+    end
+  end
+
+  test "fake processor subscribe" do
+    assert_difference "Pay::Subscription.count" do
+      @billable.subscribe
+    end
+  end
+end

--- a/test/pay/fake_processor/billable_test.rb
+++ b/test/pay/fake_processor/billable_test.rb
@@ -2,7 +2,15 @@ require "test_helper"
 
 class Pay::FakeProcessor::Billable::Test < ActiveSupport::TestCase
   setup do
-    @billable = User.create!(email: "gob@bluth.com", processor: :fake_processor, processor_id: "17368056")
+    @billable = User.create!(email: "gob@bluth.com", processor: :fake_processor, processor_id: "17368056", pay_fake_processor_allowed: true)
+  end
+
+  test "doesn't allow fake processor by default" do
+    assert_not User.new(email: "gob@bluth.com", processor: :fake_processor, processor_id: "17368056").valid?
+  end
+
+  test "allows fake processor if enabled" do
+    assert User.new(email: "gob@bluth.com", processor: :fake_processor, processor_id: "17368056", pay_fake_processor_allowed: true).valid?
   end
 
   test "fake processor customer" do

--- a/test/pay/fake_processor/charge_test.rb
+++ b/test/pay/fake_processor/charge_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Pay::FakeProcessor::Charge::Test < ActiveSupport::TestCase
   setup do
-    @billable = User.create!(email: "gob@bluth.com", processor: :fake_processor, processor_id: "17368056")
+    @billable = User.create!(email: "gob@bluth.com", processor: :fake_processor, processor_id: "17368056", pay_fake_processor_allowed: true)
     @charge = @billable.charge(10_00)
   end
 

--- a/test/pay/fake_processor/charge_test.rb
+++ b/test/pay/fake_processor/charge_test.rb
@@ -1,0 +1,18 @@
+require "test_helper"
+
+class Pay::FakeProcessor::Charge::Test < ActiveSupport::TestCase
+  setup do
+    @billable = User.create!(email: "gob@bluth.com", processor: :fake_processor, processor_id: "17368056")
+    @charge = @billable.charge(10_00)
+  end
+
+  test "fake processor charge" do
+    assert_equal @charge, @charge.processor_charge
+  end
+
+  test "fake processor refund" do
+    assert_nil @charge.amount_refunded
+    @charge.refund!
+    assert_equal 10_00, @charge.reload.amount_refunded
+  end
+end

--- a/test/pay/fake_processor/subscription_test.rb
+++ b/test/pay/fake_processor/subscription_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Pay::FakeProcessor::Subscription::Test < ActiveSupport::TestCase
   setup do
-    @billable = User.create!(email: "gob@bluth.com", processor: :fake_processor, processor_id: "17368056")
+    @billable = User.create!(email: "gob@bluth.com", processor: :fake_processor, processor_id: "17368056", pay_fake_processor_allowed: true)
     @subscription = @billable.subscribe
   end
 

--- a/test/pay/fake_processor/subscription_test.rb
+++ b/test/pay/fake_processor/subscription_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class Pay::FakeProcessor::Subscription::Test < ActiveSupport::TestCase
+  setup do
+    @billable = User.create!(email: "gob@bluth.com", processor: :fake_processor, processor_id: "17368056")
+    @subscription = @billable.subscribe
+  end
+
+  test "fake processor subscription" do
+    assert_equal @subscription, @subscription.processor_subscription
+  end
+
+  test "fake processor cancel" do
+    freeze_time do
+      @subscription.cancel
+      assert_equal Time.current.end_of_month, @subscription.ends_at
+    end
+  end
+
+  test "fake processor cancel_now!" do
+    @subscription.cancel_now!
+    assert_not @subscription.active?
+  end
+
+  test "fake processor on_grace_period?" do
+    freeze_time do
+      @subscription.cancel
+      assert @subscription.on_grace_period?
+    end
+  end
+
+  test "fake processor resume" do
+    freeze_time do
+      @subscription.cancel
+      assert_not_nil @subscription.ends_at
+      @subscription.resume
+      assert_nil @subscription.ends_at
+    end
+  end
+
+  test "fake processor swap" do
+    @subscription.swap("another_plan")
+    assert_equal "another_plan", @subscription.processor_plan
+  end
+end

--- a/test/pay/fake_processor/subscription_test.rb
+++ b/test/pay/fake_processor/subscription_test.rb
@@ -13,7 +13,7 @@ class Pay::FakeProcessor::Subscription::Test < ActiveSupport::TestCase
   test "fake processor cancel" do
     freeze_time do
       @subscription.cancel
-      assert_equal Time.current.end_of_month, @subscription.ends_at
+      assert_equal Time.current.end_of_month.to_date, @subscription.ends_at.to_date
     end
   end
 


### PR DESCRIPTION
This provides a fake payment processor that can be used for testing and for giving users a free subscription to your app.

You'll want to be careful not to allow someone to subscribe with `fake_processor`. We'll probably want to add a validation to Billable so that `fake_processor` isn't allowed unless explicitly enabled.

*Update* Added a fake processor flag and validation so users can't set this maliciously from the frontend.