### PR TITLE
fixes #456 - Allow enable and disable of processors

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@
 
 Pay::Engine.routes.draw do
   resources :payments, only: [:show], module: :pay
-  post "webhooks/stripe", to: "pay/webhooks/stripe#create" if defined? ::Stripe
-  post "webhooks/braintree", to: "pay/webhooks/braintree#create" if defined? ::Braintree
-  post "webhooks/paddle", to: "pay/webhooks/paddle#create" if defined? ::PaddlePay
+  post "webhooks/stripe", to: "pay/webhooks/stripe#create" if Pay::Stripe.enabled?
+  post "webhooks/braintree", to: "pay/webhooks/braintree#create" if Pay::Braintree.enabled?
+  post "webhooks/paddle", to: "pay/webhooks/paddle#create" if Pay::Paddle.enabled?
 end

--- a/lib/pay.rb
+++ b/lib/pay.rb
@@ -51,6 +51,9 @@ module Pay
   mattr_accessor :routes_path
   @@routes_path = "/pay"
 
+  mattr_accessor :enabled_processors
+  @@enabled_processors = [:stripe, :braintree, :paddle]
+
   def self.setup
     yield self
   end

--- a/lib/pay/braintree.rb
+++ b/lib/pay/braintree.rb
@@ -19,6 +19,12 @@ module Pay
 
     extend Env
 
+    def self.enabled?
+      return false unless Pay.enabled_processors.include?(:braintree) && defined?(::Braintree)
+
+      Pay::Engine.version_matches?(required: "~> 4", current: ::Braintree::Version::String) || (raise "[Pay] braintree gem must be version ~> 4")
+    end
+
     def self.setup
       Pay.braintree_gateway = ::Braintree::Gateway.new(
         environment: environment.to_sym,

--- a/lib/pay/engine.rb
+++ b/lib/pay/engine.rb
@@ -18,29 +18,15 @@ module Pay
     end
 
     initializer "pay.webhooks" do
-      Pay::Stripe.configure_webhooks if defined?(::Stripe)
-      Pay::Braintree.configure_webhooks if defined?(::Braintree)
-      Pay::Paddle.configure_webhooks if defined?(::PaddlePay)
+      Pay::Stripe.configure_webhooks if Pay::Stripe.enabled?
+      Pay::Braintree.configure_webhooks if Pay::Braintree.enabled?
+      Pay::Paddle.configure_webhooks if Pay::Paddle.enabled?
     end
 
     config.to_prepare do
-      if defined?(::Stripe) && Pay::Engine.version_matches?(required: "~> 5", current: ::Stripe::VERSION)
-        Pay::Stripe.setup
-      else
-        raise "[Pay] stripe gem must be version ~> 5"
-      end
-
-      if defined?(::Braintree) && Pay::Engine.version_matches?(required: "~> 4", current: ::Braintree::Version::String)
-        Pay::Braintree.setup
-      else
-        raise "[Pay] braintree gem must be version ~> 4"
-      end
-
-      if defined?(::PaddlePay) && Pay::Engine.version_matches?(required: "~> 0.2", current: ::PaddlePay::VERSION)
-        Pay::Paddle.setup
-      else
-        raise "[Pay] paddle_pay gem must be version ~> 0.2"
-      end
+      Pay::Stripe.setup if Pay::Stripe.enabled?
+      Pay::Braintree.setup if Pay::Braintree.enabled?
+      Pay::Paddle.setup if Pay::Paddle.enabled?
 
       if defined?(::Receipts::VERSION) && Pay::Engine.version_matches?(required: "~> 2", current: ::Receipts::VERSION)
         Pay::Charge.include Pay::Receipts

--- a/lib/pay/paddle.rb
+++ b/lib/pay/paddle.rb
@@ -17,6 +17,12 @@ module Pay
 
     extend Env
 
+    def self.enabled?
+      return false unless Pay.enabled_processors.include?(:paddle) && defined?(::PaddlePay)
+
+      Pay::Engine.version_matches?(required: "~> 0.2", current: ::PaddlePay::VERSION) || (raise "[Pay] paddle gem must be version ~> 0.2")
+    end
+
     def self.setup
       ::PaddlePay.config.vendor_id = vendor_id
       ::PaddlePay.config.vendor_auth_code = vendor_auth_code

--- a/lib/pay/stripe.rb
+++ b/lib/pay/stripe.rb
@@ -28,6 +28,12 @@ module Pay
 
     extend Env
 
+    def self.enabled?
+      return false unless Pay.enabled_processors.include?(:stripe) && defined?(::Stripe)
+
+      Pay::Engine.version_matches?(required: "~> 5", current: ::Stripe::VERSION) || (raise "[Pay] stripe gem must be version ~> 5")
+    end
+
     def self.setup
       ::Stripe.api_key = private_key
       ::Stripe.api_version = "2020-08-27"

--- a/test/pay_test.rb
+++ b/test/pay_test.rb
@@ -42,4 +42,45 @@ class Pay::Test < ActiveSupport::TestCase
     assert Pay.respond_to?(:default_plan_name)
     assert Pay.respond_to?(:default_plan_name=)
   end
+
+  test "can configure enabled_processors" do
+    assert Pay.respond_to?(:enabled_processors)
+    assert Pay.respond_to?(:enabled_processors=)
+  end
+
+  test "can enable and disable the stripe processor" do
+    original = Pay.enabled_processors
+
+    Pay.enabled_processors = []
+    refute Pay::Stripe.enabled?
+
+    Pay.enabled_processors = [:stripe]
+    assert Pay::Stripe.enabled?
+
+    Pay.enabled_processors = original
+  end
+
+  test "can enable and disable the braintree processor" do
+    original = Pay.enabled_processors
+
+    Pay.enabled_processors = []
+    refute Pay::Braintree.enabled?
+
+    Pay.enabled_processors = [:braintree]
+    assert Pay::Braintree.enabled?
+
+    Pay.enabled_processors = original
+  end
+
+  test "can enable and disable the paddle processor" do
+    original = Pay.enabled_processors
+
+    Pay.enabled_processors = []
+    refute Pay::Paddle.enabled?
+
+    Pay.enabled_processors = [:paddle]
+    assert Pay::Paddle.enabled?
+
+    Pay.enabled_processors = original
+  end
 end


### PR DESCRIPTION
This PR allows for explicitly setting the payment processors to be used via an enabled_processors config variable. It also creates new class methods for `Pay::Stripe`, `Pay::Braintree`, and `Pay::Paddle` to check if they are enabled and of a compatible version. These methods are used to set up the processors and  the webhook routes if enabled.