### PR TITLE
Allow UserMailer delivery to be configured.

### DIFF
--- a/lib/pay.rb
+++ b/lib/pay.rb
@@ -48,6 +48,24 @@ module Pay
 
   mattr_accessor :routes_path
   @@routes_path = "/pay"
+  
+  module Emails
+    mattr_accessor :receipt
+    @@receipt = true
+
+    mattr_accessor :refund
+    @@refund = true
+
+    mattr_accessor :subscription_renewing
+    @@subscription_renewing = true
+
+    mattr_accessor :payment_action_required
+    @@payment_action_required = true
+  end
+
+  def self.emails
+    Emails
+  end
 
   def self.setup
     yield self

--- a/lib/pay.rb
+++ b/lib/pay.rb
@@ -48,7 +48,7 @@ module Pay
 
   mattr_accessor :routes_path
   @@routes_path = "/pay"
-  
+
   module Emails
     mattr_accessor :receipt
     @@receipt = true

--- a/lib/pay/stripe/webhooks/subscription_renewing.rb
+++ b/lib/pay/stripe/webhooks/subscription_renewing.rb
@@ -6,6 +6,8 @@ module Pay
         # Occurs X number of days before a subscription is scheduled to create an invoice that is automatically charged—where X is determined by your subscriptions settings. Note: The received Invoice object will not have an invoice ID.
 
         def call(event)
+          return unless Pay.emails.subscription_renewing
+
           # Event is of type "invoice" see:
           # https://stripe.com/docs/api/invoices/object
           subscription = Pay::Subscription.find_by_processor_and_id(:stripe, event.data.object.subscription)

--- a/test/pay/stripe/webhooks/subscription_renewing_test.rb
+++ b/test/pay/stripe/webhooks/subscription_renewing_test.rb
@@ -32,7 +32,7 @@ class Pay::Stripe::Webhooks::SubscriptionRenewingTest < ActiveSupport::TestCase
   end
 
   test "should prevent delivery" do
-    Pay.emails.subscription_renewing=false
+    Pay.emails.subscription_renewing = false
 
     @event.data.object.lines.data.first.price.recurring.interval = "year"
     create_subscription(processor_id: @event.data.object.subscription)

--- a/test/pay/stripe/webhooks/subscription_renewing_test.rb
+++ b/test/pay/stripe/webhooks/subscription_renewing_test.rb
@@ -31,6 +31,17 @@ class Pay::Stripe::Webhooks::SubscriptionRenewingTest < ActiveSupport::TestCase
     end
   end
 
+  test "should prevent delivery" do
+    Pay.emails.subscription_renewing=false
+
+    @event.data.object.lines.data.first.price.recurring.interval = "year"
+    create_subscription(processor_id: @event.data.object.subscription)
+
+    assert_no_enqueued_emails do
+      Pay::Stripe::Webhooks::SubscriptionRenewing.new.call(@event)
+    end
+  end
+
   private
 
   def create_subscription(processor_id:)

--- a/test/pay/stripe/webhooks/subscription_renewing_test.rb
+++ b/test/pay/stripe/webhooks/subscription_renewing_test.rb
@@ -8,7 +8,7 @@ class Pay::Stripe::Webhooks::SubscriptionRenewingTest < ActiveSupport::TestCase
   end
 
   teardown do
-    Pay.emails.subscription_renewing= true
+    Pay.emails.subscription_renewing = true
   end
 
   test "yearly subscription should receive renewal email" do
@@ -36,7 +36,7 @@ class Pay::Stripe::Webhooks::SubscriptionRenewingTest < ActiveSupport::TestCase
   end
 
   test "should prevent delivery" do
-    Pay.emails.subscription_renewing= false
+    Pay.emails.subscription_renewing = false
 
     @event.data.object.lines.data.first.price.recurring.interval = "year"
     create_subscription(processor_id: @event.data.object.subscription)

--- a/test/pay/stripe/webhooks/subscription_renewing_test.rb
+++ b/test/pay/stripe/webhooks/subscription_renewing_test.rb
@@ -7,6 +7,10 @@ class Pay::Stripe::Webhooks::SubscriptionRenewingTest < ActiveSupport::TestCase
     @pay_customer.update(processor_id: @event.data.object.customer)
   end
 
+  teardown do
+    Pay.emails.subscription_renewing= true
+  end
+
   test "yearly subscription should receive renewal email" do
     @event.data.object.lines.data.first.price.recurring.interval = "year"
 
@@ -32,7 +36,7 @@ class Pay::Stripe::Webhooks::SubscriptionRenewingTest < ActiveSupport::TestCase
   end
 
   test "should prevent delivery" do
-    Pay.emails.subscription_renewing = false
+    Pay.emails.subscription_renewing= false
 
     @event.data.object.lines.data.first.price.recurring.interval = "year"
     create_subscription(processor_id: @event.data.object.subscription)

--- a/test/pay_test.rb
+++ b/test/pay_test.rb
@@ -64,6 +64,6 @@ class Pay::Test < ActiveSupport::TestCase
   private
 
   def mailer_actions
-    %i(receipt refund subscription_renewing payment_action_required)
+    %i[receipt refund subscription_renewing payment_action_required]
   end
 end

--- a/test/pay_test.rb
+++ b/test/pay_test.rb
@@ -49,17 +49,21 @@ class Pay::Test < ActiveSupport::TestCase
   end
 
   test "can set email deliverability per mailer action" do
-    MAILER_ACTIONS = %i(receipt refund subscription_renewing payment_action_required)
-    MAILER_ACTIONS.each do |mailer_action|
+    mailer_actions.each do |mailer_action|
       assert Pay.emails.respond_to?(:"#{mailer_action}")
       assert Pay.emails.respond_to?(:"#{mailer_action}=")
     end
   end
 
   test "default value for mailers is true" do
-    MAILER_ACTIONS = %i(receipt refund subscription_renewing payment_action_required)
-    MAILER_ACTIONS.each do |mailer_action|
-      assert Pay.emails.send(:"#{mailer_action}"), true
+    mailer_actions.each do |mailer_action|
+      assert_equal Pay.emails.send(mailer_action), true
     end
+  end
+
+  private
+
+  def mailer_actions
+    %i(receipt refund subscription_renewing payment_action_required)
   end
 end

--- a/test/pay_test.rb
+++ b/test/pay_test.rb
@@ -55,4 +55,11 @@ class Pay::Test < ActiveSupport::TestCase
       assert Pay.emails.respond_to?(:"#{mailer_action}=")
     end
   end
+
+  test "default value for mailers is true" do
+    MAILER_ACTIONS = %i(receipt refund subscription_renewing payment_action_required)
+    MAILER_ACTIONS.each do |mailer_action|
+      assert Pay.emails.send(:"#{mailer_action}"), true
+    end
+  end
 end

--- a/test/pay_test.rb
+++ b/test/pay_test.rb
@@ -42,4 +42,9 @@ class Pay::Test < ActiveSupport::TestCase
     assert Pay.respond_to?(:default_plan_name)
     assert Pay.respond_to?(:default_plan_name=)
   end
+
+  test "can set email deliverability" do
+    assert Pay.respond_to?(:send_emails)
+    assert Pay.respond_to?(:send_emails=)
+  end
 end

--- a/test/pay_test.rb
+++ b/test/pay_test.rb
@@ -47,4 +47,12 @@ class Pay::Test < ActiveSupport::TestCase
     assert Pay.respond_to?(:send_emails)
     assert Pay.respond_to?(:send_emails=)
   end
+
+  test "can set email deliverability per mailer action" do
+    MAILER_ACTIONS = %i(receipt refund subscription_renewing payment_action_required)
+    MAILER_ACTIONS.each do |mailer_action|
+      assert Pay.emails.respond_to?(:"#{mailer_action}")
+      assert Pay.emails.respond_to?(:"#{mailer_action}=")
+    end
+  end
 end


### PR DESCRIPTION
I'm still exploring how to do this, but I'm not entirely sure how to namespace it such that `Pay.emails.some_method` can be called correctly.

The following works, but I doubt it's the Ruby way because the tests are failing intermittently.  

```ruby
module Pay
 ...
  module Emails
    mattr_accessor :receipt
    @@receipt = true

    mattr_accessor :refund
    @@refund = true

    mattr_accessor :subscription_renewing
    @@subscription_renewing = true

    mattr_accessor :payment_action_required
    @@payment_action_required = true
  end

  def self.emails
    Emails
  end
end
```

Once I get that sorted out, we'll need to determine if we even want to allow someone to configure deliverability for the `receipt`, `refund` and `payment_action_required` mailer actions.

---

Closes #234 