### PR TITLE
Remove binding.irb statement in dummy app

### DIFF
--- a/test/dummy/app/controllers/stripe/charges_controller.rb
+++ b/test/dummy/app/controllers/stripe/charges_controller.rb
@@ -15,7 +15,6 @@ module Stripe
     def create
       current_user.set_payment_processor params[:processor]
       current_user.payment_processor.payment_method_token = params[:card_token]
-      binding.irb
       charge = current_user.payment_processor.charge(params[:amount])
       redirect_to stripe_charge_path(charge)
     rescue Pay::ActionRequired => e


### PR DESCRIPTION
Something I noticed when looking through the dummy app. I haven't actually used `binding.irb` before, but my impression is that it's a debugging statement similar to pry's `binding.pry` so I assume it just got left in by accident. 