### PR TITLE
raises ArgumentError when the argument passed to swap method is not a String…

### DIFF
--- a/lib/pay/braintree/subscription.rb
+++ b/lib/pay/braintree/subscription.rb
@@ -92,6 +92,8 @@ module Pay
       end
 
       def swap(plan)
+        raise ArgumentError, 'plan must be a string' unless plan.is_a?(String)
+
         if on_grace_period? && processor_plan == plan
           resume
           return

--- a/lib/pay/braintree/subscription.rb
+++ b/lib/pay/braintree/subscription.rb
@@ -92,7 +92,7 @@ module Pay
       end
 
       def swap(plan)
-        raise ArgumentError, 'plan must be a string' unless plan.is_a?(String)
+        raise ArgumentError, "plan must be a string" unless plan.is_a?(String)
 
         if on_grace_period? && processor_plan == plan
           resume

--- a/lib/pay/fake_processor/subscription.rb
+++ b/lib/pay/fake_processor/subscription.rb
@@ -52,6 +52,8 @@ module Pay
       end
 
       def swap(plan)
+        raise ArgumentError, 'plan must be a string' unless plan.is_a?(String)
+
         pay_subscription.update(processor_plan: plan)
       end
     end

--- a/lib/pay/fake_processor/subscription.rb
+++ b/lib/pay/fake_processor/subscription.rb
@@ -52,7 +52,7 @@ module Pay
       end
 
       def swap(plan)
-        raise ArgumentError, 'plan must be a string' unless plan.is_a?(String)
+        raise ArgumentError, "plan must be a string" unless plan.is_a?(String)
 
         pay_subscription.update(processor_plan: plan)
       end

--- a/lib/pay/paddle/subscription.rb
+++ b/lib/pay/paddle/subscription.rb
@@ -79,7 +79,7 @@ module Pay
       end
 
       def swap(plan)
-        raise ArgumentError, 'plan must be a string' unless plan.is_a?(String)
+        raise ArgumentError, "plan must be a string" unless plan.is_a?(String)
 
         attributes = {plan_id: plan, prorate: prorate}
         attributes[:quantity] = quantity if quantity?

--- a/lib/pay/paddle/subscription.rb
+++ b/lib/pay/paddle/subscription.rb
@@ -79,6 +79,8 @@ module Pay
       end
 
       def swap(plan)
+        raise ArgumentError, 'plan must be a string' unless plan.is_a?(String)
+
         attributes = {plan_id: plan, prorate: prorate}
         attributes[:quantity] = quantity if quantity?
         PaddlePay::Subscription::User.update(processor_id, attributes)

--- a/lib/pay/stripe/subscription.rb
+++ b/lib/pay/stripe/subscription.rb
@@ -22,7 +22,7 @@ module Pay
 
       def self.sync(subscription_id, object: nil, name: Pay.default_product_name)
         # Skip loading the latest subscription details from the API if we already have it
-        object ||= ::Stripe::Subscription.retrieve({id: subscription_id, expand: ['pending_setup_intent', 'latest_invoice.payment_intent']})
+        object ||= ::Stripe::Subscription.retrieve({id: subscription_id, expand: ["pending_setup_intent", "latest_invoice.payment_intent"]})
 
         owner = Pay.find_billable(processor: :stripe, processor_id: object.customer)
         return unless owner
@@ -91,19 +91,19 @@ module Pay
       end
 
       def pause
-        raise NotImplementedError, 'Stripe does not support pausing subscriptions'
+        raise NotImplementedError, "Stripe does not support pausing subscriptions"
       end
 
       def resume
         unless on_grace_period?
-          raise StandardError, 'You can only resume subscriptions within their grace period.'
+          raise StandardError, "You can only resume subscriptions within their grace period."
         end
 
         ::Stripe::Subscription.update(
           processor_id,
           {
             plan: processor_plan,
-            trial_end: (on_trial? ? trial_ends_at.to_i : 'now'),
+            trial_end: (on_trial? ? trial_ends_at.to_i : "now"),
             cancel_at_period_end: false
           },
           stripe_options
@@ -113,15 +113,15 @@ module Pay
       end
 
       def swap(plan)
-        raise ArgumentError, 'plan must be a string' unless plan.is_a?(String)
+        raise ArgumentError, "plan must be a string" unless plan.is_a?(String)
 
         ::Stripe::Subscription.update(
           processor_id,
           {
             cancel_at_period_end: false,
             plan: plan,
-            proration_behavior: (prorate ? 'create_prorations' : 'none'),
-            trial_end: (on_trial? ? trial_ends_at.to_i : 'now'),
+            proration_behavior: (prorate ? "create_prorations" : "none"),
+            trial_end: (on_trial? ? trial_ends_at.to_i : "now"),
             quantity: quantity
           },
           stripe_options

--- a/lib/pay/stripe/subscription.rb
+++ b/lib/pay/stripe/subscription.rb
@@ -22,7 +22,7 @@ module Pay
 
       def self.sync(subscription_id, object: nil, name: Pay.default_product_name)
         # Skip loading the latest subscription details from the API if we already have it
-        object ||= ::Stripe::Subscription.retrieve({id: subscription_id, expand: ["pending_setup_intent", "latest_invoice.payment_intent"]})
+        object ||= ::Stripe::Subscription.retrieve({id: subscription_id, expand: ['pending_setup_intent', 'latest_invoice.payment_intent']})
 
         owner = Pay.find_billable(processor: :stripe, processor_id: object.customer)
         return unless owner
@@ -91,19 +91,19 @@ module Pay
       end
 
       def pause
-        raise NotImplementedError, "Stripe does not support pausing subscriptions"
+        raise NotImplementedError, 'Stripe does not support pausing subscriptions'
       end
 
       def resume
         unless on_grace_period?
-          raise StandardError, "You can only resume subscriptions within their grace period."
+          raise StandardError, 'You can only resume subscriptions within their grace period.'
         end
 
         ::Stripe::Subscription.update(
           processor_id,
           {
             plan: processor_plan,
-            trial_end: (on_trial? ? trial_ends_at.to_i : "now"),
+            trial_end: (on_trial? ? trial_ends_at.to_i : 'now'),
             cancel_at_period_end: false
           },
           stripe_options
@@ -113,13 +113,15 @@ module Pay
       end
 
       def swap(plan)
+        raise ArgumentError, 'plan must be a string' unless plan.is_a?(String)
+
         ::Stripe::Subscription.update(
           processor_id,
           {
             cancel_at_period_end: false,
             plan: plan,
-            proration_behavior: (prorate ? "create_prorations" : "none"),
-            trial_end: (on_trial? ? trial_ends_at.to_i : "now"),
+            proration_behavior: (prorate ? 'create_prorations' : 'none'),
+            trial_end: (on_trial? ? trial_ends_at.to_i : 'now'),
             quantity: quantity
           },
           stripe_options

--- a/test/pay/stripe/subscription_test.rb
+++ b/test/pay/stripe/subscription_test.rb
@@ -48,11 +48,13 @@ class Pay::Stripe::SubscriptionTest < ActiveSupport::TestCase
   end
 
   test "it will throw an error if the passed argument is not a string" do
-    @user.processor_id = nil
+    @user.processor = stripe
     @user.card_token = "pm_card_visa"
+    @user.subscribe
 
-    plan_hash = {}
-    assert_raise(Pay::Stripe::Error) { @user.subscribe(name: "default", plan: plan_hash) }
+    assert_raises Pay::Stripe::Error do
+      @user.swap({invalid: :object})
+    end
   end
 
   private

--- a/test/pay/stripe/subscription_test.rb
+++ b/test/pay/stripe/subscription_test.rb
@@ -48,7 +48,7 @@ class Pay::Stripe::SubscriptionTest < ActiveSupport::TestCase
   end
 
   test "it will throw an error if the passed argument is not a string" do
-    @user.processor = stripe
+    @user.processor = :stripe
     @user.card_token = "pm_card_visa"
     @user.subscribe
 

--- a/test/pay/stripe/subscription_test.rb
+++ b/test/pay/stripe/subscription_test.rb
@@ -52,7 +52,7 @@ class Pay::Stripe::SubscriptionTest < ActiveSupport::TestCase
     @user.card_token = "pm_card_visa"
 
     plan_hash = {}
-    assert_raise(ArgumentError) { @user.subscribe(name: "default", plan: plan_hash) }
+    assert_raise(Pay::Stripe::Error) { @user.subscribe(name: "default", plan: plan_hash) }
   end
 
   private

--- a/test/pay/stripe/subscription_test.rb
+++ b/test/pay/stripe/subscription_test.rb
@@ -47,6 +47,14 @@ class Pay::Stripe::SubscriptionTest < ActiveSupport::TestCase
     assert_not_nil pay_subscription.ends_at
   end
 
+  test "it will throw an error if the passed argument is not a string" do
+    @user.processor_id = nil
+    @user.card_token = "pm_card_visa"
+
+    plan_hash = {}
+    assert_raise(ArgumentError) { @user.subscribe(name: "default", plan: plan_hash) }
+  end
+
   private
 
   def fake_stripe_subscription(**values)


### PR DESCRIPTION
According to https://github.com/pay-rails/pay/issues/174#issue-644277572. sometimes users mistake the argument for `swap` to be an instance of an Object. But, `swap` only accepts a string that corresponds to the Plan/Price etc.

And according to https://github.com/pay-rails/pay/issues/174#issuecomment-650606862 this is a desired behaviour.

This PR makes all `swap` methods(including fake_processor) to raise an exception when the argument passed to them is not an instance of `String`