### PR TITLE
Allow syncing customers by overriding `pay_should_sync_customer?`

### DIFF
--- a/lib/pay/billable/sync_customer.rb
+++ b/lib/pay/billable/sync_customer.rb
@@ -8,7 +8,7 @@ module Pay
       extend ActiveSupport::Concern
 
       included do
-        after_update :enqeue_sync_email_job, if: :pay_should_sync_customer?
+        after_update :enqeue_customer_sync_job, if: :pay_should_sync_customer?
       end
 
       def pay_should_sync_customer?
@@ -17,8 +17,8 @@ module Pay
 
       private
 
-      def enqeue_sync_email_job
-        if saved_change_to_email?
+      def enqeue_customer_sync_job
+        if pay_should_sync_customer?
           # Queue job to update each payment processor for this customer
           pay_customers.pluck(:id).each do |pay_customer_id|
             CustomerSyncJob.perform_later(pay_customer_id)

--- a/test/pay/billable/sync_customer_test.rb
+++ b/test/pay/billable/sync_customer_test.rb
@@ -3,13 +3,28 @@ require "test_helper"
 class Pay::Billable::SyncCustomer::Test < ActiveSupport::TestCase
   include ActiveJob::TestHelper
 
-  test "email sync only on updating customer email" do
+  test "customer sync only on updating customer email" do
     assert_no_enqueued_jobs do
       User.create(email: "test@example.com")
     end
 
     assert_enqueued_with(job: Pay::CustomerSyncJob, args: [users(:stripe).payment_processor.id]) do
       users(:stripe).update(email: "test@test.com")
+    end
+  end
+
+  test "customer sync on updating with pay_should_sync_customer? overriden" do
+    assert_no_enqueued_jobs do
+      User.create(email: "test@example.com")
+    end
+
+    assert_enqueued_with(job: Pay::CustomerSyncJob, args: [users(:stripe).payment_processor.id]) do
+      user = users(:stripe)
+      def user.pay_should_sync_customer?
+        true
+      end
+
+      users(:stripe).update(first_name: "whatever")
     end
   end
 


### PR DESCRIPTION
Before this change it was possible to trigger the `enqeue_sync_email_job` method by changing the
`pay_should_sync_customer?` but the method would be a no-op unless the email changed.

This pull request makes it possible for someone to override _when_ the customer would be synced by overriding the `pay_should_sync_customer?` method.

The idea behind this is that the customer's `name` will also be synced to Stripe when they change it in our app. We would achieve this by adding this to `models/user.rb`:

```ruby
def pay_should_sync_customer?
  saved_change_to_email? || saved_change_to_name?
end
```
