### PR TITLE
Increment amount_refunded on each refund instead of overwriting it

### DIFF
--- a/lib/pay/stripe/charge.rb
+++ b/lib/pay/stripe/charge.rb
@@ -128,7 +128,7 @@ module Pay
         else
           ::Stripe::Refund.create(options.merge(charge: processor_id, amount: amount_to_refund), stripe_options)
         end
-        pay_charge.update!(amount_refunded: amount_to_refund)
+        pay_charge.update!(amount_refunded: amount_refunded + amount_to_refund)
       rescue ::Stripe::StripeError => e
         raise Pay::Stripe::Error, e
       end


### PR DESCRIPTION
I found a simple bug with a one line patch.

Behavior:
- Create a Stripe Pay::Charge for $30
- Refund $10 of it using `charge.refund!(1000)`
- Refund $10 _again_ of it using `charge.refund!(1000)`
- `charge.amount_refunded` will be `1000`

Expected behavior:
- Because I refunded the charge for 1000 _twice_, the total amount refunded at this point is actually 2000. `charge.amount_refunded` should be `2000`, not `1000`. Looking at the payment in the Stripe dashboard confirms that two separate refunds for $10 each have been processed. 

All we need to do to fix it is increment `amount_refunded` on each refund, not override it.