### PR TITLE
Cancel active subscriptions when Owner is deleted

### DIFF
--- a/app/models/pay/subscription.rb
+++ b/app/models/pay/subscription.rb
@@ -15,6 +15,9 @@ module Pay
     scope :incomplete, -> { where(status: :incomplete) }
     scope :past_due, -> { where(status: :past_due) }
 
+    # Callbacks
+    before_destroy :cancel_now!, if: :active?
+
     # TODO: Include these with a module
     store_accessor :data, :paddle_update_url
     store_accessor :data, :paddle_cancel_url

--- a/lib/pay/attributes.rb
+++ b/lib/pay/attributes.rb
@@ -12,6 +12,8 @@ module Pay
         has_many :charges, through: :pay_customers, class_name: "Pay::Charge", dependent: :destroy
         has_many :subscriptions, through: :pay_customers, class_name: "Pay::Subscription", dependent: :destroy
         has_one :payment_processor, -> { where(default: true) }, class_name: "Pay::Customer", as: :owner, inverse_of: :owner
+
+        after_commit :cancel_active_subscriptions!, on: :destroy
       end
 
       # Changes a user's payment processor
@@ -54,5 +56,12 @@ module Pay
         end
       end
     end
+
+    private
+
+    def cancel_active_subscriptions!
+      byebug
+    end
+
   end
 end

--- a/lib/pay/attributes.rb
+++ b/lib/pay/attributes.rb
@@ -12,8 +12,6 @@ module Pay
         has_many :charges, through: :pay_customers, class_name: "Pay::Charge"
         has_many :subscriptions, through: :pay_customers, class_name: "Pay::Subscription"
         has_one :payment_processor, -> { where(default: true) }, class_name: "Pay::Customer", as: :owner, inverse_of: :owner
-
-        before_destroy :cancel_active_subscriptions!
       end
 
       # Changes a user's payment processor
@@ -55,12 +53,6 @@ module Pay
           end
         end
       end
-    end
-
-    private
-
-    def cancel_active_subscriptions!
-      byebug
     end
 
   end

--- a/lib/pay/attributes.rb
+++ b/lib/pay/attributes.rb
@@ -9,8 +9,8 @@ module Pay
 
       included do
         has_many :pay_customers, class_name: "Pay::Customer", as: :owner, inverse_of: :owner, dependent: :destroy
-        has_many :charges, through: :pay_customers, class_name: "Pay::Charge", dependent: :destroy
-        has_many :subscriptions, through: :pay_customers, class_name: "Pay::Subscription", dependent: :destroy
+        has_many :charges, through: :pay_customers, class_name: "Pay::Charge"
+        has_many :subscriptions, through: :pay_customers, class_name: "Pay::Subscription"
         has_one :payment_processor, -> { where(default: true) }, class_name: "Pay::Customer", as: :owner, inverse_of: :owner
 
         before_destroy :cancel_active_subscriptions!

--- a/lib/pay/attributes.rb
+++ b/lib/pay/attributes.rb
@@ -13,7 +13,7 @@ module Pay
         has_many :subscriptions, through: :pay_customers, class_name: "Pay::Subscription", dependent: :destroy
         has_one :payment_processor, -> { where(default: true) }, class_name: "Pay::Customer", as: :owner, inverse_of: :owner
 
-        after_commit :cancel_active_subscriptions!, on: :destroy
+        before_destroy :cancel_active_subscriptions!
       end
 
       # Changes a user's payment processor

--- a/lib/pay/attributes.rb
+++ b/lib/pay/attributes.rb
@@ -8,9 +8,9 @@ module Pay
       extend ActiveSupport::Concern
 
       included do
-        has_many :pay_customers, class_name: "Pay::Customer", as: :owner, inverse_of: :owner
-        has_many :charges, through: :pay_customers, class_name: "Pay::Charge"
-        has_many :subscriptions, through: :pay_customers, class_name: "Pay::Subscription"
+        has_many :pay_customers, class_name: "Pay::Customer", as: :owner, inverse_of: :owner, dependent: :destroy
+        has_many :charges, through: :pay_customers, class_name: "Pay::Charge", dependent: :destroy
+        has_many :subscriptions, through: :pay_customers, class_name: "Pay::Subscription", dependent: :destroy
         has_one :payment_processor, -> { where(default: true) }, class_name: "Pay::Customer", as: :owner, inverse_of: :owner
       end
 

--- a/lib/pay/attributes.rb
+++ b/lib/pay/attributes.rb
@@ -54,6 +54,5 @@ module Pay
         end
       end
     end
-
   end
 end

--- a/test/models/pay/subscription_test.rb
+++ b/test/models/pay/subscription_test.rb
@@ -236,14 +236,21 @@ class Pay::Subscription::Test < ActiveSupport::TestCase
     fail
   end
   
-  test "should delete associated pay_customer when owner is deleted" do
-    assert_difference("Pay::Customer.count", -1) do
+  test "should delete associated pay_charges when owner is deleted" do
+    # TODO: Need to add a Pay::Charge record in fixtures.
+    assert_difference("Pay::Charge.count", -(@owner.charges.count)) do
       @owner.destroy
     end
   end
 
-  test "should delete associated pay_subscription when owner is deleted" do
-    assert_difference("Pay::Subscription.count", -1) do
+  test "should delete associated pay_customers when owner is deleted" do
+    assert_difference("Pay::Customer.count", -(@owner.pay_customers.count)) do
+      @owner.destroy
+    end
+  end
+
+  test "should delete associated pay_subscriptions when owner is deleted" do
+    assert_difference("Pay::Subscription.count", -(@owner.subscriptions.count)) do
       @owner.destroy
     end
   end  

--- a/test/models/pay/subscription_test.rb
+++ b/test/models/pay/subscription_test.rb
@@ -239,7 +239,7 @@ class Pay::Subscription::Test < ActiveSupport::TestCase
   end
 
   test "should delete associated pay_customers when owner is deleted" do
-    assert_difference("Pay::Customer.count", -(@owner.pay_customers.count)) do
+    assert_difference("Pay::Customer.count", -@owner.pay_customers.count) do
       @owner.destroy
     end
   end

--- a/test/models/pay/subscription_test.rb
+++ b/test/models/pay/subscription_test.rb
@@ -230,16 +230,11 @@ class Pay::Subscription::Test < ActiveSupport::TestCase
     assert Pay::Subscription.new(customer: pay_customers(:fake), status: :active, ends_at: 1.day.ago).canceled?
   end
 
-  test "should cancel active subscriptions when owner is deleted" do
-    # TODO: Need to figure out how to test that cancel_now! was called on the Subscription
-    # Maybe we do it via after_commit :cancel_now!, on: [:destroy] ?
-    fail
-  end
-  
-  test "should delete associated pay_charges when owner is deleted" do
-    # TODO: Need to add a Pay::Charge record in fixtures.
-    assert_difference("Pay::Charge.count", -(@owner.charges.count)) do
-      @owner.destroy
+  test "should cancel active subscriptions before being deleted" do
+    assert_equal "active", @subscription.status
+    freeze_time do
+      @subscription.destroy
+      assert_equal "canceled", @subscription.status
     end
   end
 
@@ -248,12 +243,6 @@ class Pay::Subscription::Test < ActiveSupport::TestCase
       @owner.destroy
     end
   end
-
-  test "should delete associated pay_subscriptions when owner is deleted" do
-    assert_difference("Pay::Subscription.count", -(@owner.subscriptions.count)) do
-      @owner.destroy
-    end
-  end  
 
   private
 

--- a/test/models/pay/subscription_test.rb
+++ b/test/models/pay/subscription_test.rb
@@ -230,6 +230,11 @@ class Pay::Subscription::Test < ActiveSupport::TestCase
     assert Pay::Subscription.new(customer: pay_customers(:fake), status: :active, ends_at: 1.day.ago).canceled?
   end
 
+  test "should cancel active subscriptions when owner is deleted" do
+    @owner.destroy
+    assert_equal "canceled", @subscription.status
+  end  
+
   private
 
   def create_subscription(options = {})

--- a/test/models/pay/subscription_test.rb
+++ b/test/models/pay/subscription_test.rb
@@ -231,8 +231,21 @@ class Pay::Subscription::Test < ActiveSupport::TestCase
   end
 
   test "should cancel active subscriptions when owner is deleted" do
-    @owner.destroy
-    assert_equal "canceled", @subscription.status
+    # TODO: Need to figure out how to test that cancel_now! was called on the Subscription
+    # Maybe we do it via after_commit :cancel_now!, on: [:destroy] ?
+    fail
+  end
+  
+  test "should delete associated pay_customer when owner is deleted" do
+    assert_difference("Pay::Customer.count", -1) do
+      @owner.destroy
+    end
+  end
+
+  test "should delete associated pay_subscription when owner is deleted" do
+    assert_difference("Pay::Subscription.count", -1) do
+      @owner.destroy
+    end
   end  
 
   private

--- a/test/pay/stripe/subscription_test.rb
+++ b/test/pay/stripe/subscription_test.rb
@@ -72,11 +72,6 @@ class Pay::Stripe::SubscriptionTest < ActiveSupport::TestCase
     end
   end
 
-  test "should cancel active subscriptions when owner is deleted" do
-    @pay_customer.owner.destroy
-    assert_equal "canceled", @pay_customer.subscription.status
-  end
-
   private
 
   def fake_stripe_subscription(**values)

--- a/test/pay/stripe/subscription_test.rb
+++ b/test/pay/stripe/subscription_test.rb
@@ -72,6 +72,11 @@ class Pay::Stripe::SubscriptionTest < ActiveSupport::TestCase
     end
   end
 
+  test "should cancel active subscriptions when owner is deleted" do
+    @pay_customer.owner.destroy
+    assert_equal "canceled", @pay_customer.subscription.status
+  end
+
   private
 
   def fake_stripe_subscription(**values)


### PR DESCRIPTION
@excid3 before I get too far, I want to make sure I'm going in the right direction. I wrote a failing test as a guide.

**Questions**
- Should I even be concerned about when the `Owner` is deleted, or is it enough to just test when the `Pay::Customer` is deleted?
- Should the test be in the Subscription namespace for each Payment Processor namespace? Or should it be in `Pay::Billable::SyncCustomer::Test`? 