### PR TITLE
allow independent configuration for each email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,17 @@
 * `pay_customer` now supports a `braintree_attributes:` option to add attributes to Braintree::Customers - @excid3
 * `pay_customer` now supports a `default_payment_processor` option to automatically create a Pay::Customer record - @excid3
 * Added `enabled_processors` to Pay config. This lets you choose exactly which processors will be enabled. - @cjilbert504
+* [Breaking] Replaced `send_emails` with `emails` config. This allows you to customize which emails can be sent independently. - @cjilbert504
+```ruby
+Pay.setup do |config|
+  # Set value to boolean
+  config.emails.receipt = true
+  # Or set value to a lambda that returns a boolean
+  config.emails.subscription_renewing = ->(pay_subscription, price) {
+    (price&.type == "recurring") && (price.recurring&.interval == "year")
+  }
+end
+```
 
 ### 3.0.24
 
@@ -383,4 +394,3 @@ end
 ### 1.0.0.beta2 - 2019-03-11
 
 * Check ENV first when looking up keys to allow for overrides
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ### Unreleased
 
+* [Breaking] Replaced `subscription` and `charge` email params to `pay_subscription` and `pay_charge` respectively. - @cjilbert504
+* [Breaking] Replaced `send_emails` with `emails` config. This allows you to customize which emails can be sent independently. - @cjilbert504
+```ruby
+Pay.setup do |config|
+  # Set value to boolean
+  config.emails.receipt = true
+  # Or set value to a lambda that returns a boolean
+  config.emails.subscription_renewing = ->(pay_subscription, price) {
+    (price&.type == "recurring") && (price.recurring&.interval == "year")
+  }
+end
+```
+
 * Stripe Tax support
 
   Using `pay_customer stripe_attributes: :method_name`, you can add an Address to `Stripe::Customer` objects which will be used for calculating taxes.
@@ -28,18 +41,6 @@
 * `pay_customer` now supports a `braintree_attributes:` option to add attributes to Braintree::Customers - @excid3
 * `pay_customer` now supports a `default_payment_processor` option to automatically create a Pay::Customer record - @excid3
 * Added `enabled_processors` to Pay config. This lets you choose exactly which processors will be enabled. - @cjilbert504
-* [Breaking] Replaced `subscription` and `charge` email params to `pay_subscription` and `pay_charge` respectively. - @cjilbert504
-* [Breaking] Replaced `send_emails` with `emails` config. This allows you to customize which emails can be sent independently. - @cjilbert504
-```ruby
-Pay.setup do |config|
-  # Set value to boolean
-  config.emails.receipt = true
-  # Or set value to a lambda that returns a boolean
-  config.emails.subscription_renewing = ->(pay_subscription, price) {
-    (price&.type == "recurring") && (price.recurring&.interval == "year")
-  }
-end
-```
 
 ### 3.0.24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@
 * `pay_customer` now supports a `braintree_attributes:` option to add attributes to Braintree::Customers - @excid3
 * `pay_customer` now supports a `default_payment_processor` option to automatically create a Pay::Customer record - @excid3
 * Added `enabled_processors` to Pay config. This lets you choose exactly which processors will be enabled. - @cjilbert504
+* [Breaking] Replaced `subscription` and `charge` email params to `pay_subscription` and `pay_charge` respectively. - @cjilbert504
 * [Breaking] Replaced `send_emails` with `emails` config. This allows you to customize which emails can be sent independently. - @cjilbert504
 ```ruby
 Pay.setup do |config|

--- a/app/mailers/pay/user_mailer.rb
+++ b/app/mailers/pay/user_mailer.rb
@@ -1,8 +1,8 @@
 module Pay
   class UserMailer < ApplicationMailer
     def receipt
-      if params[:charge].respond_to? :receipt
-        attachments[params[:charge].filename] = params[:charge].receipt
+      if params[:pay_charge].respond_to? :receipt
+        attachments[params[:pay_charge].filename] = params[:pay_charge].receipt
       end
 
       mail to: to

--- a/app/views/pay/user_mailer/receipt.html.erb
+++ b/app/views/pay/user_mailer/receipt.html.erb
@@ -5,13 +5,13 @@ Questions? Please reply to this email.<br/>
 ------------------------------------<br/>
 RECEIPT - SUBSCRIPTION<br/>
 <br/>
-Amount: <%= params[:charge].amount_with_currency %><br/>
+Amount: <%= params[:pay_charge].amount_with_currency %><br/>
 <br/>
-Charged to: <%= params[:charge].charged_to %><br/>
-Transaction ID: <%= params[:charge].id %><br/>
-Date: <%= params[:charge].created_at %><br/>
-<% if params[:charge].customer.owner.try(:extra_billing_info?) %>
-<%= params[:charge].customer.owner.extra_billing_info %><br/>
+Charged to: <%= params[:pay_charge].charged_to %><br/>
+Transaction ID: <%= params[:pay_charge].id %><br/>
+Date: <%= params[:pay_charge].created_at %><br/>
+<% if params[:pay_charge].customer.owner.try(:extra_billing_info?) %>
+<%= params[:pay_charge].customer.owner.extra_billing_info %><br/>
 <% end %>
 <br/>
 <br/>

--- a/app/views/pay/user_mailer/refund.html.erb
+++ b/app/views/pay/user_mailer/refund.html.erb
@@ -6,13 +6,13 @@ Questions? Please reply to this email.<br/>
 ------------------------------------<br/>
 RECEIPT - REFUND<br/>
 <br/>
-Amount: <%= params[:charge].amount_refunded_with_currency %><br/>
+Amount: <%= params[:pay_charge].amount_refunded_with_currency %><br/>
 <br/>
-Refunded to: <%= params[:charge].charged_to %><br/>
-Transaction ID: <%= params[:charge].id %><br/>
-Date: <%= params[:charge].created_at %><br/>
-<% if params[:charge].customer.owner.try(:extra_billing_info?) %>
-<%= params[:charge].customer.owner.extra_billing_info %><br/>
+Refunded to: <%= params[:pay_charge].charged_to %><br/>
+Transaction ID: <%= params[:pay_charge].id %><br/>
+Date: <%= params[:pay_charge].created_at %><br/>
+<% if params[:pay_charge].customer.owner.try(:extra_billing_info?) %>
+<%= params[:pay_charge].customer.owner.extra_billing_info %><br/>
 <% end %>
 <br/>
 <br/>

--- a/docs/2_configuration.md
+++ b/docs/2_configuration.md
@@ -111,6 +111,7 @@ Pay.setup do |config|
   # This example for subscription_renewing only applies to Stripe, therefor we supply the second argument of price
   config.emails.subscription_renewing = ->(pay_subscription, price) {
     (price&.type == "recurring") && (price.recurring&.interval == "year")
+  }
 end
 ```
 

--- a/docs/2_configuration.md
+++ b/docs/2_configuration.md
@@ -76,13 +76,14 @@ bin/rails generate pay:email_views
 
 ## Emails
 
-Emails can be enabled/disabled using the `send_emails` configuration option (enabled by default).
+Emails can be enabled/disabled independently using the `emails` configuration option as show in the configuration section below (all are enabled by default).
 
 When enabled, the following emails will be sent when:
 
 - A charge succeeded
 - A charge was refunded
 - A yearly subscription is about to renew
+- A payment action is required
 
 ## Configuration
 
@@ -96,8 +97,6 @@ Pay.setup do |config|
   config.application_name = "My App"
   config.support_email = "helpme@example.com"
 
-  config.send_emails = true
-
   config.default_product_name = "default"
   config.default_plan_name = "default"
 
@@ -105,6 +104,13 @@ Pay.setup do |config|
   config.routes_path = "/pay" # Only when automount_routes is true
   # All processors are enabled by default. If a processor is already implemented in your application, you can omit it from this list and the processor will not be set up through the Pay gem.
   config.enabled_processors = [:stripe, :braintree, :paddle]
+  # All emails can be configured independently as to whether to be sent or not. The values can be set to true, false or a custom lambda to set up more involved logic. The Pay defaults are show below and can be modified as needed.
+  config.emails.payment_action_required = true
+  config.emails.receipt = true
+  config.emails.refund = true
+  # This example for subscription_renewing only applies to Stripe, therefor we supply the second argument of price
+  config.emails.subscription_renewing = ->(pay_subscription, price) {
+    (price&.type == "recurring") && (price.recurring&.interval == "year")
 end
 ```
 

--- a/lib/pay.rb
+++ b/lib/pay.rb
@@ -54,7 +54,27 @@ module Pay
   mattr_accessor :enabled_processors
   @@enabled_processors = [:stripe, :braintree, :paddle]
 
+  mattr_accessor :emails
+  @@emails = ActiveSupport::OrderedOptions.new
+  @@emails.payment_action_required = true
+  @@emails.receipt = true
+  @@emails.refund = true
+  # This only applies to Stripe, therefor we supply the second argument of price
+  @@emails.subscription_renewing = ->(pay_subscription, price) {
+    (price&.type == "recurring") && (price.recurring&.interval == "year")
+  }
+
   def self.setup
     yield self
+  end
+
+  def self.send_email?(email_option, *remaining_args)
+    config_option = emails.send(email_option)
+
+    if config_option.respond_to?(:call)
+      config_option.call(*remaining_args)
+    else
+      config_option
+    end
   end
 end

--- a/lib/pay.rb
+++ b/lib/pay.rb
@@ -35,10 +35,6 @@ module Pay
   mattr_accessor :business_logo
   mattr_accessor :support_email
 
-  # Email configuration
-  mattr_accessor :send_emails
-  @@send_emails = true
-
   mattr_accessor :automount_routes
   @@automount_routes = true
 

--- a/lib/pay/braintree/webhooks/subscription_charged_successfully.rb
+++ b/lib/pay/braintree/webhooks/subscription_charged_successfully.rb
@@ -14,8 +14,8 @@ module Pay
           pay_customer = pay_subscription.customer
           pay_charge = Pay::Braintree::Billable.new(pay_customer).save_transaction(subscription.transactions.first)
 
-          if pay_charge && Pay.send_emails
-            Pay::UserMailer.with(pay_customer: pay_customer, charge: pay_charge).receipt.deliver_later
+          if pay_charge && Pay.send_email?(:receipt, pay_charge)
+            Pay::UserMailer.with(pay_customer: pay_customer, pay_charge: pay_charge).receipt.deliver_later
           end
         end
       end

--- a/lib/pay/braintree/webhooks/subscription_trial_ended.rb
+++ b/lib/pay/braintree/webhooks/subscription_trial_ended.rb
@@ -11,7 +11,7 @@ module Pay
           pay_subscription = Pay::Subscription.find_by_processor_and_id(:braintree, subscription.id)
           return unless pay_subscription.present?
 
-          pay_subscription.update(trial_ends_at: Time.current)
+          pay_subscription.update!(trial_ends_at: Time.current)
         end
       end
     end

--- a/lib/pay/paddle/webhooks/subscription_payment_refunded.rb
+++ b/lib/pay/paddle/webhooks/subscription_payment_refunded.rb
@@ -6,10 +6,10 @@ module Pay
           pay_charge = Pay::Charge.find_by_processor_and_id(:paddle, event.subscription_payment_id)
           return unless pay_charge.present?
 
-          pay_charge.update(amount_refunded: (event.gross_refund.to_f * 100).to_i)
+          pay_charge.update!(amount_refunded: (event.gross_refund.to_f * 100).to_i)
 
-          if Pay.send_emails
-            Pay::UserMailer.with(pay_customer: pay_charge.customer, charge: pay_charge).refund.deliver_later
+          if Pay.send_email?(:refund, pay_charge)
+            Pay::UserMailer.with(pay_customer: pay_charge.customer, pay_charge: pay_charge).refund.deliver_later
           end
         end
       end

--- a/lib/pay/paddle/webhooks/subscription_payment_succeeded.rb
+++ b/lib/pay/paddle/webhooks/subscription_payment_succeeded.rb
@@ -43,7 +43,7 @@ module Pay
         end
 
         def notify_user(pay_charge)
-          if Pay.send_emails
+          if Pay.send_email?(:receipt, pay_charge)
             Pay::UserMailer.with(pay_customer: pay_charge.customer, charge: pay_charge).receipt.deliver_later
           end
         end

--- a/lib/pay/paddle/webhooks/subscription_payment_succeeded.rb
+++ b/lib/pay/paddle/webhooks/subscription_payment_succeeded.rb
@@ -17,8 +17,8 @@ module Pay
 
           return if pay_customer.charges.where(processor_id: event.subscription_payment_id).any?
 
-          charge = create_charge(pay_customer, event)
-          notify_user(charge)
+          pay_charge = create_charge(pay_customer, event)
+          notify_user(pay_charge)
         end
 
         def create_charge(pay_customer, event)
@@ -33,18 +33,18 @@ module Pay
             metadata: Pay::Paddle.parse_passthrough(event.passthrough).except("owner_sgid")
           }.merge(payment_method_details)
 
-          charge = pay_customer.charges.find_or_initialize_by(processor_id: event.subscription_payment_id)
-          charge.update!(attributes)
+          pay_charge = pay_customer.charges.find_or_initialize_by(processor_id: event.subscription_payment_id)
+          pay_charge.update!(attributes)
 
           # Update customer's payment method
           Pay::Paddle::PaymentMethod.sync(pay_customer: pay_customer, attributes: payment_method_details)
 
-          charge
+          pay_charge
         end
 
         def notify_user(pay_charge)
           if Pay.send_email?(:receipt, pay_charge)
-            Pay::UserMailer.with(pay_customer: pay_charge.customer, charge: pay_charge).receipt.deliver_later
+            Pay::UserMailer.with(pay_customer: pay_charge.customer, pay_charge: pay_charge).receipt.deliver_later
           end
         end
       end

--- a/lib/pay/paddle/webhooks/subscription_updated.rb
+++ b/lib/pay/paddle/webhooks/subscription_updated.rb
@@ -3,33 +3,33 @@ module Pay
     module Webhooks
       class SubscriptionUpdated
         def call(event)
-          subscription = Pay::Subscription.find_by_processor_and_id(:paddle, event["subscription_id"])
+          pay_subscription = Pay::Subscription.find_by_processor_and_id(:paddle, event["subscription_id"])
 
-          return if subscription.nil?
+          return if pay_subscription.nil?
 
           case event["status"]
           when "deleted"
-            subscription.status = "canceled"
-            subscription.ends_at = Time.zone.parse(event["next_bill_date"]) || Time.current if subscription.ends_at.blank?
+            pay_subscription.status = "canceled"
+            pay_subscription.ends_at = Time.zone.parse(event["next_bill_date"]) || Time.current if pay_subscription.ends_at.blank?
           when "trialing"
-            subscription.status = "trialing"
-            subscription.trial_ends_at = Time.zone.parse(event["next_bill_date"])
+            pay_subscription.status = "trialing"
+            pay_subscription.trial_ends_at = Time.zone.parse(event["next_bill_date"])
           when "active"
-            subscription.status = "active"
-            subscription.paddle_paused_from = Time.zone.parse(event["paused_from"]) if event["paused_from"].present?
+            pay_subscription.status = "active"
+            pay_subscription.paddle_paused_from = Time.zone.parse(event["paused_from"]) if event["paused_from"].present?
           else
-            subscription.status = event["status"]
+            pay_subscription.status = event["status"]
           end
 
-          subscription.quantity = event["new_quantity"]
-          subscription.processor_plan = event["subscription_plan_id"]
-          subscription.paddle_update_url = event["update_url"]
-          subscription.paddle_cancel_url = event["cancel_url"]
+          pay_subscription.quantity = event["new_quantity"]
+          pay_subscription.processor_plan = event["subscription_plan_id"]
+          pay_subscription.paddle_update_url = event["update_url"]
+          pay_subscription.paddle_cancel_url = event["cancel_url"]
 
           # If user was on trial, their subscription ends at the end of the trial
-          subscription.ends_at = subscription.trial_ends_at if subscription.on_trial?
+          pay_subscription.ends_at = pay_subscription.trial_ends_at if pay_subscription.on_trial?
 
-          subscription.save!
+          pay_subscription.save!
         end
       end
     end

--- a/lib/pay/stripe/webhooks/charge_refunded.rb
+++ b/lib/pay/stripe/webhooks/charge_refunded.rb
@@ -5,8 +5,8 @@ module Pay
         def call(event)
           pay_charge = Pay::Stripe::Charge.sync(event.data.object.id, stripe_account: event.try(:account))
 
-          if pay_charge && Pay.send_emails
-            Pay::UserMailer.with(pay_customer: pay_charge.customer, charge: pay_charge).refund.deliver_later
+          if pay_charge && Pay.send_email?(:refund, pay_charge)
+            Pay::UserMailer.with(pay_customer: pay_charge.customer, pay_charge: pay_charge).refund.deliver_later
           end
         end
       end

--- a/lib/pay/stripe/webhooks/charge_succeeded.rb
+++ b/lib/pay/stripe/webhooks/charge_succeeded.rb
@@ -6,7 +6,7 @@ module Pay
           pay_charge = Pay::Stripe::Charge.sync(event.data.object.id, stripe_account: event.try(:account))
 
           if pay_charge && Pay.send_emails
-            Pay::UserMailer.with(pay_customer: pay_charge.customer, charge: pay_charge).receipt.deliver_later
+            Pay::UserMailer.with(pay_customer: pay_charge.customer, pay_charge: pay_charge).receipt.deliver_later
           end
         end
       end

--- a/lib/pay/stripe/webhooks/charge_succeeded.rb
+++ b/lib/pay/stripe/webhooks/charge_succeeded.rb
@@ -5,7 +5,7 @@ module Pay
         def call(event)
           pay_charge = Pay::Stripe::Charge.sync(event.data.object.id, stripe_account: event.try(:account))
 
-          if pay_charge && Pay.send_emails
+          if pay_charge && Pay.send_email?(:receipt, pay_charge)
             Pay::UserMailer.with(pay_customer: pay_charge.customer, pay_charge: pay_charge).receipt.deliver_later
           end
         end

--- a/lib/pay/stripe/webhooks/payment_action_required.rb
+++ b/lib/pay/stripe/webhooks/payment_action_required.rb
@@ -8,14 +8,14 @@ module Pay
 
           object = event.data.object
 
-          subscription = Pay::Subscription.find_by_processor_and_id(:stripe, object.subscription)
-          return if subscription.nil?
+          pay_subscription = Pay::Subscription.find_by_processor_and_id(:stripe, object.subscription)
+          return if pay_subscription.nil?
 
-          if Pay.send_emails
+          if Pay.send_email?(:payment_action_required, pay_subscription)
             Pay::UserMailer.with(
-              pay_customer: subscription.customer,
+              pay_customer: pay_subscription.customer,
               payment_intent_id: event.data.object.payment_intent,
-              subscription: subscription
+              pay_subscription: pay_subscription
             ).payment_action_required.deliver_later
           end
         end

--- a/lib/pay/stripe/webhooks/subscription_renewing.rb
+++ b/lib/pay/stripe/webhooks/subscription_renewing.rb
@@ -13,10 +13,6 @@ module Pay
 
           # Stripe subscription items all have the same interval
           price = event.data.object.lines.data.first.price
-          # return unless price.type == "recurring"
-
-          # interval = price.recurring.interval
-          # return unless interval == "year"
 
           if Pay.send_email?(:subscription_renewing, pay_subscription, price)
             Pay::UserMailer.with(

--- a/lib/pay/stripe/webhooks/subscription_renewing.rb
+++ b/lib/pay/stripe/webhooks/subscription_renewing.rb
@@ -8,20 +8,20 @@ module Pay
         def call(event)
           # Event is of type "invoice" see:
           # https://stripe.com/docs/api/invoices/object
-          subscription = Pay::Subscription.find_by_processor_and_id(:stripe, event.data.object.subscription)
-          return unless subscription
+          pay_subscription = Pay::Subscription.find_by_processor_and_id(:stripe, event.data.object.subscription)
+          return unless pay_subscription
 
           # Stripe subscription items all have the same interval
           price = event.data.object.lines.data.first.price
-          return unless price.type == "recurring"
+          # return unless price.type == "recurring"
 
-          interval = price.recurring.interval
-          return unless interval == "year"
+          # interval = price.recurring.interval
+          # return unless interval == "year"
 
-          if Pay.send_emails
+          if Pay.send_email?(:subscription_renewing, pay_subscription, price)
             Pay::UserMailer.with(
-              pay_customer: subscription.customer,
-              subscription: subscription,
+              pay_customer: pay_subscription.customer,
+              pay_subscription: pay_subscription,
               date: Time.zone.at(event.data.object.next_payment_attempt)
             ).subscription_renewing.deliver_later
           end

--- a/test/mailers/pay/user_mailer_test.rb
+++ b/test/mailers/pay/user_mailer_test.rb
@@ -9,7 +9,7 @@ class UserMailerTest < ActionMailer::TestCase
   end
 
   test "receipt" do
-    email = Pay::UserMailer.with(pay_customer: @pay_customer, charge: @charge).receipt
+    email = Pay::UserMailer.with(pay_customer: @pay_customer, pay_charge: @charge).receipt
 
     assert_equal [@user.email], email.to
     assert_equal I18n.t("pay.user_mailer.receipt.subject"), email.subject
@@ -25,13 +25,13 @@ class UserMailerTest < ActionMailer::TestCase
     @charge.stubs(:filename).returns(filename)
     @charge.stubs(:receipt).returns(receipt)
 
-    email = Pay::UserMailer.with(pay_customer: @pay_customer, charge: @charge).receipt
+    email = Pay::UserMailer.with(pay_customer: @pay_customer, pay_charge: @charge).receipt
 
     assert_equal filename, email.attachments.first.filename
   end
 
   test "refund" do
-    email = Pay::UserMailer.with(pay_customer: @pay_customer, charge: @charge).refund
+    email = Pay::UserMailer.with(pay_customer: @pay_customer, pay_charge: @charge).refund
 
     assert_equal [@user.email], email.to
     assert_equal I18n.t("pay.user_mailer.refund.subject"), email.subject
@@ -39,7 +39,7 @@ class UserMailerTest < ActionMailer::TestCase
 
   test "subscription_renewing" do
     time = Time.current
-    email = Pay::UserMailer.with(pay_customer: @pay_customer, subscription: Pay::Subscription.new, date: time).subscription_renewing
+    email = Pay::UserMailer.with(pay_customer: @pay_customer, pay_subscription: Pay::Subscription.new, date: time).subscription_renewing
 
     assert_equal [@user.email], email.to
     assert_equal I18n.t("pay.user_mailer.subscription_renewing.subject"), email.subject
@@ -47,7 +47,7 @@ class UserMailerTest < ActionMailer::TestCase
   end
 
   test "payment_action_required" do
-    email = Pay::UserMailer.with(pay_customer: @pay_customer, payment_intent_id: "x", subscription: Pay::Subscription.new).payment_action_required
+    email = Pay::UserMailer.with(pay_customer: @pay_customer, payment_intent_id: "x", pay_subscription: Pay::Subscription.new).payment_action_required
 
     assert_equal [@user.email], email.to
     assert_equal I18n.t("pay.user_mailer.payment_action_required.subject"), email.subject
@@ -57,7 +57,7 @@ class UserMailerTest < ActionMailer::TestCase
   test "receipt with no extra billing info column" do
     team = teams(:one)
     @pay_customer.update!(owner: team)
-    email = Pay::UserMailer.with(pay_customer: @pay_customer, charge: @charge).receipt
+    email = Pay::UserMailer.with(pay_customer: @pay_customer, pay_charge: @charge).receipt
 
     assert_equal [team.owner.email], email.to
     assert_equal I18n.t("pay.user_mailer.receipt.subject"), email.subject
@@ -66,7 +66,7 @@ class UserMailerTest < ActionMailer::TestCase
   test "refund with no extra billing info column" do
     team = teams(:one)
     @pay_customer.update!(owner: team)
-    email = Pay::UserMailer.with(pay_customer: @pay_customer, charge: @charge).refund
+    email = Pay::UserMailer.with(pay_customer: @pay_customer, pay_charge: @charge).refund
 
     assert_equal [team.owner.email], email.to
     assert_equal I18n.t("pay.user_mailer.refund.subject"), email.subject

--- a/test/pay_test.rb
+++ b/test/pay_test.rb
@@ -83,4 +83,25 @@ class Pay::Test < ActiveSupport::TestCase
 
     Pay.enabled_processors = original
   end
+
+  test "can configure email options with a boolean" do
+    Pay.emails.stub :subscription_renewing, true do
+      assert Pay.send_email?(:subscription_renewing)
+      assert Pay.send_email?(:subscription_renewing, "dummy_subscription")
+    end
+
+    Pay.emails.stub :subscription_renewing, false do
+      refute Pay.send_email?(:subscription_renewing)
+    end
+  end
+
+  test "can configure email options with a lambda" do
+    pay_subscription = pay_subscriptions(:fake)
+
+    custom_lambda = ->(subscription) { assert_equal pay_subscription, subscription }
+
+    Pay.emails.stub :subscription_renewing, -> { custom_lambda } do
+      Pay.send_email?(:subscription_renewing, pay_subscription)
+    end
+  end
 end


### PR DESCRIPTION
fixes #234 - This PR allows for the independent configuration of all emails sent out by Pay. These can be configured with a boolean value or a lambda.