### PR TITLE
Fixes non deterministic customer#subscription

### DIFF
--- a/app/models/pay/customer.rb
+++ b/app/models/pay/customer.rb
@@ -2,7 +2,7 @@ module Pay
   class Customer < Pay::ApplicationRecord
     belongs_to :owner, polymorphic: true
     has_many :charges, dependent: :destroy
-    has_many :subscriptions, dependent: :destroy
+    has_many :subscriptions, -> { order({ id: :asc }) }, dependent: :destroy
     has_many :payment_methods, dependent: :destroy
     has_one :default_payment_method, -> { where(default: true) }, class_name: "Pay::PaymentMethod"
 

--- a/app/models/pay/customer.rb
+++ b/app/models/pay/customer.rb
@@ -2,7 +2,7 @@ module Pay
   class Customer < Pay::ApplicationRecord
     belongs_to :owner, polymorphic: true
     has_many :charges, dependent: :destroy
-    has_many :subscriptions, -> { order({ id: :asc }) }, dependent: :destroy
+    has_many :subscriptions, -> { order({id: :asc}) }, dependent: :destroy
     has_many :payment_methods, dependent: :destroy
     has_one :default_payment_method, -> { where(default: true) }, class_name: "Pay::PaymentMethod"
 

--- a/test/models/pay/customer_test.rb
+++ b/test/models/pay/customer_test.rb
@@ -22,4 +22,50 @@ class Pay::CustomerTest < ActiveSupport::TestCase
   test "update_customer!" do
     assert pay_customers(:fake).respond_to?(:update_customer!)
   end
+
+  test "subscription should be consistent regardless of loaded subscriptions or not" do
+
+    # This test assures a consistent pay_customer#subscription regardless of
+    # pay_customer#subscriptions being previously loaded or not. 
+
+    # Before the introduction of the scope `-> { order({ id: :asc }) }` in
+    # Customer.has_many(:subscriptions), calling customer#subscription was
+    # non-deterministic if the subscriptions were already loaded.
+
+    # That happened because in Postgres, if an order clause is not specified,
+    # the results return in non-deterministic order
+    # (https://stackoverflow.com/questions/6585574/postgres-default-sort-by-id-worldship). 
+
+    # Psql will give the impression of returning records in ascending primary
+    # key (ID) order, but it turns out if you update a previously created
+    # record, it will start appearing first. This is what this test simulates
+    # by updating subscription_1.
+
+    # If that association scope is removed, this test fails in psql only
+    # (see bin/test_databases for multi-db tests).
+
+    @pay_customer = pay_customers(:stripe)
+
+    subscription_1 = create_subscription
+
+    assert_equal @pay_customer.subscription, subscription_1
+
+    subscription_2 = create_subscription(status: "canceled")
+
+    assert_equal @pay_customer.subscription, subscription_2
+
+    assert_equal @pay_customer.subscription, subscription_2
+
+    subscription_1.update_columns(status: "canceled")
+
+    @pay_customer.reload
+
+    assert_not @pay_customer.subscriptions.loaded?
+
+    @pay_customer.subscriptions.load
+
+    assert_equal @pay_customer.subscription, subscription_2
+
+  end
+
 end

--- a/test/models/pay/customer_test.rb
+++ b/test/models/pay/customer_test.rb
@@ -24,9 +24,8 @@ class Pay::CustomerTest < ActiveSupport::TestCase
   end
 
   test "subscription should be consistent regardless of loaded subscriptions or not" do
-
     # This test assures a consistent pay_customer#subscription regardless of
-    # pay_customer#subscriptions being previously loaded or not. 
+    # pay_customer#subscriptions being previously loaded or not.
 
     # Before the introduction of the scope `-> { order({ id: :asc }) }` in
     # Customer.has_many(:subscriptions), calling customer#subscription was
@@ -34,7 +33,7 @@ class Pay::CustomerTest < ActiveSupport::TestCase
 
     # That happened because in Postgres, if an order clause is not specified,
     # the results return in non-deterministic order
-    # (https://stackoverflow.com/questions/6585574/postgres-default-sort-by-id-worldship). 
+    # (https://stackoverflow.com/questions/6585574/postgres-default-sort-by-id-worldship).
 
     # Psql will give the impression of returning records in ascending primary
     # key (ID) order, but it turns out if you update a previously created
@@ -65,7 +64,5 @@ class Pay::CustomerTest < ActiveSupport::TestCase
     @pay_customer.subscriptions.load
 
     assert_equal @pay_customer.subscription, subscription_2
-
   end
-
 end

--- a/test/models/pay/subscription_test.rb
+++ b/test/models/pay/subscription_test.rb
@@ -272,5 +272,4 @@ class Pay::Subscription::Test < ActiveSupport::TestCase
     subscription.update(trial_ends_at: 14.days.from_now)
     refute subscription.generic_trial?
   end
-
 end

--- a/test/models/pay/subscription_test.rb
+++ b/test/models/pay/subscription_test.rb
@@ -273,17 +273,4 @@ class Pay::Subscription::Test < ActiveSupport::TestCase
     refute subscription.generic_trial?
   end
 
-  private
-
-  def create_subscription(options = {})
-    defaults = {
-      name: "default",
-      processor_id: rand(1..999_999_999),
-      processor_plan: "default",
-      quantity: "1",
-      status: :active
-    }
-
-    @pay_customer.subscriptions.create! defaults.merge(options)
-  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -70,6 +70,18 @@ class ActiveSupport::TestCase
     end
   end
 
+  def create_subscription(options = {})
+    defaults = {
+      name: "default",
+      processor_id: rand(1..999_999_999),
+      processor_plan: "default",
+      quantity: "1",
+      status: :active
+    }
+
+    @pay_customer.subscriptions.create! defaults.merge(options)
+  end
+
   def assert_indexed_selects
     subscriber = ActiveSupport::Notifications.subscribe "sql.active_record" do |name, started, finished, unique_id, data|
       if data[:sql].starts_with? "SELECT"


### PR DESCRIPTION
This PR fixes a non-deterministic `pay_customer#subscription` return if using Postgres.

That happened because in Postgres, if an order clause is not specified, the results return in non-deterministic order (https://stackoverflow.com/questions/6585574/postgres-default-sort-by-id-worldship). 

Psql will give the impression of returning records in ascending primary key (ID) order, but it turns out if you update a previously created record, it will start appearing first, before of the records with higher primary key. 

The bug only happened if `pay_customer#subscriptions` were already loaded; if they weren't, it would use `subscriptions.last`, which includes a sort clause in the query, and the bug didn't manifest; however, if they were loaded, for performance reasons, the gem used `subscriptions.reverse.detect {}`, and those already-loaded subscriptions were loaded in non-deterministic order.

The PR adds a default sort clause in the `has_many :subscriptions` association. 

I managed to write a failing test for psql; if you remove the `-> { order({ id: :asc }) }` this PR adds, that test will fail. 

This bug was causing random `pay_customer#subscription` returns depending on webhooks race condition (depending on the time of the subscription update, we'd get a different result as `pay_customer#subscription`. This PR fixes it.