### PR TITLE
Enable automatic payment methods for Stripe Checkout

### DIFF
--- a/docs/stripe/1_overview.md
+++ b/docs/stripe/1_overview.md
@@ -40,7 +40,6 @@ class SubscriptionsController < ApplicationController
     # Or Subscriptions (https://stripe.com/docs/billing/subscriptions/build-subscription)
     @checkout_session = current_user.payment_processor.checkout(
       mode: 'subscription',
-      payment_method_types: ['card'],
       locale: I18n.locale,
       line_items: [{
         price: 'price_1ILVZaKXBGcbgpbZQ26kgXWG',
@@ -82,7 +81,7 @@ First, create a session in your controller:
 class SubscriptionsController < ApplicationController
   def index
     @portal_session = current_user.payment_processor.billing_portal
-    # 
+    #
   end
 end
 ```

--- a/lib/pay/stripe/billable.rb
+++ b/lib/pay/stripe/billable.rb
@@ -184,7 +184,6 @@ module Pay
         customer unless processor_id?
         args = {
           customer: processor_id,
-          payment_method_types: ["card"],
           mode: "payment",
           # These placeholder URLs will be replaced in a following step.
           success_url: merge_session_id_param(options.delete(:success_url) || root_url),


### PR DESCRIPTION
Removes hard coded `payment_method_types` to enable automatic payment methods to be surfaced in Checkout based on the Stripe Dashboard configuration. 

`payment_method_types` can still be passed in, but this will increase conversion by default by accepting more payment methods.

Helps address #376 