### PR TITLE
Properly process subscription renewels from stripe

### DIFF
--- a/lib/pay/stripe/subscription.rb
+++ b/lib/pay/stripe/subscription.rb
@@ -37,17 +37,15 @@ module Pay
           trial_ends_at: (object.trial_end ? Time.at(object.trial_end) : nil)
         }
 
-        if object.ended_at
+        attributes[:ends_at] = if object.ended_at
           # Fully cancelled subscription
-          attributes[:ends_at] = Time.at(object.ended_at)
+          Time.at(object.ended_at)
         elsif object.cancel_at
           # subscription cancelling in the future
-          attributes[:ends_at] = Time.at(object.cancel_at)
+          Time.at(object.cancel_at)
         elsif object.cancel_at_period_end
           # Subscriptions cancelling in the future
-          attributes[:ends_at] = Time.at(object.current_period_end)
-        else
-          attributes[:ends_at] = nil
+          Time.at(object.current_period_end)
         end
 
         # Update or create the subscription

--- a/lib/pay/stripe/subscription.rb
+++ b/lib/pay/stripe/subscription.rb
@@ -36,12 +36,15 @@ module Pay
           stripe_account: owner.stripe_account,
           trial_ends_at: (object.trial_end ? Time.at(object.trial_end) : nil)
         }
-
-        # Subscriptions cancelling in the future
-        attributes[:ends_at] = Time.at(object.current_period_end) if object.cancel_at_period_end
-
-        # Fully cancelled subscription
-        attributes[:ends_at] = Time.at(object.ended_at) if object.ended_at
+        if object.ended_at
+          # Fully cancelled subscription
+          attributes[:ends_at] = Time.at(object.ended_at)
+        elsif object.cancel_at_period_end
+          # Subscriptions cancelling in the future
+          attributes[:ends_at] = Time.at(object.current_period_end)
+        elsif object.cancel_at.nil?
+          attributes[:ends_at] = nil
+        end
 
         # Update or create the subscription
         pay_subscription = owner.subscriptions.find_or_initialize_by(processor: :stripe, processor_id: object.id)

--- a/lib/pay/stripe/subscription.rb
+++ b/lib/pay/stripe/subscription.rb
@@ -36,13 +36,17 @@ module Pay
           stripe_account: owner.stripe_account,
           trial_ends_at: (object.trial_end ? Time.at(object.trial_end) : nil)
         }
+
         if object.ended_at
           # Fully cancelled subscription
           attributes[:ends_at] = Time.at(object.ended_at)
+        elsif object.cancel_at
+          # subscription cancelling in the future
+          attributes[:ends_at] = Time.at(object.cancel_at)
         elsif object.cancel_at_period_end
           # Subscriptions cancelling in the future
           attributes[:ends_at] = Time.at(object.current_period_end)
-        elsif object.cancel_at.nil?
+        else
           attributes[:ends_at] = nil
         end
 

--- a/test/pay/stripe/subscription_test.rb
+++ b/test/pay/stripe/subscription_test.rb
@@ -53,6 +53,7 @@ class Pay::Stripe::SubscriptionTest < ActiveSupport::TestCase
     values.reverse_merge!(
       id: "123",
       application_fee_percent: nil,
+      cancel_at: nil,
       cancel_at_period_end: false,
       created: 1466783124,
       current_period_end: 1488987924,

--- a/test/pay/stripe/webhooks/subscription_updated_test.rb
+++ b/test/pay/stripe/webhooks/subscription_updated_test.rb
@@ -48,7 +48,6 @@ class Pay::Stripe::Webhooks::SubscriptionUpdatedTest < ActiveSupport::TestCase
     assert_equal 3.days.from_now.beginning_of_day, subscription.reload.ends_at
   end
 
-
   test "subscription is updated with ended_at set" do
     build_user
 

--- a/test/pay/stripe/webhooks/subscription_updated_test.rb
+++ b/test/pay/stripe/webhooks/subscription_updated_test.rb
@@ -14,7 +14,7 @@ class Pay::Stripe::Webhooks::SubscriptionUpdatedTest < ActiveSupport::TestCase
   test "subscription is updated" do
     @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: @event.data.object.customer)
     subscription = @user.subscriptions.create!(processor: :stripe, processor_id: @event.data.object.id, name: "default", processor_plan: "some-plan", status: "active")
-    ::Stripe::Subscription.stubs(:retrieve).returns fake_stripe_subscription(quantity: 2, ended_at: nil)
+    ::Stripe::Subscription.stubs(:retrieve).returns fake_stripe_subscription(quantity: 2, ended_at: nil, cancel_at: nil)
 
     Pay::Stripe::Webhooks::SubscriptionUpdated.new.call(@event)
 
@@ -28,7 +28,7 @@ class Pay::Stripe::Webhooks::SubscriptionUpdatedTest < ActiveSupport::TestCase
   test "subscription is updated with cancel_at_period_end = true and on_trial? = false" do
     @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: @event.data.object.customer)
     subscription = @user.subscriptions.create!(processor: :stripe, processor_id: @event.data.object.id, name: "default", processor_plan: "some-plan", status: "active")
-    ::Stripe::Subscription.stubs(:retrieve).returns fake_stripe_subscription(cancel_at_period_end: true, current_period_end: @event.data.object.current_period_end, ended_at: nil)
+    ::Stripe::Subscription.stubs(:retrieve).returns fake_stripe_subscription(cancel_at_period_end: true, current_period_end: @event.data.object.current_period_end, ended_at: nil, cancel_at: nil)
 
     Pay::Stripe::Webhooks::SubscriptionUpdated.new.call(@event)
     assert_equal Time.at(@event.data.object.current_period_end), subscription.reload.ends_at
@@ -38,7 +38,7 @@ class Pay::Stripe::Webhooks::SubscriptionUpdatedTest < ActiveSupport::TestCase
     @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: @event.data.object.customer)
     subscription = @user.subscriptions.create!(processor: :stripe, processor_id: @event.data.object.id, name: "default", processor_plan: "some-plan", status: "active")
     trial_end = 3.days.from_now.beginning_of_day
-    ::Stripe::Subscription.stubs(:retrieve).returns fake_stripe_subscription(cancel_at_period_end: true, current_period_end: trial_end, ended_at: nil, trial_end: trial_end)
+    ::Stripe::Subscription.stubs(:retrieve).returns fake_stripe_subscription(cancel_at_period_end: true, current_period_end: trial_end, ended_at: nil, trial_end: trial_end, cancel_at: nil)
 
     Pay::Stripe::Webhooks::SubscriptionUpdated.new.call(@event)
 

--- a/test/pay/stripe/webhooks/subscription_updated_test.rb
+++ b/test/pay/stripe/webhooks/subscription_updated_test.rb
@@ -12,7 +12,8 @@ class Pay::Stripe::Webhooks::SubscriptionUpdatedTest < ActiveSupport::TestCase
   end
 
   test "subscription is updated" do
-    @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: @event.data.object.customer)
+    build_user
+
     subscription = @user.subscriptions.create!(processor: :stripe, processor_id: @event.data.object.id, name: "default", processor_plan: "some-plan", status: "active")
     ::Stripe::Subscription.stubs(:retrieve).returns fake_stripe_subscription(quantity: 2, ended_at: nil, cancel_at: nil)
 
@@ -26,7 +27,8 @@ class Pay::Stripe::Webhooks::SubscriptionUpdatedTest < ActiveSupport::TestCase
   end
 
   test "subscription is updated with cancel_at_period_end = true and on_trial? = false" do
-    @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: @event.data.object.customer)
+    build_user
+
     subscription = @user.subscriptions.create!(processor: :stripe, processor_id: @event.data.object.id, name: "default", processor_plan: "some-plan", status: "active")
     ::Stripe::Subscription.stubs(:retrieve).returns fake_stripe_subscription(cancel_at_period_end: true, current_period_end: @event.data.object.current_period_end, ended_at: nil, cancel_at: nil)
 
@@ -35,7 +37,8 @@ class Pay::Stripe::Webhooks::SubscriptionUpdatedTest < ActiveSupport::TestCase
   end
 
   test "subscription is updated with cancel_at_period_end = true and on_trial? = true" do
-    @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: @event.data.object.customer)
+    build_user
+
     subscription = @user.subscriptions.create!(processor: :stripe, processor_id: @event.data.object.id, name: "default", processor_plan: "some-plan", status: "active")
     trial_end = 3.days.from_now.beginning_of_day
     ::Stripe::Subscription.stubs(:retrieve).returns fake_stripe_subscription(cancel_at_period_end: true, current_period_end: trial_end, ended_at: nil, trial_end: trial_end, cancel_at: nil)
@@ -45,8 +48,45 @@ class Pay::Stripe::Webhooks::SubscriptionUpdatedTest < ActiveSupport::TestCase
     assert_equal 3.days.from_now.beginning_of_day, subscription.reload.ends_at
   end
 
+
+  test "subscription is updated with ended_at set" do
+    build_user
+
+    subscription = @user.subscriptions.create!(processor: :stripe, processor_id: @event.data.object.id, name: "default", processor_plan: "some-plan", status: "active")
+    sub_end = 3.days.ago.beginning_of_day
+    ::Stripe::Subscription.stubs(:retrieve).returns fake_stripe_subscription(cancel_at_period_end: false, ended_at: sub_end, cancel_at: nil)
+
+    Pay::Stripe::Webhooks::SubscriptionUpdated.new.call(@event)
+    assert_equal sub_end, subscription.reload.ends_at
+  end
+
+  test "subscription is updated with cancel_at set" do
+    build_user
+
+    subscription = @user.subscriptions.create!(processor: :stripe, processor_id: @event.data.object.id, name: "default", processor_plan: "some-plan", status: "active")
+    sub_cancel = 3.days.ago.beginning_of_day
+    ::Stripe::Subscription.stubs(:retrieve).returns fake_stripe_subscription(ended_at: nil, cancel_at: sub_cancel)
+
+    Pay::Stripe::Webhooks::SubscriptionUpdated.new.call(@event)
+    assert_equal sub_cancel, subscription.reload.ends_at
+  end
+
+  test "subscription was canceled, now renewed" do
+    build_user
+
+    subscription = @user.subscriptions.create!(processor: :stripe, processor_id: @event.data.object.id, name: "default", processor_plan: "some-plan", status: "active", ends_at: Time.now)
+    ::Stripe::Subscription.stubs(:retrieve).returns fake_stripe_subscription(cancel_at_period_end: false, ended_at: nil, cancel_at: nil)
+
+    Pay::Stripe::Webhooks::SubscriptionUpdated.new.call(@event)
+    assert_equal nil, subscription.reload.ends_at
+  end
+
   def fake_stripe_subscription(**values)
     values.reverse_merge!(@event.data.object.to_hash)
     ::Stripe::Subscription.construct_from(values)
+  end
+
+  def build_user
+    @user = User.create!(email: "gob@bluth.com", processor: :stripe, processor_id: @event.data.object.customer)
   end
 end


### PR DESCRIPTION
pulling in v2.7.1 to my code.  There's a problem with processing stripe subscriptions that are Renewed after a user cancels them -- because of the way the sync logic worked we weren't properly bringing them "back from the dead".

There's a lot of different fields in the slack api around subscriptions ending/cancelling/etc -- I'm not sure I understand them all, so I hope I'm getting this right.  I'm honestly coding just a little blind. 

It also feels as though we could *probably* just trust the `cancel_at` field in the slack api (without bothering with `cancel_at_period_end` etc) but again I'm not super-familiar with the intimates of the api.