### PR TITLE
Update 7_webhooks.md

### DIFF
--- a/docs/7_webhooks.md
+++ b/docs/7_webhooks.md
@@ -6,7 +6,7 @@ Routes are automatically mounted to `/pay` by default.
 
 We provide a route for confirming Stripe SCA payments at `/pay/payments/:payment_intent_id`
 
-See [Stripe SCA docs](docs/stripe/4_sca.md)
+See [Stripe SCA docs](stripe/4_sca.md)
 
 ## Webhooks
 


### PR DESCRIPTION
Should be the right link without `docs/` prefix, because when I click it from https://github.com/pay-rails/pay/blob/master/docs/7_webhooks.md - I'm getting 404.