### PR TITLE
Use `pay_customer_name` if available

### DIFF
--- a/app/models/pay/customer.rb
+++ b/app/models/pay/customer.rb
@@ -65,6 +65,7 @@ module Pay
     end
 
     def customer_name
+      return owner.pay_customer_name if owner.respond_to?(:pay_customer_name) && owner.pay_customer_name.present?
       owner.respond_to?(:name) ? owner.name : [owner.try(:first_name), owner.try(:last_name)].compact.join(" ")
     end
 

--- a/test/pay/billable_test.rb
+++ b/test/pay/billable_test.rb
@@ -9,6 +9,11 @@ class Pay::Billable::Test < ActiveSupport::TestCase
     assert_equal "Fake User", @user.payment_processor.customer_name
   end
 
+  test "customer with a pay_customer_name" do
+    @user.define_singleton_method(:pay_customer_name) { "Pay Customer Name" }
+    assert_equal "Pay Customer Name", @user.payment_processor.customer_name
+  end
+
   test "has charges" do
     assert_equal Pay::Charge.none, users(:none).charges
   end


### PR DESCRIPTION
In order to allow setting a specific name to be used as the
`pay_customer_name`, check for the existance of `pay_customer_name` on
the `owner` and use that if present. Else, try `name` and then
`first_name` + `last_name` as before.