### PR TITLE
RFC: add a path for syncing all of a customer's subscriptions

### DIFF
--- a/lib/pay/stripe/billable.rb
+++ b/lib/pay/stripe/billable.rb
@@ -180,8 +180,8 @@ module Pay
         end
       rescue ::Stripe::StripeError => e
         raise Pay::Stripe::Error, e
-      end   
-    
+      end
+
       # https://stripe.com/docs/api/checkout/sessions/create
       #
       # checkout(mode: "payment")

--- a/lib/pay/stripe/billable.rb
+++ b/lib/pay/stripe/billable.rb
@@ -206,6 +206,17 @@ module Pay
         ::Stripe::Checkout::Session.create(args.merge(options), {stripe_account: stripe_account})
       end
 
+      def sync_subscriptions
+        stripe_customer = customer
+
+        subscriptions = ::Stripe::Subscription.list(customer: stripe_customer)
+        subscriptions.map do |subscription|
+          Pay::Stripe::Subscription.sync(subscription.id)
+        end
+      rescue ::Stripe::StripeError => e
+        raise Pay::Stripe::Error, e
+      end
+
       # https://stripe.com/docs/api/checkout/sessions/create
       #
       # checkout_charge(amount: 15_00, name: "T-shirt", quantity: 2)

--- a/lib/pay/stripe/billable.rb
+++ b/lib/pay/stripe/billable.rb
@@ -209,7 +209,7 @@ module Pay
       def sync_subscriptions
         stripe_customer = customer
 
-        subscriptions = ::Stripe::Subscription.list(customer: stripe_customer)
+        subscriptions = ::Stripe::Subscription.list({customer: stripe_customer}, {stripe_account: stripe_account})
         subscriptions.map do |subscription|
           Pay::Stripe::Subscription.sync(subscription.id)
         end


### PR DESCRIPTION
Hi, 
I'm getting going with pay-rails and stripe, and Stripe's lack of any accountability for its webhooks arriving at all, or in the correct order, or... well really anything, is making me just a touch nervous.  In development particularly their webhooks completely miss the stripe local server, leading to odd out of sync states.

So here's a little api wrapper that resyncs all of a stripe customer subscriptions.  Unfortunately I don't see a way to map a stripe price_id for the subscription back to a rails-pay `name` -- not sure if I'm missing somewhere where a mapping should be registered?  Nor do I have necessarily have the bandwidth to go figure out the other payment processors.

But I found this useful.  yeah.

