### PR TITLE
Use bulk: true when running change_table migrations

### DIFF
--- a/lib/generators/active_record/templates/migration.rb
+++ b/lib/generators/active_record/templates/migration.rb
@@ -2,7 +2,7 @@
 
 class AddPayBillableTo<%= table_name.camelize %> < ActiveRecord::Migration<%= migration_version %>
   def change
-    change_table :<%= table_name %> do |t|
+    change_table :<%= table_name %>, bulk: true do |t|
 <%= migration_data -%>
     end
   end

--- a/test/dummy/db/migrate/20200603150703_add_pay_billable_to_users.rb
+++ b/test/dummy/db/migrate/20200603150703_add_pay_billable_to_users.rb
@@ -2,7 +2,7 @@
 
 class AddPayBillableToUsers < ActiveRecord::Migration[6.0]
   def change
-    change_table :users do |t|
+    change_table :users, bulk: true do |t|
       t.string :processor
       t.string :processor_id
       t.datetime :trial_ends_at

--- a/test/dummy/db/migrate/20200603152357_add_pay_billable_to_teams.rb
+++ b/test/dummy/db/migrate/20200603152357_add_pay_billable_to_teams.rb
@@ -2,7 +2,7 @@
 
 class AddPayBillableToTeams < ActiveRecord::Migration[6.0]
   def change
-    change_table :teams do |t|
+    change_table :teams, bulk: true do |t|
       t.string :processor
       t.string :processor_id
       t.datetime :trial_ends_at


### PR DESCRIPTION
As I was running these migration on my personal project, I've noticed that `change_table` is being run without `bulk: true`. Without that flag, all the new columns would be added one by one, which can be significantly slower on large tables. Instead, this will group them into one SQL query.

References:
- https://aaronlasseigne.com/2012/06/05/faster-activerecord-migrations-using-change-table-bulk/
- https://blog.toshima.ru/2020/01/02/rails-migration-bulk-true.html#migration-with-bulk-option
- https://makandracards.com/makandra/3303-bulk-change-multiple-table-rows-in-a-migration