### PR TITLE
Updates webhook routes declaration

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@
 
 Pay::Engine.routes.draw do
   resources :payments, only: [:show], module: :pay
-  post "webhooks/stripe", to: "pay/webhooks/stripe#create"
-  post "webhooks/braintree", to: "pay/webhooks/braintree#create"
-  post "webhooks/paddle", to: "pay/webhooks/paddle#create"
+  post "webhooks/stripe", to: "pay/webhooks/stripe#create" if defined? ::Stripe
+  post "webhooks/braintree", to: "pay/webhooks/braintree#create" if defined? ::Braintree
+  post "webhooks/paddle", to: "pay/webhooks/paddle#create" if defined? ::PaddlePay
 end


### PR DESCRIPTION
This commit only declare payment processor webhook route for installed ones, preventing from having unused webhook routes.