### PR TITLE
Add current_period_start and current_period_end to Stripe subscriptions

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,24 @@
 
 Follow this guide to upgrade older Pay versions. These may require database migrations and code changes.
 
+## **Pay 5.0 to 6.0**
+This version adds support for accessing the start and end of the current billing period of a subscription. This currently only works with Stripe subscriptions.
+- Adds `current_period_start` and `current_period_end` to `Pay::Subscription`
+
+To upgrade you must add and run the following database migration.
+
+```ruby
+class UpgradeToPayVersion6 < ActiveRecord::Migration[6.0]
+  def change
+    add_column :pay_subscriptions, :current_period_start, :datetime
+    add_column :pay_subscriptions, :current_period_end, :datetime
+  end
+end
+```
+
+Stripe subscriptions created before this upgrade will gain the `current_period_start` and `current_period_end` attributes the next time they are synced. You can manually sync a Stripe subscription by running `Pay::Stripe::Subscription.sync("STRIPE_SUBSCRIPTION_ID")`
+
+
 ## **Pay 3.0 to 4.0**
 
 This is a major change to add Stripe tax support, Stripe metered billing, new configuration options for payment processors and emails, syncing additional customer attributes to Stripe and Braintree, and improving the architecture of Pay.

--- a/db/migrate/1_create_pay_tables.rb
+++ b/db/migrate/1_create_pay_tables.rb
@@ -39,6 +39,8 @@ class CreatePayTables < ActiveRecord::Migration[6.0]
       t.string :processor_plan, null: false
       t.integer :quantity, default: 1, null: false
       t.string :status, null: false
+      t.datetime :current_period_start
+      t.datetime :current_period_end
       t.datetime :trial_ends_at
       t.datetime :ends_at
       t.decimal :application_fee_percent, precision: 8, scale: 2

--- a/lib/pay/stripe/subscription.rb
+++ b/lib/pay/stripe/subscription.rb
@@ -21,6 +21,8 @@ module Pay
         :trial_ends_at,
         :pause_behavior,
         :pause_resumes_at,
+        :current_period_start,
+        :current_period_end,
         to: :pay_subscription
 
       def self.sync(subscription_id, object: nil, name: nil, stripe_account: nil, try: 0, retries: 1)
@@ -40,7 +42,9 @@ module Pay
           subscription_items: [],
           metered: false,
           pause_behavior: object.pause_collection&.behavior,
-          pause_resumes_at: (object.pause_collection&.resumes_at ? Time.at(object.pause_collection&.resumes_at) : nil)
+          pause_resumes_at: (object.pause_collection&.resumes_at ? Time.at(object.pause_collection&.resumes_at) : nil),
+          current_period_start: (object.current_period_start ? Time.at(object.current_period_start) : nil),
+          current_period_end: (object.current_period_end ? Time.at(object.current_period_end) : nil),
         }
 
         # Subscriptions that have ended should have their trial ended at the same time

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -78,6 +78,8 @@ ActiveRecord::Schema.define(version: 2017_02_05_000000) do
     t.string "processor_plan", null: false
     t.bigint "quantity", default: 1, null: false
     t.string "status", null: false
+    t.datetime "current_period_start"
+    t.datetime "current_period_end"
     t.datetime "trial_ends_at"
     t.datetime "ends_at"
     t.decimal "application_fee_percent", precision: 8, scale: 2

--- a/test/pay/stripe/subscription_test.rb
+++ b/test/pay/stripe/subscription_test.rb
@@ -70,6 +70,18 @@ class Pay::Stripe::SubscriptionTest < ActiveSupport::TestCase
     end
   end
 
+  test "sync stripe subscription sets current_period_start" do
+    fake_subscription = fake_stripe_subscription(current_period_start: 1488987924)
+    pay_subscription = Pay::Stripe::Subscription.sync("123", object: fake_subscription)
+    assert_not_nil pay_subscription.current_period_start
+  end
+
+  test "sync stripe subscription sets current_period_end" do
+    fake_subscription = fake_stripe_subscription(current_period_end: 1488987924)
+    pay_subscription = Pay::Stripe::Subscription.sync("123", object: fake_subscription)
+    assert_not_nil pay_subscription.current_period_end
+  end
+
   test "sync stripe subscription sets ends_at when canceling at period end" do
     fake_subscription = fake_stripe_subscription(cancel_at_period_end: true)
     pay_subscription = Pay::Stripe::Subscription.sync("123", object: fake_subscription)


### PR DESCRIPTION
This adds support for storing and reading `current_period_start` and  `current_period_end` on Stripe subscriptions. This is based on discussion https://github.com/pay-rails/pay/discussions/693.

Hoping to get feedback on this initial implementation.

- How do this Stripe implementation look?
- Is this how you would expect to handle the upgrade / db migration (i.e. just update `1_create_pay_tables.rb` directly and include a migration script in the upgrade documentation?)
- Tests sufficient?
- Would you want to add support for this in `fake_processor`?
- I'm not familiar with Braintree or Paddle but can look into it if you think it is required and no one else is available to.

Thanks!
