### PR TITLE
Ensure Pay::Customer exists when client_reference_id is passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 ### Unreleased
 
+* Support `client_reference_id` on Stripe Checkout Sessions - @excid3 @cjilbert504
+  This is helpful when using the Stripe Pricing Table or any Checkout Session. Requires a Signed GlobalID as the value to prevent tampering.
+
+```ruby
+::Stripe::Checkout::Session.create(
+  mode: "payment",
+  client_reference_id: current_user.to_sgid,
+  ...
+)
+```
+
 ### 4.0.1
 
 * Update `refund!` method in `stripe/charge.rb` to handle multiple refunds on the same charge. - @cjilbert504 @kyleschmolze

--- a/lib/pay/stripe/webhooks/checkout_session_async_payment_succeeded.rb
+++ b/lib/pay/stripe/webhooks/checkout_session_async_payment_succeeded.rb
@@ -1,14 +1,7 @@
 module Pay
   module Stripe
     module Webhooks
-      class CheckoutSessionAsyncPaymentSucceeded
-        def call(event)
-          # TODO: Also handle payment intents
-
-          if event.data.object.subscription
-            Pay::Stripe::Subscription.sync(event.data.object.subscription, stripe_account: event.try(:account))
-          end
-        end
+      class CheckoutSessionAsyncPaymentSucceeded < CheckoutSessionCompleted
       end
     end
   end

--- a/lib/pay/stripe/webhooks/checkout_session_completed.rb
+++ b/lib/pay/stripe/webhooks/checkout_session_completed.rb
@@ -5,9 +5,27 @@ module Pay
         def call(event)
           # TODO: Also handle payment intents
 
-          if event.data.object.subscription
-            Pay::Stripe::Subscription.sync(event.data.object.subscription, stripe_account: event.try(:account))
+          locate_owner(event.data.object)
+
+          if (payment_intent_id = event.data.object.payment_intent)
+            payment_intent = ::Stripe::PaymentIntent.retrieve(payment_intent_id, {stripe_account: event.try(:account)}.compact)
+            payment_intent.charges.each do |charge|
+              Pay::Stripe::Charge.sync(charge.id, stripe_account: event.try(:account))
+            end
           end
+
+          if (subscription_id = event.data.object.subscription)
+            Pay::Stripe::Subscription.sync(subscription_id, stripe_account: event.try(:account))
+          end
+        end
+
+        def locate_owner(object)
+          return if object.client_reference_id.nil?
+
+          # If there is a client reference ID, make sure we have a Pay::Customer record
+          owner = client_id.start_with?("gid://") ? GlobalID::Locator.locate(client_id) : GlobalID::Locator.locate_signed(client_id)
+          owner.add_payment_processor(:stripe, processor_id: object.customer)
+        rescue
         end
       end
     end

--- a/lib/pay/stripe/webhooks/checkout_session_completed.rb
+++ b/lib/pay/stripe/webhooks/checkout_session_completed.rb
@@ -23,7 +23,7 @@ module Pay
           return if object.client_reference_id.nil?
 
           # If there is a client reference ID, make sure we have a Pay::Customer record
-          owner = client_id.start_with?("gid://") ? GlobalID::Locator.locate(client_id) : GlobalID::Locator.locate_signed(client_id)
+          owner = GlobalID::Locator.locate_signed(client_id)
           owner.add_payment_processor(:stripe, processor_id: object.customer)
         rescue
         end


### PR DESCRIPTION
Stripe Checkout Sessions can include a `client_reference_id` to relate it to a record in your application. If this is set as a Signed GlobalID, Pay will now look up the record and make sure that it has a Stripe Pay::Customer record attached.

This is useful for using the new Stripe Pricing Table, or just with any Checkout Session:

```ruby
::Stripe::Checkout::Session.create(
  mode: "payment",
  client_reference_id: current_user.to_sgid,
  ...
)
```

The Pay webhooks will automatically lookup the record using it's Signed GlobalID and ensure they have a Pay::Customer record for Stripe.

cc @cjavdev