### PR TITLE
Add clarity for flow of syncing attributes

### DIFF
--- a/docs/1_installation.md
+++ b/docs/1_installation.md
@@ -106,7 +106,7 @@ Pay will include attributes when creating a Customer and update them when the Cu
 
 ### Syncing attributes
 
-By adding `pay_customer` to your model, the `Pay::Billable::SyncCustomer` concern will be included. It's responsible for syncing your customer's data with your payment processor in an `after_commit` callback if the method `pay_should_sync_customer?` returns `true`.
+By adding `pay_customer` to your model, the `Pay::Billable::SyncCustomer` concern will be included. It's responsible for syncing your customer's data from your application to the payment processor in an `after_commit` callback if the method `pay_should_sync_customer?` returns `true`.
 
 By default, `pay_should_sync_customer?` will respond with `saved_change_to_email?`, which means Pay will automatically sync your customer with your payment processor when it's e-mail changes.
 


### PR DESCRIPTION
Previously, it read a bit vaguely as to which direction customer attributes are syncing. This update hopefully provides a clearer description of which direction the sync flows.