### PR TITLE
Don't validate SetupIntent for trialing subscription

### DIFF
--- a/lib/pay/payment.rb
+++ b/lib/pay/payment.rb
@@ -42,7 +42,6 @@ module Pay
     end
 
     def validate
-      binding.pry
       if requires_payment_method?
         raise Pay::InvalidPaymentMethod.new(self)
       elsif requires_action?

--- a/lib/pay/payment.rb
+++ b/lib/pay/payment.rb
@@ -42,6 +42,7 @@ module Pay
     end
 
     def validate
+      binding.pry
       if requires_payment_method?
         raise Pay::InvalidPaymentMethod.new(self)
       elsif requires_action?

--- a/lib/pay/stripe/billable.rb
+++ b/lib/pay/stripe/billable.rb
@@ -97,10 +97,6 @@ module Pay
         # No trial, card requires SCA
         if subscription.incomplete?
           Pay::Payment.new(stripe_sub.latest_invoice.payment_intent).validate
-
-        # Card requires SCA
-        elsif !subscription.on_trial? && stripe_sub.pending_setup_intent
-          Pay::Payment.new(stripe_sub.pending_setup_intent).validate
         end
 
         subscription

--- a/lib/pay/stripe/billable.rb
+++ b/lib/pay/stripe/billable.rb
@@ -95,7 +95,6 @@ module Pay
         subscription = Pay::Stripe::Subscription.sync(stripe_sub.id, object: stripe_sub, name: name)
 
         # No trial, card requires SCA
-        binding.pry
         if subscription.incomplete?
           Pay::Payment.new(stripe_sub.latest_invoice.payment_intent).validate
 

--- a/lib/pay/stripe/billable.rb
+++ b/lib/pay/stripe/billable.rb
@@ -95,6 +95,7 @@ module Pay
         subscription = Pay::Stripe::Subscription.sync(stripe_sub.id, object: stripe_sub, name: name)
 
         # No trial, card requires SCA
+        binding.pry
         if subscription.incomplete?
           Pay::Payment.new(stripe_sub.latest_invoice.payment_intent).validate
 

--- a/lib/pay/stripe/billable.rb
+++ b/lib/pay/stripe/billable.rb
@@ -98,8 +98,8 @@ module Pay
         if subscription.incomplete?
           Pay::Payment.new(stripe_sub.latest_invoice.payment_intent).validate
 
-        # Trial, card requires SCA
-        elsif subscription.on_trial? && stripe_sub.pending_setup_intent
+        # Card requires SCA
+        elsif !subscription.on_trial? && stripe_sub.pending_setup_intent
           Pay::Payment.new(stripe_sub.pending_setup_intent).validate
         end
 


### PR DESCRIPTION
Trialing subscriptions don't require a PaymentMethod, so validating the associated SetupIntent is unnecessary.