### PR TITLE
Remove deprecation warning for legacy connection handling

### DIFF
--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -13,6 +13,6 @@ module Dummy
 
     config.active_job.queue_adapter = :test
     config.action_mailer.default_url_options = {host: "localhost", port: 3000}
-    config.active_record.legacy_connection_handling = false
+    config.active_record.legacy_connection_handling = false if ("6.1".."7.0.4").cover?(Rails.version)
   end
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -4,7 +4,6 @@ require "rails/all"
 
 Bundler.require(*Rails.groups)
 require "pay"
-require "pp"
 
 module Dummy
   class Application < Rails::Application
@@ -13,7 +12,7 @@ module Dummy
     # -- all .rb files in that directory are automatically loaded.
 
     config.active_job.queue_adapter = :test
-    config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+    config.action_mailer.default_url_options = {host: "localhost", port: 3000}
     config.active_record.legacy_connection_handling = false
   end
 end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -14,5 +14,6 @@ module Dummy
 
     config.active_job.queue_adapter = :test
     config.action_mailer.default_url_options = { host: "localhost", port: 3000 }
+    config.active_record.legacy_connection_handling = false
   end
 end


### PR DESCRIPTION
Fixes this deprecation warning that is being triggered when running tests

![image](https://user-images.githubusercontent.com/52426811/202927090-2b75056d-3c43-4013-9b4d-c36a7075722a.png)

@andrewmcodes
@xspynks
@Eduardo06sp
@cjilbert504