### PR TITLE
update mailer to pull ActionMailer default from email address

### DIFF
--- a/app/mailers/pay/application_mailer.rb
+++ b/app/mailers/pay/application_mailer.rb
@@ -1,6 +1,6 @@
 module Pay
   class ApplicationMailer < ActionMailer::Base
-    default from: Pay.support_email
+    default from: Pay.support_email || ApplicationMailer.default_params[:from]
     layout "mailer"
   end
 end


### PR DESCRIPTION
If the pay support_email isn't set, use the applications ActionMailer default from email address instead. 