### PR TITLE
Fix Stripe PaymentMethodAttached webhooks not setting `default` attribute

### DIFF
--- a/lib/pay/stripe/payment_method.rb
+++ b/lib/pay/stripe/payment_method.rb
@@ -15,8 +15,14 @@ module Pay
         pay_customer = Pay::Customer.find_by(processor: :stripe, processor_id: object.customer)
         return unless pay_customer
 
-        default_payment_method_id = pay_customer.customer.invoice_settings.default_payment_method
-        default = (id == default_payment_method_id)
+        # Avoid repeated API calls.
+        stripe_customer = pay_customer.customer
+
+        default_payment_method_id = stripe_customer.invoice_settings.default_payment_method
+
+        default_source_id = stripe_customer.default_source
+
+        default = [default_payment_method_id, default_source_id].include?(id)
 
         attributes = extract_attributes(object).merge(default: default, stripe_account: stripe_account)
 

--- a/lib/pay/stripe/webhooks/payment_method_attached.rb
+++ b/lib/pay/stripe/webhooks/payment_method_attached.rb
@@ -4,10 +4,8 @@ module Pay
       class PaymentMethodAttached
         def call(event)
           object = event.data.object
-          pay_customer = Pay::Customer.find_by(processor: :stripe, processor_id: object.customer)
-          return unless pay_customer
 
-          pay_customer.save_payment_method(object, default: false)
+          Pay::Stripe::PaymentMethod.sync(object.id, object: object)
         end
       end
     end

--- a/lib/pay/stripe/webhooks/payment_method_updated.rb
+++ b/lib/pay/stripe/webhooks/payment_method_updated.rb
@@ -6,11 +6,6 @@ module Pay
           object = event.data.object
 
           if object.customer
-            pay_customer = Pay::Customer.find_by(processor: :stripe, processor_id: object.customer)
-
-            # Couldn't find user, we can skip
-            return unless pay_customer.present?
-
             Pay::Stripe::PaymentMethod.sync(object.id, stripe_account: event.try(:account))
           else
             # If customer was removed, we should delete the payment method if it exists

--- a/test/pay/stripe/webhooks/payment_method_attached_test.rb
+++ b/test/pay/stripe/webhooks/payment_method_attached_test.rb
@@ -5,7 +5,10 @@ class Pay::Stripe::Webhooks::PaymentMethodAttachedTest < ActiveSupport::TestCase
     @event = stripe_event("payment_method.attached")
   end
 
-  test "payment_method.detached removes payment method from database" do
+  test "payment_method.attached creates payment method in database" do
+    fake_customer = OpenStruct.new(invoice_settings: OpenStruct.new(default_payment_method: nil))
+    ::Stripe::Customer.expects(:retrieve).returns(fake_customer)
+
     assert_difference "Pay::PaymentMethod.count", 1 do
       Pay::Stripe::Webhooks::PaymentMethodAttached.new.call(@event)
     end


### PR DESCRIPTION
Summary: This PR fixes the `Stripe::Webhooks::PaymentMethodAttached` not setting the `default` attribute correctly when creating the `Pay::PaymentMethod` in the database

Explanation:

Using Stripe's dashboard, you can manually add payment methods to customers, and make them become the default.

I noticed that when adding a Payment Method manually via the Dashboard UI to a customer that didn't have any payment methods before, it would be immediately set as the default payment method (notice the blue "Padrão" tag).

![image](https://user-images.githubusercontent.com/743879/177883558-36ed9baa-cfad-4aba-9137-a8623496b325.png)

However, even tough Pay was creating the `Pay::PaymentMethod`, it's `default` attribute was being set to false.

Digging further, I noticed that:

- The `PaymentMethodAttached` Webhook was using `pay_customer.save_payment_method(object, default :false)`, so it would never become the default payment method due to that `default` param being set to `false`, always!

- I noticed the gem already had a `Pay::Stripe::PaymentMethod.sync`, which also was able to create PaymentMethods, and it already contained logic for setting the `default` attribute correctly based on the Customer default payment method. 

So I refactored the `Stripe::Webhooks::PaymentMethodUpdated` Webhooks to use `Pay::Stripe::PaymentMethod.sync` instead. 

This also increases the codebase consistency, because `Stripe::Webhooks::PaymentMethodUpdated` already used `Pay::Stripe::PaymentMethod.sync` method, so now both of these webhooks use the exact same #sync method (it makes sense: being attached or updated, both of them call the same sync behavior, which handles both scenarios, since it can also create PaymentMethods - it uses `find_or_initialize`).

However, this still didn't fix the issue; in `Pay::Stripe::PaymentMethod.sync`, the logic for setting the `default` attribute was checking if the PaymentMethod `id` matched the customer's `customer.invoice_settings.default_payment_method`. 

However, when you define a PaymentMethod on the Dashboard UI (so, not using the PaymentMethod API), which is something that is supported by Stripe in test and production modes, the customer's `customer.invoice_settings.default_payment_method` stays `nil`, but its `customer.default_source` gets the payment methods id.

This is partially explained in Stripe doc's here https://stripe.com/docs/api/customers/object#customer_object-default_source

So I added logic to `Pay::Stripe::PaymentMethod.sync` to **also** check if the PaymentMethod's id == the customer's default_source, thereby correctly setting the PaymentMethod's default as true. So regardless of being the `default_source` or the `invoice_settings.default_payment_method` it will be correctly be set as default, so it then matches the Dashboard UI setting. 

Lastly, this PR also:

- Removes a needless return early if the Pay::Customer couldn't be found in `Stripe::Webhooks::PaymentMethodUpdated`, because it was already using `Pay::Stripe::PaymentMethod.sync`, which has that exact return early within it, so it was redundant. 

- Fixes a typo in `Pay::Stripe::Webhooks::PaymentMethodAttachedTest`; even tough the file name, event and test content clearly indicated we were testing `PaymentMethodAttached`, the test name was left as a duplication of the payment_method.detached test description, so I fixed it;