### PR TITLE
Update Paddle docs to add public key encoding

### DIFF
--- a/docs/paddle/1_overview.md
+++ b/docs/paddle/1_overview.md
@@ -19,3 +19,21 @@ The [Paddle Sandbox](https://developer.paddle.com/getting-started/sandbox) can b
   Paddle.Setup({ vendor: <%= Pay::Paddle.vendor_id %> });
 </script>
 ```
+
+## Paddle Public Key
+
+Paddle uses public/private keys for webhook verification. You can find
+your public key [here for Production](https://vendors.paddle.com/public-key)
+and [here for Sandbox](https://sandbox-vendors.paddle.com/public-key).
+
+Pay uses a Base64 encoded version of this public key. To generate one, download
+the public key from the link above and save it in the root of your Rails app as `paddle.pem`, then open a `rails console`
+
+```ruby
+paddle_public_key = OpenSSL::PKey::RSA.new(File.read("paddle.pem"))
+Base64.encode64(paddle_public_key.to_der)
+```
+
+Copy what's displayed and then insert that into an environment variable or your secrets file. The `paddle.pem` file can then be deleted.
+
+If you get an error such as `OpenSSL::PKey::RSAError (Neither PUB key nor PRIV key: nested asn1 error)` when you may have a space at the start of the public key.


### PR DESCRIPTION
I'm currently in the process of setting up an application with Pay & Paddle and I found that there was missing documentation for the Public Key so I've added it in this PR