### PR TITLE
Update installation doc to v5

### DIFF
--- a/docs/1_installation.md
+++ b/docs/1_installation.md
@@ -7,7 +7,7 @@ Pay's installation is pretty straightforward. We'll add the gems, add some migra
 Add these lines to your application's Gemfile:
 
 ```ruby
-gem "pay", "~> 4.0"
+gem "pay", "~> 5.0"
 
 # To use Stripe, also include:
 gem "stripe", "~> 7.0"


### PR DESCRIPTION
This **very minor** 😅 PR updates the version in the installation docs to v5.0, otherwise it fails when using v4.0 + Stripe v7:

``` sh
$ bin/rails pay:install:migrations
rails aborted!
[Pay] stripe gem must be version ~> 6
.../config/environment.rb:7:in `<main>'
Tasks: TOP => railties:install:migrations => db:load_config => environment
(See full trace by running task with --trace)
```