### PR TITLE
fix 6.1 rails reference in 2.x

### DIFF
--- a/db/migrate/20210714175351_add_uniqueness_to_pay_models.rb
+++ b/db/migrate/20210714175351_add_uniqueness_to_pay_models.rb
@@ -1,4 +1,4 @@
-class AddUniquenessToPayModels < ActiveRecord::Migration[6.1]
+class AddUniquenessToPayModels < ActiveRecord::Migration[4.2]
   def change
     add_index :pay_charges, [:processor, :processor_id], unique: true
     add_index :pay_subscriptions, [:processor, :processor_id], unique: true


### PR DESCRIPTION
```
rake aborted!
ArgumentError: Unknown migration version "6.1"; expected one of "4.2", "5.0", "5.1", "5.2"
```

Fix Rails 6.1 reference in 2.x when using in <6 Rails app