### PR TITLE
Refactor webhooks

### DIFF
--- a/lib/pay/stripe.rb
+++ b/lib/pay/stripe.rb
@@ -10,6 +10,8 @@ module Pay
       autoload :AccountUpdated, "pay/stripe/webhooks/account_updated"
       autoload :ChargeRefunded, "pay/stripe/webhooks/charge_refunded"
       autoload :ChargeSucceeded, "pay/stripe/webhooks/charge_succeeded"
+      autoload :CheckoutSessionCompleted, "pay/stripe/webhooks/checkout_session_completed"
+      autoload :CheckoutSessionAsyncPaymentSucceeded, "pay/stripe/webhooks/checkout_session_async_payment_succeeded"
       autoload :CustomerDeleted, "pay/stripe/webhooks/customer_deleted"
       autoload :CustomerUpdated, "pay/stripe/webhooks/customer_updated"
       autoload :PaymentActionRequired, "pay/stripe/webhooks/payment_action_required"
@@ -86,6 +88,10 @@ module Pay
 
         # If an account is updated in stripe, we should update it as well
         events.subscribe "stripe.account.updated", Pay::Stripe::Webhooks::AccountUpdated.new
+
+        # Handle subscriptions in Stripe Checkout Sessions
+        events.subscribe "stripe.checkout.session.completed", Pay::Stripe::Webhooks::CheckoutSessionCompleted.new
+        events.subscribe "stripe.checkout.session.async_payment_succeeded", Pay::Stripe::Webhooks::CheckoutSessionAsyncPaymentSucceeded.new
       end
     end
   end

--- a/lib/pay/stripe/billable.rb
+++ b/lib/pay/stripe/billable.rb
@@ -92,7 +92,7 @@ module Pay
         stripe_sub = ::Stripe::Subscription.create(opts, {stripe_account: stripe_account})
 
         # Save Pay::Subscription
-        subscription = Pay::Stripe::Subscription.sync(stripe_sub.id, subscription: stripe_sub, name: name)
+        subscription = Pay::Stripe::Subscription.sync(stripe_sub.id, object: stripe_sub, name: name)
 
         # No trial, card requires SCA
         if subscription.incomplete?

--- a/lib/pay/stripe/billable.rb
+++ b/lib/pay/stripe/billable.rb
@@ -65,7 +65,8 @@ module Pay
         Pay::Payment.new(payment_intent).validate
 
         # Create a new charge object
-        save_pay_charge(payment_intent.charges.first)
+        charge = payment_intent.charges.first
+        Pay::Stripe::Charge.sync(charge.id, charge: charge)
       rescue ::Stripe::StripeError => e
         raise Pay::Stripe::Error, e
       end
@@ -87,8 +88,11 @@ module Pay
         # Load the Stripe customer to verify it exists and update card if needed
         opts[:customer] = customer.id
 
+        # Create subscription on Stripe
         stripe_sub = ::Stripe::Subscription.create(opts, {stripe_account: stripe_account})
-        subscription = billable.create_pay_subscription(stripe_sub, "stripe", name, plan, status: stripe_sub.status, quantity: quantity, stripe_account: stripe_account, application_fee_percent: stripe_sub.application_fee_percent)
+
+        # Save Pay::Subscription
+        subscription = Pay::Stripe::Subscription.sync(stripe_sub.id, subscription: stripe_sub, name: name)
 
         # No trial, card requires SCA
         if subscription.incomplete?
@@ -166,31 +170,6 @@ module Pay
         )
 
         billable.card_token = nil
-      end
-
-      def save_pay_charge(object)
-        charge = billable.charges.find_or_initialize_by(processor: :stripe, processor_id: object.id)
-
-        attrs = {
-          amount: object.amount,
-          card_last4: object.payment_method_details.card.last4,
-          card_type: object.payment_method_details.card.brand,
-          card_exp_month: object.payment_method_details.card.exp_month,
-          card_exp_year: object.payment_method_details.card.exp_year,
-          created_at: Time.zone.at(object.created),
-          currency: object.currency,
-          stripe_account: stripe_account,
-          application_fee_amount: object.application_fee_amount
-        }
-
-        # Associate charge with subscription if we can
-        if object.invoice
-          invoice = (object.invoice.is_a?(::Stripe::Invoice) ? object.invoice : ::Stripe::Invoice.retrieve(object.invoice))
-          attrs[:subscription] = Pay::Subscription.find_by(processor: :stripe, processor_id: invoice.subscription)
-        end
-
-        charge.update(attrs)
-        charge
       end
 
       # https://stripe.com/docs/api/checkout/sessions/create

--- a/lib/pay/stripe/billable.rb
+++ b/lib/pay/stripe/billable.rb
@@ -66,7 +66,7 @@ module Pay
 
         # Create a new charge object
         charge = payment_intent.charges.first
-        Pay::Stripe::Charge.sync(charge.id, charge: charge)
+        Pay::Stripe::Charge.sync(charge.id, object: charge)
       rescue ::Stripe::StripeError => e
         raise Pay::Stripe::Error, e
       end

--- a/lib/pay/stripe/charge.rb
+++ b/lib/pay/stripe/charge.rb
@@ -5,6 +5,35 @@ module Pay
 
       delegate :processor_id, :owner, :stripe_account, to: :pay_charge
 
+      def sync(charge_id, charge: nil)
+        object ||= ::Stripe::Charge.retrieve(id: charge_id)
+        billable = Pay.find_billable(processor: :stripe, processor_id: object.customer)
+        return unless billable
+
+        attrs = {
+          amount: object.amount,
+          amount_refunded: object.amount_refunded
+          application_fee_amount: object.application_fee_amount,
+          card_exp_month: object.payment_method_details.card.exp_month,
+          card_exp_year: object.payment_method_details.card.exp_year,
+          card_last4: object.payment_method_details.card.last4,
+          card_type: object.payment_method_details.card.brand,
+          created_at: Time.at(object.created),
+          currency: object.currency,
+          stripe_account: stripe_account
+        }
+
+        # Associate charge with subscription if we can
+        if object.invoice
+          invoice = (object.invoice.is_a?(::Stripe::Invoice) ? object.invoice : ::Stripe::Invoice.retrieve(object.invoice))
+          attrs[:subscription] = Pay::Subscription.find_by(processor: :stripe, processor_id: invoice.subscription)
+        end
+
+        pay_charge = billable.charges.find_or_initialize_by(processor: :stripe, processor_id: object.id)
+        pay_charge.update(attrs)
+        pay_charge
+      end
+
       def initialize(pay_charge)
         @pay_charge = pay_charge
       end

--- a/lib/pay/stripe/charge.rb
+++ b/lib/pay/stripe/charge.rb
@@ -5,7 +5,7 @@ module Pay
 
       delegate :processor_id, :owner, :stripe_account, to: :pay_charge
 
-      def sync(charge_id, charge: nil)
+      def self.sync(charge_id, charge: nil)
         object ||= ::Stripe::Charge.retrieve(id: charge_id)
         billable = Pay.find_billable(processor: :stripe, processor_id: object.customer)
         return unless billable
@@ -20,7 +20,7 @@ module Pay
           card_type: object.payment_method_details.card.brand,
           created_at: Time.at(object.created),
           currency: object.currency,
-          stripe_account: stripe_account
+          stripe_account: object.stripe_account
         }
 
         # Associate charge with subscription if we can

--- a/lib/pay/stripe/charge.rb
+++ b/lib/pay/stripe/charge.rb
@@ -5,7 +5,7 @@ module Pay
 
       delegate :processor_id, :owner, :stripe_account, to: :pay_charge
 
-      def self.sync(charge_id, charge: nil)
+      def self.sync(charge_id, object: nil)
         object ||= ::Stripe::Charge.retrieve(id: charge_id)
         billable = Pay.find_billable(processor: :stripe, processor_id: object.customer)
         return unless billable

--- a/lib/pay/stripe/charge.rb
+++ b/lib/pay/stripe/charge.rb
@@ -12,7 +12,7 @@ module Pay
 
         attrs = {
           amount: object.amount,
-          amount_refunded: object.amount_refunded
+          amount_refunded: object.amount_refunded,
           application_fee_amount: object.application_fee_amount,
           card_exp_month: object.payment_method_details.card.exp_month,
           card_exp_year: object.payment_method_details.card.exp_year,

--- a/lib/pay/stripe/subscription.rb
+++ b/lib/pay/stripe/subscription.rb
@@ -25,7 +25,7 @@ module Pay
         object ||= ::Stripe::Subscription.retrieve(id: subscription_id, expand: ["pending_setup_intent", "latest_invoice.payment_intent"])
 
         owner = Pay.find_billable(processor: :stripe, processor_id: object.customer)
-        return if owner.nil?
+        return unless owner
 
         attributes = {
           application_fee_percent: object.application_fee_percent,

--- a/lib/pay/stripe/subscription.rb
+++ b/lib/pay/stripe/subscription.rb
@@ -20,6 +20,34 @@ module Pay
         :trial_ends_at,
         to: :pay_subscription
 
+      def self.sync(subscription_id, subscription: nil, name: Pay.default_product_name)
+        # Skip loading the latest subscription details from the API if we already have it
+        subscription ||= ::Stripe::Subscription.retrieve(id: subscription_id, expand: ["pending_setup_intent", "latest_invoice.payment_intent"])
+
+        owner = Pay.find_billable(processor: :stripe, processor_id: subscription.customer)
+        return if owner.nil?
+
+        attributes = {
+          application_fee_percent: subscription.application_fee_percent,
+          processor_plan: subscription.plan.id,
+          quantity: subscription.quantity,
+          name: name,
+          status: subscription.status,
+          trial_ends_at: (subscription.trial_end ? Time.at(subscription.trial_end) : nil)
+        }
+
+        # Subscriptions cancelling in the future
+        attributes[:ends_at] = Time.at(subscription.current_period_end) if subscription.cancel_at_period_end
+
+        # Fully cancelled subscription
+        attributes[:ends_at] = Time.at(subscription.ended_at) if subscription.ended_at
+
+        # Update or create the subscription
+        pay_subscription = owner.subscriptions.find_or_initialize_by(processor: :stripe, processor_id: subscription.id)
+        pay_subscription.update(attributes)
+        pay_subscription
+      end
+
       def initialize(pay_subscription)
         @pay_subscription = pay_subscription
       end

--- a/lib/pay/stripe/subscription.rb
+++ b/lib/pay/stripe/subscription.rb
@@ -33,6 +33,7 @@ module Pay
           quantity: object.quantity,
           name: name,
           status: object.status,
+          stripe_account: owner.stripe_account,
           trial_ends_at: (object.trial_end ? Time.at(object.trial_end) : nil)
         }
 

--- a/lib/pay/stripe/webhooks/charge_refunded.rb
+++ b/lib/pay/stripe/webhooks/charge_refunded.rb
@@ -3,13 +3,8 @@ module Pay
     module Webhooks
       class ChargeRefunded
         def call(event)
-          object = event.data.object
-          charge = Pay.charge_model.find_by(processor: :stripe, processor_id: object.id)
-
-          return unless charge.present?
-
-          charge.update(amount_refunded: object.amount_refunded)
-          notify_user(charge.owner, charge)
+          pay_charge = Pay::Stripe::Charge.sync(event.data.object.id)
+          notify_user(pay_charge.owner, pay_charge)
         end
 
         def notify_user(billable, charge)

--- a/lib/pay/stripe/webhooks/charge_refunded.rb
+++ b/lib/pay/stripe/webhooks/charge_refunded.rb
@@ -4,7 +4,7 @@ module Pay
       class ChargeRefunded
         def call(event)
           pay_charge = Pay::Stripe::Charge.sync(event.data.object.id)
-          notify_user(pay_charge.owner, pay_charge)
+          notify_user(pay_charge.owner, pay_charge) if pay_charge
         end
 
         def notify_user(billable, charge)

--- a/lib/pay/stripe/webhooks/charge_succeeded.rb
+++ b/lib/pay/stripe/webhooks/charge_succeeded.rb
@@ -4,7 +4,7 @@ module Pay
       class ChargeSucceeded
         def call(event)
           pay_charge = Pay::Stripe::Charge.sync(event.data.object.id)
-          notify_user(pay_charge.owner, pay_charge)
+          notify_user(pay_charge.owner, pay_charge) if pay_charge
         end
 
         def notify_user(billable, charge)

--- a/lib/pay/stripe/webhooks/charge_succeeded.rb
+++ b/lib/pay/stripe/webhooks/charge_succeeded.rb
@@ -3,14 +3,8 @@ module Pay
     module Webhooks
       class ChargeSucceeded
         def call(event)
-          object = event.data.object
-          billable = Pay.find_billable(processor: :stripe, processor_id: object.customer)
-
-          return unless billable.present?
-          return if billable.charges.where(processor_id: object.id).any?
-
-          charge = Pay::Stripe::Billable.new(billable).save_pay_charge(object)
-          notify_user(billable, charge)
+          pay_charge = Pay::Stripe::Charge.sync(event.data.object.id)
+          notify_user(pay_charge.owner, pay_charge)
         end
 
         def notify_user(billable, charge)

--- a/lib/pay/stripe/webhooks/checkout_session_async_payment_succeeded.rb
+++ b/lib/pay/stripe/webhooks/checkout_session_async_payment_succeeded.rb
@@ -1,0 +1,13 @@
+module Pay
+  module Stripe
+    module Webhooks
+      class CheckoutSessionAsyncPaymentSucceeded
+        def call(event)
+          if event.data.object.subscription
+            Pay::Stripe::Subscription.sync(event.data.object.subscription)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pay/stripe/webhooks/checkout_session_completed.rb
+++ b/lib/pay/stripe/webhooks/checkout_session_completed.rb
@@ -1,0 +1,13 @@
+module Pay
+  module Stripe
+    module Webhooks
+      class CheckoutSessionCompleted
+        def call(event)
+          if event.data.object.subscription
+            Pay::Stripe::Subscription.sync(event.data.object.subscription)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pay/stripe/webhooks/subscription_created.rb
+++ b/lib/pay/stripe/webhooks/subscription_created.rb
@@ -3,42 +3,7 @@ module Pay
     module Webhooks
       class SubscriptionCreated
         def call(event)
-          object = event.data.object
-
-          # We may already have the subscription in the database, so we can update that record
-          subscription = Pay.subscription_model.find_by(processor: :stripe, processor_id: object.id)
-
-          # Create the subscription in the database if we don't have it already
-          if subscription.nil?
-            # The customer should already be in the database
-            owner = Pay.find_billable(processor: :stripe, processor_id: object.customer)
-
-            if owner.nil?
-              Rails.logger.error("[Pay] Unable to find Pay::Billable with processor: :stripe and processor_id: '#{object.customer}'. Searched these models: #{Pay.billable_models.join(", ")}")
-              return
-            end
-
-            subscription = Pay.subscription_model.new(name: Pay.default_product_name, owner: owner, processor: :stripe, processor_id: object.id)
-          end
-
-          subscription.application_fee_percent = object.application_fee_percent
-          subscription.processor_plan = object.plan.id
-          subscription.quantity = object.quantity
-          subscription.status = object.status
-          subscription.trial_ends_at = Time.at(object.trial_end) if object.trial_end.present?
-
-          # If user was on trial, their subscription ends at the end of the trial
-          subscription.ends_at = if object.cancel_at_period_end && subscription.on_trial?
-            subscription.trial_ends_at
-
-          # User wasn't on trial, so subscription ends at period end
-          elsif object.cancel_at_period_end
-            Time.at(object.current_period_end)
-
-            # Subscription isn't marked to cancel at period end
-          end
-
-          subscription.save!
+          Pay::Stripe::Subscription.sync(event.data.object.id)
         end
       end
     end

--- a/lib/pay/stripe/webhooks/subscription_deleted.rb
+++ b/lib/pay/stripe/webhooks/subscription_deleted.rb
@@ -3,15 +3,7 @@ module Pay
     module Webhooks
       class SubscriptionDeleted
         def call(event)
-          object = event.data.object
-          subscription = Pay.subscription_model.find_by(processor: :stripe, processor_id: object.id)
-
-          # We couldn't find the subscription for some reason, maybe it's from another service
-          return if subscription.nil?
-
-          # User canceled subscriptions have an ends_at
-          # Automatically canceled subscriptions need this value set
-          subscription.update!(ends_at: Time.at(object.ended_at)) if subscription.ends_at.blank? && object.ended_at.present?
+          Pay::Stripe::Subscription.sync(event.data.object.id)
         end
       end
     end

--- a/lib/pay/stripe/webhooks/subscription_renewing.rb
+++ b/lib/pay/stripe/webhooks/subscription_renewing.rb
@@ -5,12 +5,10 @@ module Pay
         def call(event)
           # Event is of type "invoice" see:
           # https://stripe.com/docs/api/invoices/object
-          subscription = Pay.subscription_model.find_by(
-            processor: :stripe,
-            processor_id: event.data.object.subscription
-          )
-          date = Time.zone.at(event.data.object.next_payment_attempt)
-          notify_user(subscription.owner, subscription, date) if subscription.present?
+          subscription = Pay.subscription_model.find_by(processor: :stripe, processor_id: event.data.object.subscription)
+          return unless subscription
+
+          notify_user(subscription.owner, subscription, Time.zone.at(event.data.object.next_payment_attempt))
         end
 
         def notify_user(billable, subscription, date)

--- a/lib/pay/stripe/webhooks/subscription_updated.rb
+++ b/lib/pay/stripe/webhooks/subscription_updated.rb
@@ -3,35 +3,7 @@ module Pay
     module Webhooks
       class SubscriptionUpdated
         def call(event)
-          object = event.data.object
-          subscription = Pay.subscription_model.find_by(processor: :stripe, processor_id: object.id)
-
-          return if subscription.nil?
-
-          # Delete any subscription attempts that have expired
-          if object.status == "incomplete_expired"
-            subscription.destroy
-            return
-          end
-
-          subscription.application_fee_percent = object.application_fee_percent
-          subscription.processor_plan = object.plan.id
-          subscription.quantity = object.quantity
-          subscription.status = object.status
-          subscription.trial_ends_at = Time.at(object.trial_end) if object.trial_end.present?
-
-          # If user was on trial, their subscription ends at the end of the trial
-          subscription.ends_at = if object.cancel_at_period_end && subscription.on_trial?
-            subscription.trial_ends_at
-
-          # User wasn't on trial, so subscription ends at period end
-          elsif object.cancel_at_period_end
-            Time.at(object.current_period_end)
-
-            # Subscription isn't marked to cancel at period end
-          end
-
-          subscription.save!
+          Pay::Stripe::Subscription.sync(event.data.object.id)
         end
       end
     end

--- a/test/pay/billable/stripe_test.rb
+++ b/test/pay/billable/stripe_test.rb
@@ -103,7 +103,7 @@ class Pay::Stripe::Billable::Test < ActiveSupport::TestCase
       description: "One-time setup fee"
     )
 
-    assert_equal 1000, @billable.invoice!.total
+    assert_equal 1000, @billable.payment_processor.invoice!.total
   end
 
   test "card gets updated automatically when retrieving customer" do
@@ -173,7 +173,7 @@ class Pay::Stripe::Billable::Test < ActiveSupport::TestCase
 
   test "can create setup intent" do
     assert_nothing_raised do
-      @billable.create_setup_intent
+      @billable.payment_processor.create_setup_intent
     end
   end
 

--- a/test/pay/stripe/charge_test.rb
+++ b/test/pay/stripe/charge_test.rb
@@ -6,10 +6,16 @@ class Pay::Stripe::ChargeTest < ActiveSupport::TestCase
   end
 
   test "sync stripe charge by ID" do
-    ::Stripe::Charge.stubs(:retrieve).returns(fake_stripe_charge)
-
     assert_difference "Pay::Charge.count" do
+      ::Stripe::Charge.stubs(:retrieve).returns(fake_stripe_charge)
       Pay::Stripe::Charge.sync("123")
+    end
+  end
+
+  test "sync stripe charge ignores when customer is missing" do
+    assert_no_difference "Pay::Charge.count" do
+      @user.destroy
+      Pay::Stripe::Charge.sync("123", object: fake_stripe_charge)
     end
   end
 

--- a/test/pay/stripe/charge_test.rb
+++ b/test/pay/stripe/charge_test.rb
@@ -1,0 +1,47 @@
+require "test_helper"
+
+class Pay::Stripe::ChargeTest < ActiveSupport::TestCase
+  setup do
+    @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: "cus_1234")
+  end
+
+  test "sync stripe charge by ID" do
+    ::Stripe::Charge.stubs(:retrieve).returns(fake_stripe_charge)
+
+    assert_difference "Pay::Charge.count" do
+      Pay::Stripe::Charge.sync("123")
+    end
+  end
+
+  test "sync associates charge with stripe subscription" do
+    pay_subscription = @user.subscriptions.create!(processor: :stripe, processor_id: "sub_1234", name: "default", processor_plan: "some-plan", status: "active")
+    fake_invoice = ::Stripe::Invoice.construct_from(subscription: "sub_1234")
+    pay_charge = Pay::Stripe::Charge.sync("123", object: fake_stripe_charge(invoice: fake_invoice))
+    assert_equal pay_subscription, pay_charge.subscription
+  end
+
+  private
+
+  def fake_stripe_charge(**values)
+    values.reverse_merge!(
+      id: "ch_123",
+      customer: "cus_1234",
+      amount: 19_00,
+      amount_refunded: nil,
+      application_fee_amount: 0,
+      created: 1546332337,
+      currency: "usd",
+      invoice: nil,
+      payment_method_details: {
+        card: {
+          exp_month: 1,
+          exp_year: 2021,
+          last4: "4242",
+          brand: "Visa"
+        }
+      },
+      stripe_account: nil
+    )
+    ::Stripe::Charge.construct_from(values)
+  end
+end

--- a/test/pay/stripe/charge_test.rb
+++ b/test/pay/stripe/charge_test.rb
@@ -45,8 +45,7 @@ class Pay::Stripe::ChargeTest < ActiveSupport::TestCase
           last4: "4242",
           brand: "Visa"
         }
-      },
-      stripe_account: nil
+      }
     )
     ::Stripe::Charge.construct_from(values)
   end

--- a/test/pay/stripe/subscription_test.rb
+++ b/test/pay/stripe/subscription_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class Pay::Stripe::SubscriptionTest < ActiveSupport::TestCase
   setup do
-    @user = User.create!(email: "gob@bluth.com", processor: :stripe)
+    @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: "1234")
   end
 
   test "change stripe subscription quantity" do
@@ -12,5 +12,18 @@ class Pay::Stripe::SubscriptionTest < ActiveSupport::TestCase
     stripe_subscription = subscription.processor_subscription
     assert_equal 5, stripe_subscription.quantity
     assert_equal 5, subscription.quantity
+  end
+
+  test "sync stripe subscription" do
+    Pay::Stripe::Subscription.sync(fake_stripe_subscription)
+
+  end
+
+  def fake_stripe_subscription(**values)
+    values.reverse_merge!(
+      id: "123",
+      customer: "1234"
+    )
+    ::Stripe::Subscription.construct_from(values)
   end
 end

--- a/test/pay/stripe/subscription_test.rb
+++ b/test/pay/stripe/subscription_test.rb
@@ -16,7 +16,6 @@ class Pay::Stripe::SubscriptionTest < ActiveSupport::TestCase
 
   test "sync stripe subscription" do
     Pay::Stripe::Subscription.sync(fake_stripe_subscription)
-
   end
 
   def fake_stripe_subscription(**values)

--- a/test/pay/stripe/subscription_test.rb
+++ b/test/pay/stripe/subscription_test.rb
@@ -2,10 +2,11 @@ require "test_helper"
 
 class Pay::Stripe::SubscriptionTest < ActiveSupport::TestCase
   setup do
-    @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: "1234")
+    @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: "cus_1234")
   end
 
   test "change stripe subscription quantity" do
+    @user.processor_id = nil
     @user.card_token = "pm_card_visa"
     subscription = @user.subscribe(name: "default", plan: "default")
     subscription.change_quantity(5)
@@ -14,14 +15,56 @@ class Pay::Stripe::SubscriptionTest < ActiveSupport::TestCase
     assert_equal 5, subscription.quantity
   end
 
-  test "sync stripe subscription" do
-    Pay::Stripe::Subscription.sync(fake_stripe_subscription)
+  test "sync stripe subscription by ID" do
+    assert_difference "Pay::Subscription.count" do
+      ::Stripe::Subscription.stubs(:retrieve).returns(fake_stripe_subscription)
+      Pay::Stripe::Subscription.sync("123")
+    end
   end
+
+  test "sync stripe subscription" do
+    assert_difference "Pay::Subscription.count" do
+      Pay::Stripe::Subscription.sync("123", object: fake_stripe_subscription)
+    end
+  end
+
+  test "sync stripe subscription ignores when customer is missing" do
+    @user.destroy
+    assert_no_difference "Pay::Subscription.count" do
+      Pay::Stripe::Subscription.sync("123", object: fake_stripe_subscription)
+    end
+  end
+
+  test "sync stripe subscription sets ends_at when canceling at period end" do
+    fake_subscription = fake_stripe_subscription(cancel_at_period_end: true)
+    pay_subscription = Pay::Stripe::Subscription.sync("123", object: fake_subscription)
+    assert_not_nil pay_subscription.ends_at
+  end
+
+  test "sync stripe subscription sets ends_at when ended" do
+    fake_subscription = fake_stripe_subscription(ended_at: 1488987924)
+    pay_subscription = Pay::Stripe::Subscription.sync("123", object: fake_subscription)
+    assert_not_nil pay_subscription.ends_at
+  end
+
+  private
 
   def fake_stripe_subscription(**values)
     values.reverse_merge!(
       id: "123",
-      customer: "1234"
+      application_fee_percent: nil,
+      cancel_at_period_end: false,
+      created: 1466783124,
+      current_period_end: 1488987924,
+      current_period_start: 1486568724,
+      customer: "cus_1234",
+      ended_at: nil,
+      plan: {
+        id: "default"
+      },
+      quantity: 1,
+      status: "active",
+      trial_end: nil
     )
     ::Stripe::Subscription.construct_from(values)
   end

--- a/test/pay/stripe/webhooks/charge_refunded_test.rb
+++ b/test/pay/stripe/webhooks/charge_refunded_test.rb
@@ -6,18 +6,7 @@ class Pay::Stripe::Webhooks::ChargeRefundedTest < ActiveSupport::TestCase
   end
 
   test "a charge is updated with refunded amount" do
-    @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: @event.data.object.customer)
-    charge = @user.charges.create!(processor: :stripe, processor_id: @event.data.object.id, amount: 500, card_type: "Visa", card_last4: "4444", card_exp_month: 1, card_exp_year: 2019)
-
+    Pay::Stripe::Charge.expects(:sync)
     Pay::Stripe::Webhooks::ChargeRefunded.new.call(@event)
-
-    assert_equal 500, charge.reload.amount_refunded
-  end
-
-  test "a charge isn't updated with the refunded amount if a corresponding charge can't be found (obviously)" do
-    @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: "does-not-exist")
-    charge = @user.charges.create!(processor: :stripe, processor_id: "doesntexist", amount: 500, card_type: "Visa", card_last4: "4444", card_exp_month: 1, card_exp_year: 2019)
-
-    assert_nil charge.reload.amount_refunded
   end
 end

--- a/test/pay/stripe/webhooks/charge_succeeded_test.rb
+++ b/test/pay/stripe/webhooks/charge_succeeded_test.rb
@@ -6,64 +6,7 @@ class Pay::Stripe::Webhooks::ChargeSucceededTest < ActiveSupport::TestCase
   end
 
   test "a charge is created" do
-    @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: @event.data.object.customer)
-    ::Stripe::Charge.stubs(:retrieve).returns fake_stripe_charge
-
-    assert_difference "Pay.charge_model.count" do
-      Pay::Stripe::Webhooks::ChargeSucceeded.new.call(@event)
-    end
-
-    charge = Pay.charge_model.last
-    assert_equal 500, charge.amount
-    assert_equal "4444", charge.card_last4
-    assert_equal "Visa", charge.card_type
-    assert_equal "1", charge.card_exp_month
-    assert_equal "2019", charge.card_exp_year
-    assert_equal "usd", charge.currency
-  end
-
-  test "a charge isn't created if no corresponding user can be found" do
-    ::Stripe::Charge.stubs(:retrieve).returns fake_stripe_charge
-    assert_no_difference "Pay.charge_model.count" do
-      Pay::Stripe::Webhooks::ChargeSucceeded.new.call(@event)
-    end
-  end
-
-  test "a charge isn't created if it already exists" do
-    @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: @event.data.object.customer)
-    @user.charges.create!(amount: 100, processor: :stripe, processor_id: "ch_chargeid", card_type: "Visa", card_exp_month: 1, card_exp_year: 2019, card_last4: "4444")
-    ::Stripe::Charge.stubs(:retrieve).returns fake_stripe_charge
-
-    assert_no_difference "Pay.charge_model.count" do
-      Pay::Stripe::Webhooks::ChargeSucceeded.new.call(@event)
-    end
-  end
-
-  test "stripe charge gets associated with subscription" do
-    @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: @event.data.object.customer)
-    subscription = @user.subscriptions.create(name: "default", processor: :stripe, processor_id: "12345", processor_plan: "default", quantity: 1, status: "active")
-    invoice = OpenStruct.new(subscription: "12345")
-    charge = OpenStruct.new(
-      amount: 15_00,
-      application_fee_amount: 0,
-      created: Time.current.to_i,
-      customer: @event.data.object.customer,
-      currency: "usd",
-      id: "abcd",
-      invoice: "in_abcd",
-      payment_method_details: OpenStruct.new(card: OpenStruct.new(last4: "1234", brand: "Visa", exp_month: 1, exp_year: 2021)),
-      stripe_account: nil
-    )
-    ::Stripe::Charge.stubs(:retrieve).returns charge
-
-    ::Stripe::Invoice.stub :retrieve, invoice do
-      Pay::Stripe::Webhooks::ChargeSucceeded.new.call(@event)
-      assert_equal subscription, Pay.charge_model.find_by(processor: :stripe, processor_id: "abcd").subscription
-    end
-  end
-
-  def fake_stripe_charge(**values)
-    values.reverse_merge!(@event.data.object.to_hash)
-    ::Stripe::Subscription.construct_from(values)
+    Pay::Stripe::Charge.expects(:sync)
+    Pay::Stripe::Webhooks::ChargeSucceeded.new.call(@event)
   end
 end

--- a/test/pay/stripe/webhooks/subscription_created_test.rb
+++ b/test/pay/stripe/webhooks/subscription_created_test.rb
@@ -6,64 +6,7 @@ class Pay::Stripe::Webhooks::SubscriptionCreatedTest < ActiveSupport::TestCase
   end
 
   test "subscription is created" do
-    @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: @event.data.object.customer)
-
-    assert_equal 0, @user.subscriptions.count
-
+    Pay::Stripe::Subscription.expects(:sync)
     Pay::Stripe::Webhooks::SubscriptionCreated.new.call(@event)
-
-    subscription = @user.subscriptions.first
-
-    assert_equal 1, @user.subscriptions.count
-    assert_equal "FFBEGINNER_00000000000000", subscription.processor_plan
-    assert_equal Time.at(@event.data.object.trial_end), subscription.trial_ends_at
-    assert_nil subscription.ends_at
-    assert_equal "active", subscription.status
-  end
-
-  test "does not create a subscription when the user does not exist" do
-    result = Pay::Stripe::Webhooks::SubscriptionCreated.new.call(@event)
-
-    assert_equal 0, Pay.subscription_model.count
-    assert_nil result
-  end
-
-  test "subscription is updated" do
-    @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: @event.data.object.customer)
-    subscription = @user.subscriptions.create!(processor: :stripe, processor_id: @event.data.object.id, name: "default", processor_plan: "FFBEGINNER_00000000000000", status: "incomplete", quantity: 2)
-
-    Pay::Stripe::Webhooks::SubscriptionCreated.new.call(@event)
-
-    subscription.reload
-
-    assert_equal 2, subscription.quantity
-    assert_equal "FFBEGINNER_00000000000000", subscription.processor_plan
-    assert_equal Time.at(@event.data.object.trial_end), subscription.trial_ends_at
-    assert_nil subscription.ends_at
-    assert_equal "active", subscription.status
-  end
-
-  test "subscription is updated with cancel_at_period_end = true and on_trial? = false" do
-    @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: @event.data.object.customer)
-    subscription = @user.subscriptions.create!(processor: :stripe, processor_id: @event.data.object.id, name: "default", processor_plan: "some-plan", status: "active")
-
-    @event.data.object.stubs(:cancel_at_period_end).returns(true)
-
-    Pay::Stripe::Webhooks::SubscriptionCreated.new.call(@event)
-
-    assert_equal Time.at(@event.data.object.current_period_end), subscription.reload.ends_at
-  end
-
-  test "subscription is updated with cancel_at_period_end = true and on_trial? = true" do
-    @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: @event.data.object.customer)
-    subscription = @user.subscriptions.create!(processor: :stripe, processor_id: @event.data.object.id, name: "default", processor_plan: "some-plan", status: "active")
-
-    @event.data.object.stubs(:cancel_at_period_end).returns(true)
-    Pay.subscription_model.any_instance.stubs(:on_trial?).returns(true)
-    Pay.subscription_model.any_instance.stubs(:trial_ends_at).returns(3.days.from_now.beginning_of_day)
-
-    Pay::Stripe::Webhooks::SubscriptionCreated.new.call(@event)
-
-    assert_equal 3.days.from_now.beginning_of_day, subscription.reload.ends_at
   end
 end

--- a/test/pay/stripe/webhooks/subscription_deleted_test.rb
+++ b/test/pay/stripe/webhooks/subscription_deleted_test.rb
@@ -5,63 +5,8 @@ class Pay::Stripe::Webhooks::SubscriptionDeletedTest < ActiveSupport::TestCase
     @event = stripe_event("test/support/fixtures/stripe/subscription_deleted_event.json")
   end
 
-  test "it sets ends_at on the subscription" do
-    @user = User.create!(
-      email: "gob@bluth.com",
-      processor: :stripe,
-      processor_id: @event.data.object.customer
-    )
-    @user.subscriptions.create!(
-      processor: :stripe,
-      processor_id: @event.data.object.id,
-      name: "default",
-      processor_plan: "some-plan",
-      status: "active"
-    )
-
-    Pay.subscription_model.any_instance.expects(:update!).with(ends_at: Time.at(@event.data.object.ended_at))
+  test "syncs subscription" do
+    Pay::Stripe::Subscription.expects(:sync)
     Pay::Stripe::Webhooks::SubscriptionDeleted.new.call(@event)
   end
-
-  test "it doesn't set ends_at on the subscription if it's already set" do
-    @user = User.create!(
-      email: "gob@bluth.com",
-      processor: :stripe,
-      processor_id: @event.data.object.customer
-    )
-    @user.subscriptions.create!(
-      processor: :stripe,
-      processor_id: @event.data.object.id,
-      name: "default",
-      processor_plan: "some-plan",
-      ends_at: Time.zone.now,
-      status: "active"
-    )
-
-    Pay.subscription_model.any_instance.expects(:update!).with(ends_at: Time.at(@event.data.object.ended_at)).never
-    Pay::Stripe::Webhooks::SubscriptionDeleted.new.call(@event)
-  end
-
-  test "it doesn't set ends_at on the subscription if it can't find the subscription" do
-    @user = User.create!(
-      email: "gob@bluth.com",
-      processor: :stripe,
-      processor_id: @event.data.object.customer
-    )
-    @user.subscriptions.create!(
-      processor: :stripe,
-      processor_id: "does-not-exist",
-      name: "default",
-      processor_plan: "some-plan",
-      status: "active"
-    )
-
-    Pay.subscription_model.any_instance.expects(:update!).with(ends_at: Time.at(@event.data.object.ended_at)).never
-    Pay::Stripe::Webhooks::SubscriptionDeleted.new.call(@event)
-  end
-
-  # test "it does nothing if subscription can't be found" do
-  #   @user = User.create!(email: 'gob@bluth.com', processor: :stripe, processor_id: @event.data.object.customer)
-  #   subscription = @user.subscriptions.create!(processor: :stripe, processor_id: 'does-not-exist', name: 'default', processor_plan: 'some-plan')
-  # end
 end

--- a/test/pay/stripe/webhooks/subscription_renewing_test.rb
+++ b/test/pay/stripe/webhooks/subscription_renewing_test.rb
@@ -8,16 +8,13 @@ class Pay::Stripe::Webhooks::SubscriptionRenewingTest < ActiveSupport::TestCase
 
   test "an email is sent to the user when subscription is renewing" do
     create_subscription(processor_id: @event.data.object.subscription)
-    # Time.zone.at(@event.data.object.next_payment_attempt)
-
     Pay::Stripe::Webhooks::SubscriptionRenewing.new.call(@event)
     assert_enqueued_emails 1
   end
 
   test "an email is not sent when subscription can't be found" do
-    create_subscription(processor_id: "does-not-exist")
-
     assert_no_enqueued_emails do
+      create_subscription(processor_id: "does-not-exist")
       Pay::Stripe::Webhooks::SubscriptionRenewing.new.call(@event)
     end
   end

--- a/test/pay/webhooks/delegator_test.rb
+++ b/test/pay/webhooks/delegator_test.rb
@@ -47,6 +47,21 @@ class Pay::WebhookDelegatorTest < ActiveSupport::TestCase
     assert delegator.backend.notifier.listening?("pay.stripe.test_event")
   end
 
+  test "supports multiple subscriptions for the same event" do
+    results = []
+
+    delegator.subscribe "stripe.test_event" do |event|
+      results << "a"
+    end
+
+    delegator.subscribe "stripe.test_event" do |event|
+      results << "b"
+    end
+
+    delegator.instrument event: {}, type: "stripe.test_event"
+    assert_equal 2, results.length
+  end
+
   private
 
   attr_reader :delegator

--- a/test/support/fixtures/stripe/charge_succeeded_event.json
+++ b/test/support/fixtures/stripe/charge_succeeded_event.json
@@ -2,6 +2,7 @@
   "object": {
     "id": "ch_chargeid",
     "amount": 500,
+    "amount_refunded": 0,
     "application_fee_amount": null,
     "created": 1546332337,
     "currency": "usd",
@@ -14,6 +15,7 @@
         "exp_year": 2019,
         "last4": "4444"
       }
-    }
+    },
+    "stripe_account": null
   }
 }


### PR DESCRIPTION
Since webhook order is not guaranteed, we can simply use the webhooks as a trigger to query the latest information from the API. That way webhooks can arrive out of order, but we won't be saving stale data.