### PR TITLE
Fix opts[:trial_from_plan] not respecting override

### DIFF
--- a/lib/pay/stripe/billable.rb
+++ b/lib/pay/stripe/billable.rb
@@ -110,7 +110,7 @@ module Pay
         }.merge(options)
 
         # Inherit trial from plan unless trial override was specified
-        opts[:trial_from_plan] = true unless opts[:trial_period_days]
+        opts[:trial_from_plan] = opts.fetch(:trial_from_plan, true)
 
         # Load the Stripe customer to verify it exists and update payment method if needed
         opts[:customer] = customer.id


### PR DESCRIPTION
When using `user.payment_processor.subscribe(plan: "xxx", trial_end: timestamp_in_the_future)`, I was getting the following error from Stripe:

> You cannot set `trial_end` or `trial_period_days` when `trial_from_plan=true`.

I then tried to pass `user.payment_processor.subscribe(plan: "xxx", trial_end: timestamp_in_the_future, trial_from_plan: false)`, but still kept getting the error.

Digging further, found a bug that `opts[:trial_from_plan]` will always be true even if you try to override it with false.

This PR makes so you can set `trial_from_plan` to false without it being overwritten to true.