### PR TITLE
Sort subscriptions by created_at instead of id, to work with uuids.

### DIFF
--- a/app/models/pay/customer.rb
+++ b/app/models/pay/customer.rb
@@ -46,7 +46,7 @@ module Pay
     end
 
     def subscription(name: Pay.default_product_name)
-      subscriptions.order(id: :desc).for_name(name).first
+      subscriptions.order(created_at: :desc).for_name(name).first
     end
 
     def subscribed?(name: Pay.default_product_name, processor_plan: nil)


### PR DESCRIPTION
When a project uses UUIDs for the table ids (`create_table "pay_subscriptions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|`), the current method of sorting the subscriptions by id will cause issues. 

For example, I have two subscriptions... Subscription 1 (has a uuid id of "942c38ef-b0df-43ac-bd85-f37d87efa643") was canceled. Subscription 2 (has a uuid of "0dca7550-ca58-49c2-87e1-2917e4e373f5") is active.

Subscription 2 should be returned when `.subscription` is called, but because the sort is id: :desc, it's returning Subscription 1.

IRB snippets:
```
irb(main):059:0> u.payment_processor.subscriptions
  Pay::Subscription Load (9.3ms)  SELECT "pay_subscriptions".* FROM "pay_subscriptions" WHERE "pay_subscriptions"."customer_id" = $1  [["customer_id", "0b2b48f2-ee13-42e1-8256-ebba29624e4e"]]
=> 
[#<Pay::Subscription:0x00007fe3d9f8e818
  id: "942c38ef-b0df-43ac-bd85-f37d87efa643",
  customer_id: "0b2b48f2-ee13-42e1-8256-ebba29624e4e",
  name: "default",
  processor_id: "sub_1MELkTLQgc8mxvfY5JpXFfos",
  processor_plan: "price_1MCQX7LQgc8mxvfYMxT5nsbt",
  quantity: 1,
  status: "canceled",
  trial_ends_at: nil,
  ends_at: Mon, 12 Dec 2022 23:52:09.000000000 UTC +00:00,
  application_fee_percent: nil,
  metadata: {},
  data:
   {"metered"=>false,
    "subscription_items"=>
     [{"id"=>"si_MyILKOxBC9kg2Z",
       "price"=>
        {"id"=>"price_1MCQX7LQgc8mxvfYMxT5nsbt",
         "type"=>"recurring",
         "active"=>true,
         "object"=>"price",
         "created"=>1670430705,
         "product"=>"prod_MjFIwK26sQBZmx",
         "currency"=>"usd",
         "livemode"=>false,
         "metadata"=>{},
         "nickname"=>"Pro Quarterly",
         "recurring"=>{"interval"=>"month", "usage_type"=>"licensed", "interval_count"=>3, "aggregate_usage"=>nil, "trial_period_days"=>nil},
         "lookup_key"=>nil,
         "tiers_mode"=>nil,
         "unit_amount"=>4000,
         "tax_behavior"=>"unspecified",
         "billing_scheme"=>"per_unit",
         "custom_unit_amount"=>nil,
         "transform_quantity"=>nil,
         "unit_amount_decimal"=>"4000"},
       "metadata"=>{},
       "quantity"=>1}]},
  created_at: Mon, 12 Dec 2022 23:49:31.462673000 UTC +00:00,
  updated_at: Tue, 13 Dec 2022 16:52:33.061619000 UTC +00:00,
  prorate: true>,
 #<Pay::Subscription:0x00007fe3d9f8d710
  id: "0dca7550-ca58-49c2-87e1-2917e4e373f5",
  customer_id: "0b2b48f2-ee13-42e1-8256-ebba29624e4e",
  name: "default",
  processor_id: "sub_1MEbZOLQgc8mxvfYOiQmQUA9",
  processor_plan: "price_1MCQECLQgc8mxvfYBKN9RfoZ",
  quantity: 1,
  status: "active",
  trial_ends_at: nil,
  ends_at: nil,
  application_fee_percent: nil,
  metadata: {},
  data:
   {"metered"=>false,
    "subscription_items"=>
     [{"id"=>"si_MyYgFV0xe0UBpL",
       "price"=>
        {"id"=>"price_1MCQECLQgc8mxvfYBKN9RfoZ",
         "type"=>"recurring",
         "active"=>true,
         "object"=>"price",
         "created"=>1670429532,
         "product"=>"prod_MjFIwK26sQBZmx",
         "currency"=>"usd",
         "livemode"=>false,
         "metadata"=>{},
         "nickname"=>"Pro Monthly",
         "recurring"=>{"interval"=>"month", "usage_type"=>"licensed", "interval_count"=>1, "aggregate_usage"=>nil, "trial_period_days"=>nil},
         "lookup_key"=>nil,
         "tiers_mode"=>nil,
         "unit_amount"=>1500,
         "tax_behavior"=>"unspecified",
         "billing_scheme"=>"per_unit",
         "custom_unit_amount"=>nil,
         "transform_quantity"=>nil,
         "unit_amount_decimal"=>"1500"},
       "metadata"=>{},
       "quantity"=>1}]},
  created_at: Tue, 13 Dec 2022 16:43:08.951331000 UTC +00:00,
  updated_at: Tue, 13 Dec 2022 16:52:31.610170000 UTC +00:00,
  prorate: true>]
```

`.subscription` returning the incorrect subscription due to sorting by id instead of created_at:
```
irb(main):058:0> u.payment_processor.subscription
  Pay::Subscription Load (1.2ms)  SELECT "pay_subscriptions".* FROM "pay_subscriptions" WHERE "pay_subscriptions"."customer_id" = $1 AND "pay_subscriptions"."name" = $2 ORDER BY "pay_subscriptions"."id" DESC LIMIT $3  [["customer_id", "0b2b48f2-ee13-42e1-8256-ebba29624e4e"], ["name", "default"], ["LIMIT", 1]]
=> 
#<Pay::Subscription:0x00007fe3d2e593f0
 id: "942c38ef-b0df-43ac-bd85-f37d87efa643",
 customer_id: "0b2b48f2-ee13-42e1-8256-ebba29624e4e",
 name: "default",
 processor_id: "sub_1MELkTLQgc8mxvfY5JpXFfos",
 processor_plan: "price_1MCQX7LQgc8mxvfYMxT5nsbt",
 quantity: 1,
 status: "canceled",
 trial_ends_at: nil,
 ends_at: Mon, 12 Dec 2022 23:52:09.000000000 UTC +00:00,
 application_fee_percent: nil,
 metadata: {},
 data:
  {"metered"=>false,
   "subscription_items"=>
    [{"id"=>"si_MyILKOxBC9kg2Z",
      "price"=>
       {"id"=>"price_1MCQX7LQgc8mxvfYMxT5nsbt",
        "type"=>"recurring",
        "active"=>true,
        "object"=>"price",
        "created"=>1670430705,
        "product"=>"prod_MjFIwK26sQBZmx",
        "currency"=>"usd",
        "livemode"=>false,
        "metadata"=>{},
        "nickname"=>"Pro Quarterly",
        "recurring"=>{"interval"=>"month", "usage_type"=>"licensed", "interval_count"=>3, "aggregate_usage"=>nil, "trial_period_days"=>nil},
        "lookup_key"=>nil,
        "tiers_mode"=>nil,
        "unit_amount"=>4000,
        "tax_behavior"=>"unspecified",
        "billing_scheme"=>"per_unit",
        "custom_unit_amount"=>nil,
        "transform_quantity"=>nil,
        "unit_amount_decimal"=>"4000"},
      "metadata"=>{},
      "quantity"=>1}]},
 created_at: Mon, 12 Dec 2022 23:49:31.462673000 UTC +00:00,
 updated_at: Tue, 13 Dec 2022 16:52:33.061619000 UTC +00:00,
 prorate: true>
```

Hope this helps. I'll try to add some test coverage when I get a chance.
