### PR TITLE
Update docs to use processor_plan keyword for subscribed? methods

### DIFF
--- a/docs/6_subscriptions.md
+++ b/docs/6_subscriptions.md
@@ -113,7 +113,7 @@ Braintree and Paddle require payment methods before creating a subscription.
 You can also check for a specific subscription or plan:
 
 ```ruby
-@user.payment_processor.subscribed?(name: "default", plan: "monthly")
+@user.payment_processor.subscribed?(name: "default", processor_plan: "monthly")
 ```
 
 ## Checking Customer Trial Status
@@ -143,7 +143,7 @@ For paid features of your app, you'll often want to check if the user is on tria
 You can also check for a specific subscription or plan:
 
 ```ruby
-@user.payment_processor.on_trial_or_subscribed?(name: "default", plan: "annual")
+@user.payment_processor.on_trial_or_subscribed?(name: "default", processor_plan: "annual")
 ```
 
 ## Subscription API


### PR DESCRIPTION
When using `#subscribed?` as documented:

```
@user.payment_processor.subscribed?(name: "default", plan: "monthly")
/gems/pay-b17b4ba767fd/app/models/pay/customer.rb:43:in `subscribed?': unknown keyword: :plan (ArgumentError)
```

The keyword looks to be `processor_plan` for `Pay::Customer#subscribed?` and `Pay::Customer#on_trial_or_subscribed?`.

https://github.com/pay-rails/pay/blob/b17b4ba767fdeaf60f5ddb690279bd7b05c28dc7/app/models/pay/customer.rb#L43-L46

https://github.com/pay-rails/pay/blob/b17b4ba767fdeaf60f5ddb690279bd7b05c28dc7/app/models/pay/customer.rb#L55-L58


```
@user.payment_processor.subscribed?(name: "default", processor_plan: "monthly")
false
```
