### PR TITLE
Correct syntax for setting `payment_processor`

### DIFF
--- a/docs/stripe/1_overview.md
+++ b/docs/stripe/1_overview.md
@@ -28,7 +28,7 @@ Choose the checkout button mode you need and pass any required arguments. Read t
 
 ```ruby
 # Make sure the user's payment processor is Stripe
-current_user.processor = :stripe
+current_user.set_payment_processor :stripe
 
 # One-time payments
 @checkout_session = current_user.payment_processor.checkout(mode: "payment", line_items: "price_1ILVZaKXBGcbgpbZQ26kgXWG")


### PR DESCRIPTION
I _think_ the currently documented syntax is from Pay2, while Pay3 has subtly updated the syntax to no longer be an assignment to `processor`, but instead an argument passed to `set_payment_processor`. Is that right?