### PR TITLE
Add stripe receipt url to charge

### DIFF
--- a/app/models/pay/charge.rb
+++ b/app/models/pay/charge.rb
@@ -17,6 +17,7 @@ module Pay
 
     # Store the payment method kind (card, paypal, etc)
     store_accessor :data, :paddle_receipt_url
+    store_accessor :data, :stripe_receipt_url
     store_accessor :data, :stripe_account
 
     # Payment method attributes

--- a/docs/5_charges.md
+++ b/docs/5_charges.md
@@ -72,12 +72,13 @@ The details saved will vary depending upon the payment method used.
 @charge.bank #=> Bank name
 ```
 
-## Paddle
+## Receipt URL
 
-Paddle provides a receipt URL for each payment.
+Paddle and Stripe provide a receipt URL for each payment.
 
 ```ruby
 @charge.paddle_receipt_url
+@charge.stripe_receipt_url
 ```
 
 ## Next

--- a/lib/pay/stripe/charge.rb
+++ b/lib/pay/stripe/charge.rb
@@ -20,6 +20,7 @@ module Pay
           created_at: Time.at(object.created),
           currency: object.currency,
           stripe_account: pay_customer.stripe_account,
+          stripe_receipt_url: object.receipt_url,
           metadata: object.metadata,
           payment_method_type: object.payment_method_details.type,
           brand: payment_method.try(:brand)&.capitalize,

--- a/test/pay/stripe/charge_test.rb
+++ b/test/pay/stripe/charge_test.rb
@@ -115,7 +115,8 @@ class Pay::Stripe::ChargeTest < ActiveSupport::TestCase
       },
       metadata: {
         license_id: 1
-      }
+      },
+      receipt_url: "https://pay.stripe.com/receipts/test_receipt"
     )
     ::Stripe::Charge.construct_from(values)
   end

--- a/test/pay/stripe/charge_test.rb
+++ b/test/pay/stripe/charge_test.rb
@@ -51,7 +51,7 @@ class Pay::Stripe::ChargeTest < ActiveSupport::TestCase
     pay_charge = Pay::Stripe::Charge.sync("123", object: fake_stripe_charge(invoice: fake_stripe_invoice))
     assert_equal "sales_tax", pay_charge.total_tax_amounts.first.dig("tax_rate", "tax_type")
   end
-  
+
   test "sync records stripe receipt_url" do
     pay_charge = Pay::Stripe::Charge.sync("123", object: fake_stripe_charge)
     assert_equal "https://pay.stripe.com/receipts/test_receipt", pay_charge.stripe_receipt_url

--- a/test/pay/stripe/charge_test.rb
+++ b/test/pay/stripe/charge_test.rb
@@ -51,6 +51,11 @@ class Pay::Stripe::ChargeTest < ActiveSupport::TestCase
     pay_charge = Pay::Stripe::Charge.sync("123", object: fake_stripe_charge(invoice: fake_stripe_invoice))
     assert_equal "sales_tax", pay_charge.total_tax_amounts.first.dig("tax_rate", "tax_type")
   end
+  
+  test "sync records stripe receipt_url" do
+    pay_charge = Pay::Stripe::Charge.sync("123", object: fake_stripe_charge)
+    assert_equal "https://pay.stripe.com/receipts/test_receipt", pay_charge.stripe_receipt_url
+  end
 
   private
 

--- a/test/support/fixtures/stripe/charge.succeeded.json
+++ b/test/support/fixtures/stripe/charge.succeeded.json
@@ -18,6 +18,7 @@
         "last4": "4444"
       }
     },
-    "stripe_account": null
+    "stripe_account": null,
+    "receipt_url": "https://pay.stripe.com/receipts/test_receipt"
   }
 }


### PR DESCRIPTION
This adds the receipt url provided by the Stripe API Charge object to Pay's Charge model in a similar fashion to the existing `paddle_receipt_url` 