### PR TITLE
Update UPGRADE.md (migration update)

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -185,6 +185,10 @@ class UpgradeToPayVersion3 < ActiveRecord::Migration[6.0]
     add_column :pay_charges, :owner_type, :string
     add_column :pay_charges, :owner_id, :integer
     add_column :pay_charges, :processor, :string
+    add_column :pay_charges, :card_type, :string
+    add_column :pay_charges, :card_last4, :string
+    add_column :pay_charges, :card_exp_month, :string
+    add_column :pay_charges, :card_exp_year, :string
     add_column :pay_subscriptions, :owner_type, :string
     add_column :pay_subscriptions, :owner_id, :integer
     add_column :pay_subscriptions, :processor, :string


### PR DESCRIPTION
Added 4 add_column in the self.down of the migration UpgradeToPayVersion3

Without them, the rollback is not complete and would block migrating again as those 4 columns have a remove_column in the migration.