### PR TITLE
Add scopes to Pay::Charge and Pay::Subscription to account for Pay::Customer deleted_at column 

### DIFF
--- a/app/models/pay/charge.rb
+++ b/app/models/pay/charge.rb
@@ -8,6 +8,8 @@ module Pay
 
     # Scopes
     scope :sorted, -> { order(created_at: :desc) }
+    scope :with_active_customer, -> { joins(:customer).merge(Customer.active) }
+    scope :with_deleted_customer, -> { joins(:customer).merge(Customer.deleted) }
     default_scope -> { sorted }
 
     # Validations

--- a/app/models/pay/customer.rb
+++ b/app/models/pay/customer.rb
@@ -66,6 +66,14 @@ class Pay::Customer < Pay::ApplicationRecord
     [owner.try(:first_name), owner.try(:last_name)].compact.join(" ")
   end
 
+  def active?
+    deleted_at.nil?
+  end
+
+  def deleted?
+    deleted_at.present?
+  end
+
   %w[stripe braintree paddle fake_processor].each do |processor_name|
     define_method "#{processor_name}?" do
       processor == processor_name

--- a/app/models/pay/subscription.rb
+++ b/app/models/pay/subscription.rb
@@ -14,6 +14,7 @@ module Pay
     scope :active, -> { where(ends_at: nil).or(on_grace_period).or(on_trial) }
     scope :incomplete, -> { where(status: :incomplete) }
     scope :past_due, -> { where(status: :past_due) }
+    scope :with_deleted_customer, -> { joins(:customer).merge(Customer.deleted) }
 
     # Callbacks
     before_destroy :cancel_now!, if: :active?

--- a/app/models/pay/subscription.rb
+++ b/app/models/pay/subscription.rb
@@ -14,6 +14,7 @@ module Pay
     scope :active, -> { where(ends_at: nil).or(on_grace_period).or(on_trial) }
     scope :incomplete, -> { where(status: :incomplete) }
     scope :past_due, -> { where(status: :past_due) }
+    scope :with_active_customer, -> { joins(:customer).merge(Customer.active) }
     scope :with_deleted_customer, -> { joins(:customer).merge(Customer.deleted) }
 
     # Callbacks

--- a/test/models/pay/charge_test.rb
+++ b/test/models/pay/charge_test.rb
@@ -47,12 +47,11 @@ class Pay::Charge::Test < ActiveSupport::TestCase
   test "with_deleted_customer scope" do
     charge = pay_charges(:stripe)
     customer = charge.customer
-    charges = Pay::Charge.with_deleted_customer
 
-    refute_includes charges, charge
+    refute_includes Pay::Charge.with_deleted_customer, charge
     customer.update(deleted_at: Time.now)
 
-    assert_includes charges, charge
+    assert_includes Pay::Charge.with_deleted_customer, charge
   end
 
   private

--- a/test/models/pay/charge_test.rb
+++ b/test/models/pay/charge_test.rb
@@ -34,4 +34,30 @@ class Pay::Charge::Test < ActiveSupport::TestCase
     charge.update(metadata: metadata)
     assert_equal metadata, charge.metadata
   end
+
+  test "with_active_customer scope" do
+    charge = pay_charges(:stripe)
+    customer = charge.customer
+    charges = Pay::Charge.with_active_customer
+
+    assert_includes charges, charge
+    customer.update(deleted_at: Time.now)
+
+    refute_includes charges, charge
+  end
+  
+  test "with_deleted_customer scope" do
+    charge = pay_charges(:stripe)
+    customer = charge.customer
+    charges = Pay::Charge.with_deleted_customer
+
+    refute_includes charges, charge
+    customer.update(deleted_at: Time.now)
+
+    assert_includes charges, charge
+  end
+
+  private
+
+
 end

--- a/test/models/pay/charge_test.rb
+++ b/test/models/pay/charge_test.rb
@@ -45,7 +45,7 @@ class Pay::Charge::Test < ActiveSupport::TestCase
 
     refute_includes charges, charge
   end
-  
+
   test "with_deleted_customer scope" do
     charge = pay_charges(:stripe)
     customer = charge.customer
@@ -58,6 +58,4 @@ class Pay::Charge::Test < ActiveSupport::TestCase
   end
 
   private
-
-
 end

--- a/test/models/pay/charge_test.rb
+++ b/test/models/pay/charge_test.rb
@@ -38,12 +38,10 @@ class Pay::Charge::Test < ActiveSupport::TestCase
   test "with_active_customer scope" do
     charge = pay_charges(:stripe)
     customer = charge.customer
-    charges = Pay::Charge.with_active_customer
 
-    assert_includes charges, charge
+    refute_includes Pay::Charge.with_deleted_customer, charge
     customer.update(deleted_at: Time.now)
-
-    refute_includes charges, charge
+    assert_includes Pay::Charge.with_deleted_customer, charge
   end
 
   test "with_deleted_customer scope" do

--- a/test/models/pay/customer_test.rb
+++ b/test/models/pay/customer_test.rb
@@ -10,4 +10,12 @@ class Pay::CustomerTest < ActiveSupport::TestCase
   test "deleted customers" do
     assert_includes Pay::Customer.deleted, pay_customers(:deleted)
   end
+
+  test "deleted?" do
+    assert pay_customers(:deleted).deleted?
+  end
+
+  test "active?" do
+    assert pay_customers(:stripe).deleted?
+  end
 end

--- a/test/models/pay/customer_test.rb
+++ b/test/models/pay/customer_test.rb
@@ -18,5 +18,4 @@ class Pay::CustomerTest < ActiveSupport::TestCase
   test "deleted?" do
     assert pay_customers(:deleted).deleted?
   end
-
 end

--- a/test/models/pay/customer_test.rb
+++ b/test/models/pay/customer_test.rb
@@ -11,11 +11,12 @@ class Pay::CustomerTest < ActiveSupport::TestCase
     assert_includes Pay::Customer.deleted, pay_customers(:deleted)
   end
 
+  test "active?" do
+    assert pay_customers(:stripe).active?
+  end
+
   test "deleted?" do
     assert pay_customers(:deleted).deleted?
   end
 
-  test "active?" do
-    assert pay_customers(:stripe).deleted?
-  end
 end

--- a/test/models/pay/subscription_test.rb
+++ b/test/models/pay/subscription_test.rb
@@ -120,24 +120,22 @@ class Pay::Subscription::Test < ActiveSupport::TestCase
 
   test "with_active_customer scope" do
     subscription = create_subscription
-    subscriptions = Pay::Subscription.with_active_customer
 
-    assert_includes subscriptions, subscription
+    assert_includes Pay::Subscription.with_active_customer, subscription
 
     @pay_customer.update!(deleted_at: Time.now)
 
-    refute_includes subscriptions, subscription
+    refute_includes Pay::Subscription.with_active_customer, subscription
   end
 
   test "with_deleted_customer scope" do
     subscription = create_subscription
-    subscriptions = Pay::Subscription.with_deleted_customer
 
-    refute_includes subscriptions, subscription
+    refute_includes Pay::Subscription.with_deleted_customer, subscription
 
     @pay_customer.update!(deleted_at: Time.now)
 
-    assert_includes subscriptions, subscription
+    assert_includes Pay::Subscription.with_deleted_customer, subscription
   end
 
   test "active trial" do

--- a/test/models/pay/subscription_test.rb
+++ b/test/models/pay/subscription_test.rb
@@ -118,6 +118,17 @@ class Pay::Subscription::Test < ActiveSupport::TestCase
     refute_includes subscriptions, subscription5
   end
 
+  test "with_deleted_customer scope" do
+    subscription = create_subscription
+    subscriptions = Pay::Subscription.with_deleted_customer
+
+    refute_includes subscriptions, subscription
+
+    @pay_customer.update!(deleted_at: Time.now)
+
+    assert_includes subscriptions, subscription
+  end
+
   test "active trial" do
     @subscription.trial_ends_at = 5.minutes.from_now
     assert @subscription.on_trial?

--- a/test/models/pay/subscription_test.rb
+++ b/test/models/pay/subscription_test.rb
@@ -118,6 +118,17 @@ class Pay::Subscription::Test < ActiveSupport::TestCase
     refute_includes subscriptions, subscription5
   end
 
+  test "with_active_customer scope" do
+    subscription = create_subscription
+    subscriptions = Pay::Subscription.with_active_customer
+
+    assert_includes subscriptions, subscription
+
+    @pay_customer.update!(deleted_at: Time.now)
+
+    refute_includes subscriptions, subscription
+  end
+
   test "with_deleted_customer scope" do
     subscription = create_subscription
     subscriptions = Pay::Subscription.with_deleted_customer


### PR DESCRIPTION
Now that we're soft deleting `Pay::Customer` records I figured it might be helpful to add some scopes on the `Pay::Charge` and `Pay::Subscription` models. This way one could query for records that are tied to a deleted customer. 

```ruby
Pay::Charge.with_active_customer
# => #<ActiveRecord::Relation []>
Pay::Charge.with_deleted_customer
# => #<ActiveRecord::Relation []>
Pay::Subscription.with_active_customer
# => #<ActiveRecord::Relation []>
Pay::Subscription.with_deleted_customer
# => #<ActiveRecord::Relation []>
```

Also, add helper methods to `Pay::Customer`

```ruby
Pay::Customer.first.active?
# => true
Pay::Customer.first.deleted?
# => false
```