### PR TITLE
Include metadata when creating customer in Stripe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ### Unreleased
 
+* `pay_customer` now supports a metadata option to save on Stripe::Customers - @excid3
+
 # 3.0.24
 
 * Make payment method and charges consistent for Fake procsesor - @excid3

--- a/docs/1_installation.md
+++ b/docs/1_installation.md
@@ -76,6 +76,24 @@ To sync customer names automatically to your payment processor, your model shoul
 * `first_name` _and_ `last_name`
 * `pay_customer_name`
 
+### Metadata
+
+Stripe allows you to send over a hash of metadata to store in the Customer record.
+
+```ruby
+class User < ApplicationRecord
+  pay_customer metadata: :stripe_metadata
+  # pay_customer metadata: ->(pay_customer) { { user_id: pay_customer.owner_id } }
+
+  def stripe_metadata(pay_customer)
+    {
+      user_id: id # or pay_customer.owner_id
+    }
+  end
+```
+
+Pay will include metadata when creating a Customer and update it when the customer's email is updated.
+
 ## Next
 
 See [Configuration](2_configuration.md)

--- a/docs/1_installation.md
+++ b/docs/1_installation.md
@@ -87,6 +87,7 @@ class User < ApplicationRecord
 
   def stripe_metadata(pay_customer)
     {
+      pay_customer_id: pay_customer.id,
       user_id: id # or pay_customer.owner_id
     }
   end

--- a/lib/pay/attributes.rb
+++ b/lib/pay/attributes.rb
@@ -63,14 +63,14 @@ module Pay
     end
 
     class_methods do
-      def pay_customer(options={})
+      def pay_customer(options = {})
         include Billable::SyncCustomer
         include CustomerExtension
 
         self.pay_customer_metadata = options[:metadata]
       end
 
-      def pay_merchant(options={})
+      def pay_merchant(options = {})
         include MerchantExtension
       end
     end

--- a/lib/pay/attributes.rb
+++ b/lib/pay/attributes.rb
@@ -8,6 +8,8 @@ module Pay
       extend ActiveSupport::Concern
 
       included do
+        cattr_accessor :pay_customer_metadata
+
         has_many :pay_customers, class_name: "Pay::Customer", as: :owner, inverse_of: :owner
         has_many :charges, through: :pay_customers, class_name: "Pay::Charge"
         has_many :subscriptions, through: :pay_customers, class_name: "Pay::Subscription"
@@ -61,12 +63,14 @@ module Pay
     end
 
     class_methods do
-      def pay_customer
+      def pay_customer(options={})
         include Billable::SyncCustomer
         include CustomerExtension
+
+        self.pay_customer_metadata = options[:metadata]
       end
 
-      def pay_merchant
+      def pay_merchant(options={})
         include MerchantExtension
       end
     end

--- a/lib/pay/stripe/billable.rb
+++ b/lib/pay/stripe/billable.rb
@@ -61,7 +61,15 @@ module Pay
       # Syncs name and email to Stripe::Customer
       def update_customer!
         return unless processor_id?
-        ::Stripe::Customer.update(processor_id, {name: customer_name, email: email}, stripe_options)
+        ::Stripe::Customer.update(
+          processor_id,
+          {
+            email: email,
+            name: customer_name,
+            metadata: customer_metadata
+          },
+          stripe_options
+        )
       end
 
       def charge(amount, options = {})

--- a/lib/pay/stripe/billable.rb
+++ b/lib/pay/stripe/billable.rb
@@ -26,9 +26,9 @@ module Pay
         owner = pay_customer.owner
         case owner.class.pay_customer_metadata
         when Symbol
-          owner.send(owner.class.pay_customer_metadata)
+          owner.send(owner.class.pay_customer_metadata, pay_customer)
         when Proc
-          owner.class.pay_customer_metadata.call(owner)
+          owner.class.pay_customer_metadata.call(pay_customer)
         end
       end
 

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -4,6 +4,6 @@ class User < ApplicationRecord
   # pay_customer metadata: ->(user) { { id: user.id } }
 
   def stripe_metadata
-    { id: id }
+    { user_id: id }
   end
 end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -1,3 +1,9 @@
 class User < ApplicationRecord
   pay_customer
+  # pay_customer metadata: :stripe_metadata
+  # pay_customer metadata: ->(user) { { id: user.id } }
+
+  def stripe_metadata
+    { id: id }
+  end
 end

--- a/test/dummy/app/models/user.rb
+++ b/test/dummy/app/models/user.rb
@@ -1,9 +1,11 @@
 class User < ApplicationRecord
   pay_customer
   # pay_customer metadata: :stripe_metadata
-  # pay_customer metadata: ->(user) { { id: user.id } }
+  # pay_customer metadata: ->(pay_customer) { { user_id: pay_customer.owner_id } }
 
-  def stripe_metadata
-    { user_id: id }
+  def stripe_metadata(pay_customer)
+    {
+      user_id: id # or pay_customer.owner_id
+    }
   end
 end

--- a/test/pay/attributes_test.rb
+++ b/test/pay/attributes_test.rb
@@ -45,4 +45,11 @@ class Pay::AttributesTest < ActiveSupport::TestCase
 
     assert account.merchant_processor
   end
+
+  test "pay_customer metadata" do
+    original_value = User.pay_customer_metadata
+    User.pay_customer_metadata = :stripe_metadata
+    assert_equal :stripe_metadata, User.pay_customer_metadata
+    User.pay_customer_metadata = original_value
+  end
 end

--- a/test/pay/stripe/billable_test.rb
+++ b/test/pay/stripe/billable_test.rb
@@ -372,9 +372,9 @@ class Pay::Stripe::BillableTest < ActiveSupport::TestCase
   end
 
   test "stripe customer metdata proc" do
-    User.pay_customer_metadata = ->(user) { {id: user.id} }
+    User.pay_customer_metadata = ->(user) { {user_id: user.id} }
     pay_customer = pay_customers(:stripe)
-    metadata = {id: pay_customer.owner_id}
+    metadata = {user_id: pay_customer.owner_id}
     assert_equal metadata, Pay::Stripe::Billable.new(pay_customer).customer_metadata
     User.pay_customer_metadata = nil
   end
@@ -383,7 +383,7 @@ class Pay::Stripe::BillableTest < ActiveSupport::TestCase
     original_value = User.pay_customer_metadata
     User.pay_customer_metadata = :stripe_metadata
     pay_customer = pay_customers(:stripe)
-    metadata = {id: pay_customer.owner_id}
+    metadata = {user_id: pay_customer.owner_id}
     assert_equal metadata, Pay::Stripe::Billable.new(pay_customer).customer_metadata
     User.pay_customer_metadata = original_value
   end

--- a/test/pay/stripe/billable_test.rb
+++ b/test/pay/stripe/billable_test.rb
@@ -372,9 +372,9 @@ class Pay::Stripe::BillableTest < ActiveSupport::TestCase
   end
 
   test "stripe customer metdata proc" do
-    User.pay_customer_metadata = ->(user){ {id: user.id} }
+    User.pay_customer_metadata = ->(user) { {id: user.id} }
     pay_customer = pay_customers(:stripe)
-    metadata = { id: pay_customer.owner_id }
+    metadata = {id: pay_customer.owner_id}
     assert_equal metadata, Pay::Stripe::Billable.new(pay_customer).customer_metadata
     User.pay_customer_metadata = nil
   end
@@ -383,7 +383,7 @@ class Pay::Stripe::BillableTest < ActiveSupport::TestCase
     original_value = User.pay_customer_metadata
     User.pay_customer_metadata = :stripe_metadata
     pay_customer = pay_customers(:stripe)
-    metadata = { id: pay_customer.owner_id }
+    metadata = {id: pay_customer.owner_id}
     assert_equal metadata, Pay::Stripe::Billable.new(pay_customer).customer_metadata
     User.pay_customer_metadata = original_value
   end

--- a/test/pay/stripe/billable_test.rb
+++ b/test/pay/stripe/billable_test.rb
@@ -371,6 +371,23 @@ class Pay::Stripe::BillableTest < ActiveSupport::TestCase
     assert_equal "wechat_pay", @pay_customer.default_payment_method.type
   end
 
+  test "stripe customer metdata proc" do
+    User.pay_customer_metadata = ->(user){ {id: user.id} }
+    pay_customer = pay_customers(:stripe)
+    metadata = { id: pay_customer.owner_id }
+    assert_equal metadata, Pay::Stripe::Billable.new(pay_customer).customer_metadata
+    User.pay_customer_metadata = nil
+  end
+
+  test "stripe customer metdata symbol" do
+    original_value = User.pay_customer_metadata
+    User.pay_customer_metadata = :stripe_metadata
+    pay_customer = pay_customers(:stripe)
+    metadata = { id: pay_customer.owner_id }
+    assert_equal metadata, Pay::Stripe::Billable.new(pay_customer).customer_metadata
+    User.pay_customer_metadata = original_value
+  end
+
   private
 
   def payment_method

--- a/test/pay/stripe/billable_test.rb
+++ b/test/pay/stripe/billable_test.rb
@@ -372,9 +372,9 @@ class Pay::Stripe::BillableTest < ActiveSupport::TestCase
   end
 
   test "stripe customer metdata proc" do
-    User.pay_customer_metadata = ->(user) { {user_id: user.id} }
     pay_customer = pay_customers(:stripe)
     metadata = {user_id: pay_customer.owner_id}
+    User.pay_customer_metadata = ->(pay_customer) { {user_id: pay_customer.owner_id} }
     assert_equal metadata, Pay::Stripe::Billable.new(pay_customer).customer_metadata
     User.pay_customer_metadata = nil
   end


### PR DESCRIPTION
Adds the ability to define a symbol or Proc that returns metadata when creating a Customer object in Stripe. This is named `metadata` currently, so if other payment processors support metadata, it can be included in those. Currently, Stripe is the only one that implements this afaik.

```ruby
class User < ApplicationRecord
  pay_customer metadata: :stripe_metadata
  # pay_customer metadata: ->(user) { { user_id: user.id } }

  def stripe_metadata
    { user_id: id }
  end
end
```

Closes #431 