### PR TITLE
Extract stripe options hash and compact to remove nils

### DIFF
--- a/lib/pay/stripe/charge.rb
+++ b/lib/pay/stripe/charge.rb
@@ -25,7 +25,7 @@ module Pay
 
         # Associate charge with subscription if we can
         if object.invoice
-          invoice = (object.invoice.is_a?(::Stripe::Invoice) ? object.invoice : ::Stripe::Invoice.retrieve(object.invoice, stripe_options))
+          invoice = (object.invoice.is_a?(::Stripe::Invoice) ? object.invoice : ::Stripe::Invoice.retrieve(object.invoice))
           attrs[:subscription] = Pay::Subscription.find_by(processor: :stripe, processor_id: invoice.subscription)
         end
 

--- a/lib/pay/stripe/subscription.rb
+++ b/lib/pay/stripe/subscription.rb
@@ -22,7 +22,7 @@ module Pay
 
       def self.sync(subscription_id, object: nil, name: Pay.default_product_name)
         # Skip loading the latest subscription details from the API if we already have it
-        object ||= ::Stripe::Subscription.retrieve({id: subscription_id, expand: ["pending_setup_intent", "latest_invoice.payment_intent"]}, stripe_options)
+        object ||= ::Stripe::Subscription.retrieve({id: subscription_id, expand: ["pending_setup_intent", "latest_invoice.payment_intent"]})
 
         owner = Pay.find_billable(processor: :stripe, processor_id: object.customer)
         return unless owner

--- a/test/pay/billable_test.rb
+++ b/test/pay/billable_test.rb
@@ -146,7 +146,7 @@ class Pay::Billable::Test < ActiveSupport::TestCase
 
   test "getting a stripe subscription" do
     @billable.processor = "stripe"
-    ::Stripe::Subscription.expects(:retrieve).with({id: "123"}, {stripe_account: nil}).returns(:subscription)
+    ::Stripe::Subscription.expects(:retrieve).with({id: "123"}, {}).returns(:subscription)
     assert_equal :subscription, @billable.processor_subscription("123")
   end
 


### PR DESCRIPTION
This removes warning of nil header from net/http and fixes a couple references that didn't include the stripe account.