### PR TITLE
Change SyncCustomer after_update to after_commit

### DIFF
--- a/lib/pay/billable/sync_customer.rb
+++ b/lib/pay/billable/sync_customer.rb
@@ -8,7 +8,7 @@ module Pay
       extend ActiveSupport::Concern
 
       included do
-        after_update :enqeue_customer_sync_job, if: :pay_should_sync_customer?
+        after_commit :enqeue_customer_sync_job, if: :pay_should_sync_customer?
       end
 
       def pay_should_sync_customer?

--- a/lib/pay/billable/sync_customer.rb
+++ b/lib/pay/billable/sync_customer.rb
@@ -8,7 +8,7 @@ module Pay
       extend ActiveSupport::Concern
 
       included do
-        after_commit :enqeue_customer_sync_job, if: :pay_should_sync_customer?
+        after_update_commit :enqeue_customer_sync_job, if: :pay_should_sync_customer?
       end
 
       def pay_should_sync_customer?


### PR DESCRIPTION
`SyncCustomer`'s concern uses an `after_update` callback to sync the customer with the Payment Processor by enqueuing a `CustomerSyncJob`.

This simple PR changes this callback to an `after_commit`. Using an `after_update` here is not recommended for two reasons:

1. If the update's transaction rollbacks for any reason, the job will have be queued already, calling the external API, which is undesired;

2. Sometimes the background processing pipeline is so fast it will process the job even before the transaction is commited; this happens often and is [documented in Sidekiq's wiki](https://github.com/mperham/sidekiq/wiki/Problems-and-Troubleshooting#cannot-find-modelname-with-id12345); we should prefer to only enqueue the job after the transaction commited, so Sidekiq is guaranteed to lookup the most up-to-date database state;