### PR TITLE
Add passthrough fallback for paddle payment succeeded webhook

### DIFF
--- a/lib/pay/paddle.rb
+++ b/lib/pay/paddle.rb
@@ -44,6 +44,13 @@ module Pay
       options.merge(owner_sgid: owner.to_sgid.to_s).to_json
     end
 
+    def self.owner_from_passthrough(passthrough)
+      passthrough_json = JSON.parse(passthrough)
+      GlobalID::Locator.locate_signed(passthrough_json["owner_sgid"])
+    rescue JSON::ParserError
+      nil
+    end
+
     def self.configure_webhooks
       Pay::Webhooks.configure do |events|
         events.subscribe "paddle.subscription_created", Pay::Paddle::Webhooks::SubscriptionCreated.new

--- a/lib/pay/paddle/webhooks/subscription_created.rb
+++ b/lib/pay/paddle/webhooks/subscription_created.rb
@@ -13,7 +13,7 @@ module Pay
             owner = Pay.find_billable(processor: :paddle, processor_id: event["user_id"])
 
             if owner.nil?
-              owner = owner_by_passtrough(event["passthrough"], event["subscription_plan_id"])
+              owner = Pay::Paddle.owner_from_passthrough(event["passthrough"])
               owner&.update!(processor: "paddle", processor_id: event["user_id"])
             end
 
@@ -43,15 +43,6 @@ module Pay
           end
 
           subscription.save!
-        end
-
-        private
-
-        def owner_by_passtrough(passthrough, product_id)
-          passthrough_json = JSON.parse(passthrough)
-          GlobalID::Locator.locate_signed(passthrough_json["owner_sgid"])
-        rescue JSON::ParserError
-          nil
         end
       end
     end


### PR DESCRIPTION
In my staging tests I realized that although the payment succeeded webhook is fired after the subscription created webhook, it is possible that the payment succeeded webhook is handled first. That means it is not guaranteed that there is already a paddle processor id saved in the database.
For this scenario the billable should be extracted from the passthrough parameter (similar to the subscription created webhook).
