### PR TITLE
Don't call route helpers unless needed for Stripe Checkout

### DIFF
--- a/lib/pay/stripe/billable.rb
+++ b/lib/pay/stripe/billable.rb
@@ -198,8 +198,8 @@ module Pay
           payment_method_types: ["card"],
           mode: "payment",
           # These placeholder URLs will be replaced in a following step.
-          success_url: root_url,
-          cancel_url: root_url
+          success_url: options.delete(:success_url) || root_url,
+          cancel_url: options.delete(:cancel_url) || root_url
         }
 
         # Line items are optional
@@ -238,7 +238,7 @@ module Pay
       def billing_portal(**options)
         args = {
           customer: processor_id,
-          return_url: options[:return_url] || root_url
+          return_url: options.delete(:return_url) || root_url
         }
         ::Stripe::BillingPortal::Session.create(args.merge(options))
       end


### PR DESCRIPTION
Fixes #309 (hopefully)