### PR TITLE
Connect Webhooks & Prices support (for Pay v2)

### DIFF
--- a/app/models/pay/subscription.rb
+++ b/app/models/pay/subscription.rb
@@ -10,14 +10,20 @@ module Pay
     # Associations
     belongs_to :owner, polymorphic: true
     has_many :charges, class_name: "Pay::Charge", foreign_key: :pay_subscription_id
+    has_many :subscription_items, class_name: "Pay::SubscriptionItem", foreign_key: :pay_subscription_id
 
     # Validations
     validates :name, presence: true
     validates :processor, presence: true
-    validates :processor_id, presence: true, uniqueness: {scope: :processor, case_sensitive: false}
-    validates :processor_plan, presence: true
-    validates :quantity, presence: true
+    validates :processor_id, presence: true
+    validates :quantity, numericality: {
+      only_integer: true,
+      allow_nil: true,
+      greater_than_or_equal_to: 1
+    }
     validates :status, presence: true
+
+    accepts_nested_attributes_for :subscription_items, allow_destroy: true
 
     # Scopes
     scope :for_name, ->(name) { where(name: name) }

--- a/app/models/pay/subscription.rb
+++ b/app/models/pay/subscription.rb
@@ -15,7 +15,7 @@ module Pay
     # Validations
     validates :name, presence: true
     validates :processor, presence: true
-    validates :processor_id, presence: true
+    validates :processor_id, presence: true, uniqueness: {scope: :processor, case_sensitive: false}
     validates :quantity, numericality: {
       only_integer: true,
       allow_nil: true,

--- a/app/models/pay/subscription_item.rb
+++ b/app/models/pay/subscription_item.rb
@@ -1,0 +1,12 @@
+class Pay::SubscriptionItem < ApplicationRecord
+  self.table_name = "pay_subscription_items"
+
+  belongs_to :subscription, class_name: "Pay::Subscription", foreign_key: :pay_subscription_id
+
+  validates :processor_id, presence: true
+  validates :processor_price, presence: true
+  validates :quantity, numericality: {
+    only_integer: true,
+    greater_than_or_equal_to: 1
+  }
+end

--- a/db/migrate/20210624143843_create_pay_subscription_items.rb
+++ b/db/migrate/20210624143843_create_pay_subscription_items.rb
@@ -1,0 +1,11 @@
+class CreatePaySubscriptionItems < ActiveRecord::Migration[6.1]
+  def change
+    create_table :pay_subscription_items do |t|
+      t.references :pay_subscription
+      t.string :processor_id, null: false
+      t.string :processor_price, null: false
+      t.integer :quantity, default: 1, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20210628151520_remove_not_null_constraint_on_processor_id_in_pay_subscriptions.rb
+++ b/db/migrate/20210628151520_remove_not_null_constraint_on_processor_id_in_pay_subscriptions.rb
@@ -1,0 +1,9 @@
+class RemoveNotNullConstraintOnProcessorIdInPaySubscriptions < ActiveRecord::Migration[6.1]
+  def up
+    change_column :pay_subscriptions, :processor_plan, :string, null: true
+  end
+
+  def down
+    change_column :pay_subscriptions, :processor_plan, :string, null: false
+  end
+end

--- a/db/migrate/20210628151951_remove_not_null_constraint_on_quantity_in_pay_subscriptions.rb
+++ b/db/migrate/20210628151951_remove_not_null_constraint_on_quantity_in_pay_subscriptions.rb
@@ -1,0 +1,9 @@
+class RemoveNotNullConstraintOnQuantityInPaySubscriptions < ActiveRecord::Migration[6.1]
+  def up
+    change_column :pay_subscriptions, :quantity, :integer, default: 1, null: true
+  end
+
+  def down
+    change_column :pay_subscriptions, :quantity, :integer, default: 1, null: false
+  end
+end

--- a/db/migrate/20210628193552_add_pay_merchant_to_accounts.rb
+++ b/db/migrate/20210628193552_add_pay_merchant_to_accounts.rb
@@ -1,0 +1,11 @@
+class AddPayMerchantToAccounts < ActiveRecord::Migration[6.1]
+  def up
+    remove_column :accounts, :pay_data, :string
+    add_column :accounts, :pay_data, Pay::Adapter.json_column_type
+  end
+
+  def down
+    add_column :accounts, :pay_data, :string
+    remove_column :accounts, :pay_data, Pay::Adapter.json_column_type
+  end
+end

--- a/lib/pay/stripe/billable.rb
+++ b/lib/pay/stripe/billable.rb
@@ -172,7 +172,7 @@ module Pay
       def sync_subscriptions
         subscriptions = ::Stripe::Subscription.list({customer: customer}, stripe_options)
         subscriptions.map do |subscription|
-          Pay::Stripe::Subscription.sync(subscription.id, options: { stripe_account: stripe_account })
+          Pay::Stripe::Subscription.sync(subscription.id, options: {stripe_account: stripe_account})
         end
       rescue ::Stripe::StripeError => e
         raise Pay::Stripe::Error, e

--- a/lib/pay/stripe/billable.rb
+++ b/lib/pay/stripe/billable.rb
@@ -172,7 +172,7 @@ module Pay
       def sync_subscriptions
         subscriptions = ::Stripe::Subscription.list({customer: customer}, stripe_options)
         subscriptions.map do |subscription|
-          Pay::Stripe::Subscription.sync(subscription.id)
+          Pay::Stripe::Subscription.sync(subscription.id, options: { stripe_account: stripe_account })
         end
       rescue ::Stripe::StripeError => e
         raise Pay::Stripe::Error, e

--- a/lib/pay/stripe/charge.rb
+++ b/lib/pay/stripe/charge.rb
@@ -15,8 +15,10 @@ module Pay
         details = object.payment_method_details
         payment_details = if details.type == 'ach_debit'
                             {
+                              card_exp_month: '**',
+                              card_exp_year: '****',
+                              card_last4: details.ach_debit.last4,
                               card_type: details.type,
-                              card_last4: details.ach_debit.last4
                             }
                           else
                             {

--- a/lib/pay/stripe/charge.rb
+++ b/lib/pay/stripe/charge.rb
@@ -5,9 +5,9 @@ module Pay
 
       delegate :processor_id, :owner, :stripe_account, to: :pay_charge
 
-      def self.sync(charge_id, object: nil, try: 0, retries: 1)
+      def self.sync(charge_id, object: nil, try: 0, retries: 1, options: {})
         # Skip loading the latest charge details from the API if we already have it
-        object ||= ::Stripe::Charge.retrieve(id: charge_id)
+        object ||= ::Stripe::Charge.retrieve(charge_id, { stripe_account: options[:stripe_account]})
 
         owner = Pay.find_billable(processor: :stripe, processor_id: object.customer)
         return unless owner

--- a/lib/pay/stripe/charge.rb
+++ b/lib/pay/stripe/charge.rb
@@ -27,7 +27,7 @@ module Pay
 
         # Associate charge with subscription if we can
         if object.invoice
-          invoice = (object.invoice.is_a?(::Stripe::Invoice) ? object.invoice : ::Stripe::Invoice.retrieve(object.invoice))
+          invoice = (object.invoice.is_a?(::Stripe::Invoice) ? object.invoice : ::Stripe::Invoice.retrieve(object.invoice, { stripe_account: owner.stripe_account }))
           attrs[:subscription] = Pay::Subscription.find_by(processor: :stripe, processor_id: invoice.subscription)
         end
 

--- a/lib/pay/stripe/charge.rb
+++ b/lib/pay/stripe/charge.rb
@@ -7,7 +7,7 @@ module Pay
 
       def self.sync(charge_id, object: nil, try: 0, retries: 1, options: {})
         # Skip loading the latest charge details from the API if we already have it
-        object ||= ::Stripe::Charge.retrieve(charge_id, { stripe_account: options[:stripe_account]})
+        object ||= ::Stripe::Charge.retrieve(charge_id, {stripe_account: options[:stripe_account]})
 
         owner = Pay.find_billable(processor: :stripe, processor_id: object.customer)
         return unless owner
@@ -27,7 +27,7 @@ module Pay
 
         # Associate charge with subscription if we can
         if object.invoice
-          invoice = (object.invoice.is_a?(::Stripe::Invoice) ? object.invoice : ::Stripe::Invoice.retrieve(object.invoice, { stripe_account: owner.stripe_account }))
+          invoice = (object.invoice.is_a?(::Stripe::Invoice) ? object.invoice : ::Stripe::Invoice.retrieve(object.invoice, {stripe_account: owner.stripe_account}))
           attrs[:subscription] = Pay::Subscription.find_by(processor: :stripe, processor_id: invoice.subscription)
         end
 

--- a/lib/pay/stripe/subscription.rb
+++ b/lib/pay/stripe/subscription.rb
@@ -122,15 +122,7 @@ module Pay
       end
 
       def change_quantity(quantity)
-<<<<<<< HEAD
         ::Stripe::Subscription.update(processor_id, {quantity: quantity}, stripe_options)
-=======
-        ::Stripe::Subscription.update(
-          processor_id,
-          {quantity: quantity},
-          {stripe_account: stripe_account}
-        )
->>>>>>> d3604b9 (Connect Subscriptions, Charges Webhooks)
       rescue ::Stripe::StripeError => e
         raise Pay::Stripe::Error, e
       end

--- a/lib/pay/stripe/subscription.rb
+++ b/lib/pay/stripe/subscription.rb
@@ -25,9 +25,9 @@ module Pay
         object ||= ::Stripe::Subscription.retrieve(
           {
             id: subscription_id,
-            expand: ["pending_setup_intent", "latest_invoice.payment_intent"],
+            expand: ["pending_setup_intent", "latest_invoice.payment_intent"]
           },
-          { stripe_account: options[:stripe_account] }
+          {stripe_account: options[:stripe_account]}
         )
 
         owner = Pay.find_billable(processor: :stripe, processor_id: object.customer)

--- a/lib/pay/stripe/subscription.rb
+++ b/lib/pay/stripe/subscription.rb
@@ -20,7 +20,7 @@ module Pay
         :trial_ends_at,
         to: :pay_subscription
 
-      def self.sync(subscription_id, object: nil, options: {}, name: Pay.default_product_name, try: 0, retries: 1)
+      def self.sync(subscription_id, object: nil, name: Pay.default_product_name, try: 0, retries: 1, options: {})
         # Skip loading the latest subscription details from the API if we already have it
         object ||= ::Stripe::Subscription.retrieve(
           {

--- a/lib/pay/stripe/subscription.rb
+++ b/lib/pay/stripe/subscription.rb
@@ -20,9 +20,15 @@ module Pay
         :trial_ends_at,
         to: :pay_subscription
 
-      def self.sync(subscription_id, object: nil, name: Pay.default_product_name, try: 0, retries: 1)
+      def self.sync(subscription_id, object: nil, options: {}, name: Pay.default_product_name, try: 0, retries: 1)
         # Skip loading the latest subscription details from the API if we already have it
-        object ||= ::Stripe::Subscription.retrieve({id: subscription_id, expand: ["pending_setup_intent", "latest_invoice.payment_intent"]})
+        object ||= ::Stripe::Subscription.retrieve(
+          {
+            id: subscription_id,
+            expand: ["pending_setup_intent", "latest_invoice.payment_intent"],
+          },
+          { stripe_account: options[:stripe_account] }
+        )
 
         owner = Pay.find_billable(processor: :stripe, processor_id: object.customer)
         return unless owner

--- a/lib/pay/stripe/webhooks/charge_refunded.rb
+++ b/lib/pay/stripe/webhooks/charge_refunded.rb
@@ -3,7 +3,8 @@ module Pay
     module Webhooks
       class ChargeRefunded
         def call(event)
-          pay_charge = Pay::Stripe::Charge.sync(event.data.object.id)
+          object = event.data.object
+          pay_charge = Pay::Stripe::Charge.sync(object.id, object: object)
           notify_user(pay_charge.owner, pay_charge) if pay_charge
         end
 

--- a/lib/pay/stripe/webhooks/charge_refunded.rb
+++ b/lib/pay/stripe/webhooks/charge_refunded.rb
@@ -4,7 +4,7 @@ module Pay
       class ChargeRefunded
         def call(event)
           object = event.data.object
-          pay_charge = Pay::Stripe::Charge.sync(object.id, options: { stripe_account: event.account })
+          pay_charge = Pay::Stripe::Charge.sync(object.id, options: {stripe_account: event.account})
           notify_user(pay_charge.owner, pay_charge) if pay_charge
         end
 

--- a/lib/pay/stripe/webhooks/charge_refunded.rb
+++ b/lib/pay/stripe/webhooks/charge_refunded.rb
@@ -4,7 +4,7 @@ module Pay
       class ChargeRefunded
         def call(event)
           object = event.data.object
-          pay_charge = Pay::Stripe::Charge.sync(object.id, object: object)
+          pay_charge = Pay::Stripe::Charge.sync(object.id, options: { stripe_account: object.account })
           notify_user(pay_charge.owner, pay_charge) if pay_charge
         end
 

--- a/lib/pay/stripe/webhooks/charge_refunded.rb
+++ b/lib/pay/stripe/webhooks/charge_refunded.rb
@@ -4,7 +4,7 @@ module Pay
       class ChargeRefunded
         def call(event)
           object = event.data.object
-          pay_charge = Pay::Stripe::Charge.sync(object.id, options: { stripe_account: object.account })
+          pay_charge = Pay::Stripe::Charge.sync(object.id, options: { stripe_account: event.account })
           notify_user(pay_charge.owner, pay_charge) if pay_charge
         end
 

--- a/lib/pay/stripe/webhooks/charge_succeeded.rb
+++ b/lib/pay/stripe/webhooks/charge_succeeded.rb
@@ -3,7 +3,8 @@ module Pay
     module Webhooks
       class ChargeSucceeded
         def call(event)
-          pay_charge = Pay::Stripe::Charge.sync(event.data.object.id)
+          object = event.data.object
+          pay_charge = Pay::Stripe::Charge.sync(object.id, object: object)
           notify_user(pay_charge.owner, pay_charge) if pay_charge
         end
 

--- a/lib/pay/stripe/webhooks/charge_succeeded.rb
+++ b/lib/pay/stripe/webhooks/charge_succeeded.rb
@@ -4,7 +4,7 @@ module Pay
       class ChargeSucceeded
         def call(event)
           object = event.data.object
-          pay_charge = Pay::Stripe::Charge.sync(object.id, options: { stripe_account: object.account })
+          pay_charge = Pay::Stripe::Charge.sync(object.id, options: { stripe_account: event.account })
           notify_user(pay_charge.owner, pay_charge) if pay_charge
         end
 

--- a/lib/pay/stripe/webhooks/charge_succeeded.rb
+++ b/lib/pay/stripe/webhooks/charge_succeeded.rb
@@ -4,7 +4,7 @@ module Pay
       class ChargeSucceeded
         def call(event)
           object = event.data.object
-          pay_charge = Pay::Stripe::Charge.sync(object.id, object: object)
+          pay_charge = Pay::Stripe::Charge.sync(object.id, options: { stripe_account: object.account })
           notify_user(pay_charge.owner, pay_charge) if pay_charge
         end
 

--- a/lib/pay/stripe/webhooks/charge_succeeded.rb
+++ b/lib/pay/stripe/webhooks/charge_succeeded.rb
@@ -4,7 +4,7 @@ module Pay
       class ChargeSucceeded
         def call(event)
           object = event.data.object
-          pay_charge = Pay::Stripe::Charge.sync(object.id, options: { stripe_account: event.account })
+          pay_charge = Pay::Stripe::Charge.sync(object.id, options: {stripe_account: event.account})
           notify_user(pay_charge.owner, pay_charge) if pay_charge
         end
 

--- a/lib/pay/stripe/webhooks/payment_intent_succeeded.rb
+++ b/lib/pay/stripe/webhooks/payment_intent_succeeded.rb
@@ -5,7 +5,7 @@ module Pay
         def call(event)
           object = event.data.object
           object.charges.data.each do |charge|
-            pay_charge = Pay::Stripe::Charge.sync(charge.id)
+            pay_charge = Pay::Stripe::Charge.sync(charge.id, object: charge)
             notify_user(pay_charge.owner, pay_charge) if pay_charge
           end
         end

--- a/lib/pay/stripe/webhooks/subscription_created.rb
+++ b/lib/pay/stripe/webhooks/subscription_created.rb
@@ -3,7 +3,8 @@ module Pay
     module Webhooks
       class SubscriptionCreated
         def call(event)
-          Pay::Stripe::Subscription.sync(event.data.object.id)
+          object = event.data.object
+          Pay::Stripe::Subscription.sync(object.id, object: object)
         end
       end
     end

--- a/lib/pay/stripe/webhooks/subscription_created.rb
+++ b/lib/pay/stripe/webhooks/subscription_created.rb
@@ -4,7 +4,7 @@ module Pay
       class SubscriptionCreated
         def call(event)
           object = event.data.object
-          Pay::Stripe::Subscription.sync(object.id, options: { stripe_account: event.account })
+          Pay::Stripe::Subscription.sync(object.id, options: {stripe_account: event.account})
         end
       end
     end

--- a/lib/pay/stripe/webhooks/subscription_created.rb
+++ b/lib/pay/stripe/webhooks/subscription_created.rb
@@ -4,7 +4,7 @@ module Pay
       class SubscriptionCreated
         def call(event)
           object = event.data.object
-          Pay::Stripe::Subscription.sync(object.id, options: { stripe_account: object.account })
+          Pay::Stripe::Subscription.sync(object.id, options: { stripe_account: event.account })
         end
       end
     end

--- a/lib/pay/stripe/webhooks/subscription_created.rb
+++ b/lib/pay/stripe/webhooks/subscription_created.rb
@@ -4,7 +4,7 @@ module Pay
       class SubscriptionCreated
         def call(event)
           object = event.data.object
-          Pay::Stripe::Subscription.sync(object.id, object: object)
+          Pay::Stripe::Subscription.sync(object.id, options: { stripe_account: object.id })
         end
       end
     end

--- a/lib/pay/stripe/webhooks/subscription_created.rb
+++ b/lib/pay/stripe/webhooks/subscription_created.rb
@@ -4,7 +4,7 @@ module Pay
       class SubscriptionCreated
         def call(event)
           object = event.data.object
-          Pay::Stripe::Subscription.sync(object.id, options: { stripe_account: object.id })
+          Pay::Stripe::Subscription.sync(object.id, options: { stripe_account: object.account })
         end
       end
     end

--- a/lib/pay/stripe/webhooks/subscription_deleted.rb
+++ b/lib/pay/stripe/webhooks/subscription_deleted.rb
@@ -4,7 +4,7 @@ module Pay
       class SubscriptionDeleted
         def call(event)
           object = event.data.object
-          Pay::Stripe::Subscription.sync(object.id, options: { stripe_account: object.account })
+          Pay::Stripe::Subscription.sync(object.id, options: { stripe_account: event.account })
         end
       end
     end

--- a/lib/pay/stripe/webhooks/subscription_deleted.rb
+++ b/lib/pay/stripe/webhooks/subscription_deleted.rb
@@ -4,7 +4,7 @@ module Pay
       class SubscriptionDeleted
         def call(event)
           object = event.data.object
-          Pay::Stripe::Subscription.sync(object.id, options: { stripe_account: event.account })
+          Pay::Stripe::Subscription.sync(object.id, options: {stripe_account: event.account})
         end
       end
     end

--- a/lib/pay/stripe/webhooks/subscription_deleted.rb
+++ b/lib/pay/stripe/webhooks/subscription_deleted.rb
@@ -3,7 +3,8 @@ module Pay
     module Webhooks
       class SubscriptionDeleted
         def call(event)
-          Pay::Stripe::Subscription.sync(event.data.object.id)
+          object = event.data.object
+          Pay::Stripe::Subscription.sync(object.id, options: { stripe_account: object.account })
         end
       end
     end

--- a/lib/pay/stripe/webhooks/subscription_updated.rb
+++ b/lib/pay/stripe/webhooks/subscription_updated.rb
@@ -3,7 +3,8 @@ module Pay
     module Webhooks
       class SubscriptionUpdated
         def call(event)
-          Pay::Stripe::Subscription.sync(event.data.object.id)
+          object = event.data.object
+          Pay::Stripe::Subscription.sync(object.id, object: object)
         end
       end
     end

--- a/lib/pay/stripe/webhooks/subscription_updated.rb
+++ b/lib/pay/stripe/webhooks/subscription_updated.rb
@@ -4,7 +4,7 @@ module Pay
       class SubscriptionUpdated
         def call(event)
           object = event.data.object
-          Pay::Stripe::Subscription.sync(object.id, options: { stripe_account: event.account })
+          Pay::Stripe::Subscription.sync(object.id, options: {stripe_account: event.account})
         end
       end
     end

--- a/lib/pay/stripe/webhooks/subscription_updated.rb
+++ b/lib/pay/stripe/webhooks/subscription_updated.rb
@@ -4,7 +4,7 @@ module Pay
       class SubscriptionUpdated
         def call(event)
           object = event.data.object
-          Pay::Stripe::Subscription.sync(object.id, options: { stripe_account: object.id })
+          Pay::Stripe::Subscription.sync(object.id, options: { stripe_account: object.account })
         end
       end
     end

--- a/lib/pay/stripe/webhooks/subscription_updated.rb
+++ b/lib/pay/stripe/webhooks/subscription_updated.rb
@@ -4,7 +4,7 @@ module Pay
       class SubscriptionUpdated
         def call(event)
           object = event.data.object
-          Pay::Stripe::Subscription.sync(object.id, options: { stripe_account: object.account })
+          Pay::Stripe::Subscription.sync(object.id, options: { stripe_account: event.account })
         end
       end
     end

--- a/lib/pay/stripe/webhooks/subscription_updated.rb
+++ b/lib/pay/stripe/webhooks/subscription_updated.rb
@@ -4,7 +4,7 @@ module Pay
       class SubscriptionUpdated
         def call(event)
           object = event.data.object
-          Pay::Stripe::Subscription.sync(object.id, object: object)
+          Pay::Stripe::Subscription.sync(object.id, options: { stripe_account: object.id })
         end
       end
     end

--- a/test/dummy/db/postgresql_schema.rb
+++ b/test/dummy/db/postgresql_schema.rb
@@ -76,5 +76,4 @@ ActiveRecord::Schema.define(version: 2020_11_16_191926) do
     t.string "card_exp_year"
     t.text "extra_billing_info"
   end
-
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -15,13 +15,7 @@ ActiveRecord::Schema.define(version: 2021_07_14_175351) do
   create_table "accounts", force: :cascade do |t|
     t.string "email"
     t.string "merchant_processor"
-    if t.respond_to? :jsonb
-      t.jsonb "pay_data"
-    else
-      t.json "pay_data"
-    end
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.json "pay_data"
   end
 
   create_table "pay_charges", force: :cascade do |t|
@@ -37,11 +31,21 @@ ActiveRecord::Schema.define(version: 2021_07_14_175351) do
     t.string "card_exp_year"
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.text "data"
+    t.json "data"
     t.string "currency"
     t.integer "application_fee_amount"
     t.integer "pay_subscription_id"
     t.index ["processor", "processor_id"], name: "index_pay_charges_on_processor_and_processor_id", unique: true
+  end
+
+  create_table "pay_subscription_items", force: :cascade do |t|
+    t.integer "pay_subscription_id"
+    t.string "processor_id", null: false
+    t.string "processor_price", null: false
+    t.integer "quantity", default: 1, null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["pay_subscription_id"], name: "index_pay_subscription_items_on_pay_subscription_id"
   end
 
   create_table "pay_subscriptions", force: :cascade do |t|
@@ -50,14 +54,14 @@ ActiveRecord::Schema.define(version: 2021_07_14_175351) do
     t.string "name", null: false
     t.string "processor", null: false
     t.string "processor_id", null: false
-    t.string "processor_plan", null: false
-    t.integer "quantity", default: 1, null: false
+    t.string "processor_plan"
+    t.integer "quantity", default: 1
     t.datetime "trial_ends_at"
     t.datetime "ends_at"
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string "status"
-    t.text "data"
+    t.json "data"
     t.decimal "application_fee_percent", precision: 8, scale: 2
     t.index ["processor", "processor_id"], name: "index_pay_subscriptions_on_processor_and_processor_id", unique: true
   end
@@ -76,9 +80,7 @@ ActiveRecord::Schema.define(version: 2021_07_14_175351) do
     t.string "card_exp_year"
     t.text "extra_billing_info"
     t.json "pay_data"
-    t.datetime "created_at"
-    t.datetime "updated_at"
-    t.index ["owner_type", "owner_id"], name: "index_teams_on_owner_type_and_owner_id"
+    t.index ["owner_type", "owner_id"], name: "index_teams_on_owner"
   end
 
   create_table "users", force: :cascade do |t|
@@ -94,8 +96,5 @@ ActiveRecord::Schema.define(version: 2021_07_14_175351) do
     t.string "card_exp_year"
     t.text "extra_billing_info"
     t.json "pay_data"
-    t.datetime "created_at"
-    t.datetime "updated_at"
   end
-
 end

--- a/test/models/pay/subscription_item_test.rb
+++ b/test/models/pay/subscription_item_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class Pay::SubscriptionItemTest < ActiveSupport::TestCase
+  setup do
+    @subscription_item = Pay::SubscriptionItem.new
+  end
+
+  test "belongs to a subscription" do
+    @subscription = Pay.subscription_model.new processor: "stripe", status: "active"
+    @subscription_item.subscription = @subscription
+
+    assert_equal Pay::Subscription, @subscription_item.subscription.class
+  end
+end

--- a/test/pay/paddle/subscription_test.rb
+++ b/test/pay/paddle/subscription_test.rb
@@ -109,8 +109,9 @@ class Pay::Paddle::Subscription::Test < ActiveSupport::TestCase
       )
       subscription = @billable.subscription
       next_payment_date = Time.zone.parse(subscription.processor_subscription.next_payment[:date])
+
       subscription.pause
-      assert_equal subscription.paddle_paused_from, next_payment_date
+      assert_equal Time.zone.parse(subscription.paddle_paused_from), next_payment_date
 
       subscription.resume
       assert_nil subscription.paddle_paused_from

--- a/test/pay/stripe/subscription_test.rb
+++ b/test/pay/stripe/subscription_test.rb
@@ -78,7 +78,31 @@ class Pay::Stripe::SubscriptionTest < ActiveSupport::TestCase
       },
       quantity: 1,
       status: "active",
-      trial_end: nil
+      trial_end: nil,
+      items: {
+        object: "list",
+        data: [
+          {
+            id: "si_00000000000000",
+            object: "subscription_item",
+            created: 1466783124,
+            price: {
+              id: "price_000000000000000000000000",
+              object: "price",
+              active: true,
+              billing_scheme: "per_unit",
+              created: 1624895327,
+              currency: "usd",
+              product: "prod_00000000000000",
+              type: "recurring",
+              unit_amount: 15400,
+              unit_amount_decimal: "15400"
+            },
+            quantity: 1,
+            subscription: "123"
+          }
+        ]
+      }
     )
     ::Stripe::Subscription.construct_from(values)
   end

--- a/test/pay/stripe/webhooks/account_updated_test.rb
+++ b/test/pay/stripe/webhooks/account_updated_test.rb
@@ -11,6 +11,6 @@ class Pay::Stripe::Webhooks::AccountUpdatedTest < ActiveSupport::TestCase
     Pay::Stripe::Webhooks::AccountUpdated.new.call(@event.data)
 
     assert @account.reload.onboarding_complete
-    assert @account.reload.stripe_connect_account_id != nil
+    assert !@account.reload.stripe_connect_account_id.nil?
   end
 end

--- a/test/pay/stripe/webhooks/account_updated_test.rb
+++ b/test/pay/stripe/webhooks/account_updated_test.rb
@@ -11,5 +11,6 @@ class Pay::Stripe::Webhooks::AccountUpdatedTest < ActiveSupport::TestCase
     Pay::Stripe::Webhooks::AccountUpdated.new.call(@event.data)
 
     assert @account.reload.onboarding_complete
+    assert @account.reload.stripe_connect_account_id != nil
   end
 end

--- a/test/support/fixtures/stripe/subscription_updated_event.json
+++ b/test/support/fixtures/stripe/subscription_updated_event.json
@@ -23,6 +23,31 @@
           "object": "subscription_item",
           "created": 1466783125,
           "metadata": {},
+          "price": {
+            "id": "price_000000000000000000000000",
+            "object": "price",
+            "active": true,
+            "billing_scheme": "per_unit",
+            "created": 1466744919,
+            "currency": "usd",
+            "livemode": false,
+            "lookup_key": null,
+            "metadata": {},
+            "nickname": "PAYPRICE",
+            "product": "prod_00000000000000",
+            "recurring": {
+              "aggregate_usage": null,
+              "interval": "year",
+              "interval_count": 1,
+              "usage_type": "licensed"
+            },
+            "tax_behavior": "unspecified",
+            "tiers_mode": null,
+            "transform_quality": null,
+            "type": "recurring",
+            "unit_amount": 15400,
+            "unit_amount_decimal": "15400"
+          },
           "plan": {
             "id": "FFBEGINNER_00000000000000",
             "object": "plan",


### PR DESCRIPTION
When syncing Stripe data via webhooks, pass in the event object in addition to the id to avoid an API lookup without the Connect account id.

Billable lookup should find the correct Connect customer and subsequently create the appropriate Charge or Subscription record in the database.