### PR TITLE
Add default payment processor option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ### Unreleased
 
-* `pay_customer` now supports a metadata option to save on Stripe::Customers - @excid3
+* `pay_customer` now supports a `metadata` option to save on Stripe::Customers - @excid3
+* `pay_customer` now supports a `default_payment_processor` option to automatically create a Pay::Customer record - @excid3
 
 # 3.0.24
 

--- a/lib/pay/attributes.rb
+++ b/lib/pay/attributes.rb
@@ -9,6 +9,7 @@ module Pay
 
       included do
         cattr_accessor :pay_customer_metadata
+        cattr_accessor :pay_default_payment_processor
 
         has_many :pay_customers, class_name: "Pay::Customer", as: :owner, inverse_of: :owner
         has_many :charges, through: :pay_customers, class_name: "Pay::Charge"
@@ -35,6 +36,16 @@ module Pay
 
         # Return new payment processor
         reload_payment_processor
+      end
+
+      def payment_processor
+        current_processor = super
+
+        if current_processor.blank? && self.class.pay_default_payment_processor.present?
+          set_payment_processor(self.class.pay_default_payment_processor, allow_fake: true)
+        else
+          current_processor
+        end
       end
 
       def cancel_active_pay_subscriptions!
@@ -68,6 +79,7 @@ module Pay
         include CustomerExtension
 
         self.pay_customer_metadata = options[:metadata]
+        self.pay_default_payment_processor = options[:default_payment_processor]
       end
 
       def pay_merchant(options = {})

--- a/test/pay/attributes_test.rb
+++ b/test/pay/attributes_test.rb
@@ -52,4 +52,13 @@ class Pay::AttributesTest < ActiveSupport::TestCase
     assert_equal :stripe_metadata, User.pay_customer_metadata
     User.pay_customer_metadata = original_value
   end
+
+  test "default_payment_processor option" do
+    original_value = User.pay_default_payment_processor
+    User.pay_default_payment_processor = :fake_processor
+    payment_processor = users(:none).payment_processor
+    assert payment_processor
+    assert_equal "fake_processor", payment_processor.processor
+    User.pay_default_payment_processor = original_value
+  end
 end


### PR DESCRIPTION
This adds the ability to define a default payment processor for a model. If you know you're going to use Stripe, then you can set it as the default and skip the `set_default_payment_processor` call.

```ruby
class User < ApplicationRecord
  pay_customer default_payment_processor: :stripe
end

pay_customer = User.create(...).payment_processor
pay_customer.processor #=> "stripe"
```

Closes #518 