### PR TITLE
Add braintree subscription sync method

### DIFF
--- a/lib/pay/braintree/webhooks/subscription_canceled.rb
+++ b/lib/pay/braintree/webhooks/subscription_canceled.rb
@@ -8,15 +8,7 @@ module Pay
           subscription = event.subscription
           return if subscription.nil?
 
-          pay_subscription = Pay::Subscription.find_by_processor_and_id(:braintree, subscription.id)
-          return unless pay_subscription.present?
-
-          ends_at = Time.current
-          pay_subscription.update!(
-            status: :canceled,
-            trial_ends_at: (ends_at if pay_subscription.trial_ends_at?),
-            ends_at: ends_at
-          )
+          Pay::Braintree::Subscription.sync(subscription.id)
         end
       end
     end

--- a/lib/pay/braintree/webhooks/subscription_expired.rb
+++ b/lib/pay/braintree/webhooks/subscription_expired.rb
@@ -8,10 +8,7 @@ module Pay
           subscription = event.subscription
           return if subscription.nil?
 
-          pay_subscription = Pay::Subscription.find_by_processor_and_id(:braintree, subscription.id)
-          return unless pay_subscription.present?
-
-          pay_subscription.update!(ends_at: Time.current, status: :canceled)
+          Pay::Braintree::Subscription.sync(subscription.id)
         end
       end
     end

--- a/lib/pay/braintree/webhooks/subscription_trial_ended.rb
+++ b/lib/pay/braintree/webhooks/subscription_trial_ended.rb
@@ -8,10 +8,7 @@ module Pay
           subscription = event.subscription
           return if subscription.nil?
 
-          pay_subscription = Pay::Subscription.find_by_processor_and_id(:braintree, subscription.id)
-          return unless pay_subscription.present?
-
-          pay_subscription.update!(trial_ends_at: Time.current)
+          Pay::Braintree::Subscription.sync(subscription.id)
         end
       end
     end

--- a/lib/pay/braintree/webhooks/subscription_went_active.rb
+++ b/lib/pay/braintree/webhooks/subscription_went_active.rb
@@ -8,10 +8,7 @@ module Pay
           subscription = event.subscription
           return if subscription.nil?
 
-          pay_subscription = Pay::Subscription.find_by_processor_and_id(:braintree, subscription.id)
-          return unless pay_subscription.present?
-
-          pay_subscription.update!(status: :active)
+          Pay::Braintree::Subscription.sync(subscription.id)
         end
       end
     end

--- a/lib/pay/braintree/webhooks/subscription_went_past_due.rb
+++ b/lib/pay/braintree/webhooks/subscription_went_past_due.rb
@@ -8,10 +8,7 @@ module Pay
           subscription = event.subscription
           return if subscription.nil?
 
-          pay_subscription = Pay::Subscription.find_by_processor_and_id(:braintree, subscription.id)
-          return unless pay_subscription.present?
-
-          pay_subscription.update!(status: :past_due)
+          Pay::Braintree::Subscription.sync(subscription.id)
         end
       end
     end

--- a/test/pay/braintree/webhooks/subscription_canceled_test.rb
+++ b/test/pay/braintree/webhooks/subscription_canceled_test.rb
@@ -5,17 +5,8 @@ class Pay::Braintree::Webhooks::SubscriptionCanceledTest < ActiveSupport::TestCa
     @event = braintree_event "subscription_cancelled"
   end
 
-  test "it sets ends_at on the subscription" do
-    pay_customer = pay_customers(:braintree)
-    pay_customer.update(processor_id: @event.subscription.transactions.first.customer_details.id)
-    subscription = pay_customer.subscriptions.create!(
-      processor_id: @event.subscription.id,
-      name: "default",
-      processor_plan: "some-plan",
-      status: "active"
-    )
-
+  test "braintree syncs subscription on cancelled webhook" do
+    Pay::Braintree::Subscription.expects(:sync)
     Pay::Braintree::Webhooks::SubscriptionCanceled.new.call(@event)
-    assert subscription.reload.cancelled?
   end
 end

--- a/test/pay/braintree/webhooks/subscription_trial_ended_test.rb
+++ b/test/pay/braintree/webhooks/subscription_trial_ended_test.rb
@@ -5,20 +5,8 @@ class Pay::Braintree::Webhooks::SubscriptionTrialEndedTest < ActiveSupport::Test
     @event = braintree_event "subscription_trial_ended"
   end
 
-  test "updates subscription trial end" do
-    pay_customer = pay_customers(:braintree)
-
-    pay_subscription = pay_customer.subscriptions.create!(
-      processor_id: @event.subscription.id,
-      name: "default",
-      processor_plan: "some-plan",
-      status: "active",
-      trial_ends_at: 14.days.from_now
-    )
-
-    freeze_time do
-      Pay::Braintree::Webhooks::SubscriptionTrialEnded.new.call(@event)
-      assert_equal Time.current, pay_subscription.reload.trial_ends_at
-    end
+  test "braintree syncs subscription on trial ended webhook" do
+    Pay::Braintree::Subscription.expects(:sync)
+    Pay::Braintree::Webhooks::SubscriptionCanceled.new.call(@event)
   end
 end

--- a/test/vcr_cassettes/test_braintree_sync_active_subscription.yml
+++ b/test/vcr_cassettes/test_braintree_sync_active_subscription.yml
@@ -1,0 +1,307 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/customers
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <customer>
+          <email>none@example.org</email>
+          <first-name>None</first-name>
+          <last-name>User</last-name>
+          <payment-method-nonce>fake-valid-visa-nonce</payment-method-nonce>
+        </customer>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:11:09 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"e20a7c1dbbcdaffdf3874be328db35a8"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.522012'
+      X-Request-Id:
+      - 2a128b59-61ef-4c2d-8b2e-07195c238197
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - 2a128b59-61ef-4c2d-8b2e-07195c238197
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - 2be1a907ac4e4
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAB2NoGMAA7RY227bOBB971cYfldkyU5iF466CxQJtkACLNqkaV4KWqRtxRKpkpRj+es7pG6UZcnypgv4wZw5HJJz4Rxx/mkXhYMt4SJg9GboXIyGA0J9hgO6uhk+fru1psNP3oe5nwjJIsK9D4PBPMDe5dgZX19dja/nNoyUEJT+GlFpwXifLt/ivUyj11/Y9y9Xc9vUKvQy4EJaFEXEe2CUzG1DoPQhKkaPgvC5XY2V1mdRjGg6oEF4M5Q8IUNby0mEgtCjYPAvskNRHJILxmH1TK4Q8RqUjXlLtGvI3shCBLKJ9TlBkmALyYFMY3IzxDCUQUSGnjtyXcuB3+ybc/XRcT6OZi9zu5qg5ycxPm9+NSFbX0fCWgYkxCLb0ipkCxQq1/4YP+3x3Uy+PH9ZPny7393vfffh9X48tytMfggcSMtHHIt8G4hzlA6Vtq7PJCBbBGEIWWEhjDkRopBn+RDjIhFyWZEwVj1ZTHEFroJ/6O4cUIa/Rd+SELlWSE6ILDbeAiI7SShWfu6EhcxHYSDbluJkBYXUooyZkBADqC7izSbOCPxhiszjJFTyVIstFMZr5LYe/BA57oOkCcQg8E9AOxyu60iZWRDeZuV9hZJbeWe5aBt2S+pCSlNvMnLc6VRhaClXeW+p5bynQCDYWTk2EWsWYsjkNi+ppFTXXoBC75FuKHujYKmSVbDM22xpBUIkiPrExDeV5cT3O/iMMq2gfa6bI+CGHVVKEqrFe/xqTCilBR6TRSArj2TDSrlESVg4YMFYSBAdeioSCqqVFTjhEGULajQJlSMMo4eaYgrZxQHX+7EiRuXac1xoJ4fCI+iUIK7CMK7BtbSGJvhw70sUCpLPMnZSOdK/u71cfH9K8J0T4rv19uV29vrDme3Ic+jeP29S8u/Bda/nrwkK5Rry1sguQ1bAggitiJXw0FtLGYuPto2EIFJcLDgKqLpIV+CgN5ReQCrbMUojQuXPiMg1wz9DtmL2FkrmIqarT4RuA86oAtwIRPGC7aBJlPbLFSGvVXEuEN1UW6tJC6huAxPPmU6dnBJMSh1shbPQKLVCUAI4iRE45IGBLv9f6RhOfM1OqvmVrICJZCF8HsQqlvW+WVW9ZBtCvV9punVSN53b2bjQJjT4lRQXJ5gG3wTQyrlHiONeThbXExdNZwtMxqMlvp5gBxN3gsYTuIRap5a2/8BVuSU0YpbAm5asLPXGDA7byGr2GJdogCqxbs1IJsLL9ARIRC4wMf52C5UpYrBPsk55D/dFQ2hOQVthEc4Zr2OOd6ocb7Ti5nLdgENTdcJxAP4ns9aJMQ3m9QaIV+LrWwSucdFGMkwmjnzdPlQGQzEYJNxQmBMh433Yy6HXPGc0Gul6OKo9YUECsfL+jkGzVfFtQ9RciIF8wkHB2U14ewwjdSZvdKE2mw9qaZRwDp82KTRSlu388etn1XgOxacOpHgA6jyQwRS0FbmGWFvYEgRWI1ZAl6z1GBATHklnL9wDSl1RcFPWgz1r0AkGnXmoi0VrRB8mrYH92HS2s05GrSFdrDoLU09mnR/zFL01OGM9hZqfRbmm89Yvo3eUbZoBOt7bitVPsdLS92dwluac08yl2M95RM44xQnmnCP/x16Zr1Dcg9qJWXDh6jCFdfw7OVhupYOI5Ih+XC0Hd/HjAnI28S2C1esTpjjXCQaWw/rzvXIT/+0DqXR3H26noXZLgZ/3qTVt+Zb9MxRN26FEvjG+sSRHVKCMFcBZRsqI4zoz58pxRrO53YI7Zqre1J+fq8nt7b6B0K1c6Je3Qa4clI1bKY9YbbT/qm5w9JSi7y/xD/d2hL7PkufxF4k/3175+y+bo/WlCGqTadal1ed/IKzSQeq+DvatX2PHoPlb2WHS1AR6sXneBMnRt7bDR4nGa9o5H+ndXKCbBXT1/x6dv1fP7+z2HX2+Z4fv+3LW992s96vZSVJx8sXsjzznvPt+gfZXpWM5IDCs8s378BsAAP//AwC7DFhJNhgAAA==
+  recorded_at: Mon, 19 Dec 2022 16:11:09 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/subscriptions
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <subscription>
+          <payment-method-token>qyyv1y2y</payment-method-token>
+          <plan-id>default</plan-id>
+        </subscription>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:11:10 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"962a19027d81f0b2bd4f1ce1fd57a740"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '1.121026'
+      X-Request-Id:
+      - 98e491f2-143f-44e6-8286-4ca317602f71
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - 98e491f2-143f-44e6-8286-4ca317602f71
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - b7fcdfed72444
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAB6NoGMAA+Qa23LbNva9X6HROy1Rki/KyEy92yabztjd5lY7Lx6QhETYJMCAoCzl6/eA4AUkAUqO087urCeTkc4NwMG5Q6vXuyQebTHPCKOXY/dkOh5hGrCQ0M3l+NPHN87F+LX30yrL/SzgJBVA5v00Gq1QGDqMZiOxT/HlGHGO9uNJgfFRjGiAvenJdLqaVN8KDIljkOuEaO+wtZMwKqJSAKECbzAfe+4SeAx0LQEp5oSFDqYh0AhcypAfx95sOps7U9dxLxpBHXqTrEwgLozSZo4L/5Y9aQ1HIS/gGD6GDhKaAEGSlpCP7tkr133lTr+sJg1DwZ+n4fP4Gwa1fs45psKpdhnsgxj3tAvLmugKCaDuzElRBofK8YiS+HIseI7Law1JFrCcCtOVrxGJc46dgqC7JhhBC684CM+aPQyqvU9aSCChF31bR2t/NYGPEpJgHkQIjoaCYiEH4CnaryYmhGSgGAzfwbuUcFwdy2csxoiOPXn01aRFUjLt1G4clBTHcZWh9+AtYs1uLGx9ip4Au60vO4JqLdE88eEA4EWt+85615siEjoi4izfRMNO1aMs+feJNKsEiwiOINgjpt7X/X7r7md7yWRAF3wQHuR9hHiN8lgAZQkokJxA6Cg1pb5IMHieyDPvKhBkC3dUfpUYwQmKwXw5koGqa4nnq0mbwMDj5JQIL5RmY0I0DOquulazRnGGK1ZForwHq/DJuPwqLwYlPR+TJ44YNcFzHveubNIWWq8hT96lFRzRDAUS13bgUr6GVxDlYe566qdnT7WPFfBS35ASEiIgAt2vGb/PsBAxlnesX4iSDct5GYqlXuTHCq4iUbB3SMYgNITY+/ThlypA6eCKoe05jZdoSIfjrznOYFd9JX5HiFDnzX3HgDcvAOET/O1YcsZDoLYgn5NRpsteRlF287KsUt5TJhicqAIo0zidu/Pzs7P5uW4bdWSX5u3dgC1X8bsANFQxqmCfMsxXk+Z7QxOwJEV0b9INYHECScWjsMTPeIeSNMYnjG9WEwVv6J6wnxFh8Kkhf1MnQTsLZhMzqGukjdzNP38L3y7Fl9vf1jcfr3fX34LZzcP1fDVpaCo9TrqKrGqQtmLT0KpRy3Zq5Vnww4rMBMcYLDUMIcX1EkOl7Z2A6knaxSBZzAIUE2FbiuONIThVV8EgbsTK45cLdwqGpYP044BH8f3wiRWJ5HRQnEZodjTl/BhKyKsQ3AOj30461wrHXudQelrcvMYaKiuNAHSvBWmbsBRqUpl6mnDc4bItgnJIzJx8O24ZTbyPRBBZ6SKSpl0Lt7nb/52ZHzC0/1r77t5qmSGcNcFxmGk2VSY/ab6y9NQMy1I3DXA0UreZgzlnHHJ9lkI9g63KLGg1hbc5vGtYcJBAF9O2nw7hOyVpkKZW1nbb5+4DK/INpOMnaIQ5fsDKJyHLZ2bzgoKZBbAy6KbyZ1W7FhLdP+ZfbpaykB4g6ktqb8udqlrcjB3gFuBb3lUKmC0OjRIKilrlYUjkrmQZ3SM1nn3LoD8AkjUYB3CpzsespVxWZ7CiKr8GKAXald2YFY13OEmFrQ+oCZqQGKASpO5yqFwtTw7x6ImIyKFYPDH+qLony4pDLHplCdp1AsT1OqPbs7V4imqFeoupO7soJiu0G5kXnntx4Zal3EIPLLCMU1T+n0mGwNbr73rghQ5bmaEa97gzKOW6QCP9HiNeNKgthgKq7aEsvRwZuotw8ulDU5A10PauIxYXBmIPxCRBG+xAd+ZFQqTZq8kEgfJFduJzBH0nhIPSf08gO1Vd8L3qgu9jtmGTLejkJKWb15huCWdUElxmiIY+20EhWMvX1sza1yqTtsUaTKR6LuJYdvNQqEvDUZ8bbIRRLCLQAxTp9JGyJ7qaaLCGMMQ+tMY1jfqqoXMO5gKmvslj2VtolF1MK5nLJgpqmYZcg2lnQHvOYo2qAugKy3KZTXxEHxu6FrSfBtnakRTF8FLbQR+pq5OFeVD0js1uGpipfwjevjn1//ych2/dOHwbbb+8WT7cucsdvo1n17ePe/yHoZPQUqu8dotp5pRAbCmjG3CDXRHI0NzD2J2dLvzzxQxdLP0Qz6fr8HwRuiGeLdB8AR5qZW2kbzFNmJOFjxbLq/GGTZczYXNxYYhN5cTBiQi4K98b5hc6FYalNfOTgQ36XUAm6ZE9cE3fklJONZpCuTvoUGccmFGoa4F+13uQGfzn4n/IRJziTMYHUHymK7k9l3EyBnkLexzLCQlYrhwz9bCNOiZmffxNajp2OvS/oLQaWhpgk58HhpdKGdqziaNNrLtwE30r8/6wdw+zxJe+fpRaMuze/lBUYAdeFRS+MzctgAP5eGieY5ihqn33F1nV9mJ+FqjRTUkVIUqxeQGwz62sTdcYD1WTchfsyVG2ZqQAbfk5z1TjHWKBSKw5UgeNrEMvrXu3b6dN1xvKPoMF76RyoIzhR23Jl5X5s5hltwjOCc2nTXoeBJZuHm5/QKlSpWkusHVqEkRQvYic07o3OTRgUeUpCh+g9pRL2uirFxNCoavM1SRH1swqP97L/Ng8q3SJ+n2YpuB2y6a3Ylai4+QVDdwhea0urypO26vd3srnLBPGyldIzYox8KhEjupuUSINEls7ERHU6g7ENenZGBS6ZtaJVuasOUucA5Ocevg15PNV/BuiqSv41lzOm8ro7M7cpXvmutNlc8AO3VBPLm0FDfbkujW1Tbh8FB16Wpid6c8TNnYt6MraemgQKjg5bkBZDlXr0tnuZYPz0oP8xtlszWWeSZknrcNMTQ8Q/uu3yKc30d38ferPTtfXf9493dGrWTh7Z3p0UDo94hx91Q7vSHFsgaAYuUCwrhoG6N3ni9Ozc5kmrTSGCGp1JBndUByrrGJ1E43q4G0dRVu6AE62Mpki82UGX3MwY9474PDzY9VSqalDR28Xy6mcfhwgrgMX5gmhxT2ZyKbqz4W6d5iwt8fiNe6XXz/88/27f3/8/f3N1fWv2qb0tzrtWVVNPlvdhj4S9WQp3QJoQ6RyqO79oxqdrCY1rCFTw3Xv+kqa16ZdJ+vvRdOZe7GwPSEVZaJ3Wv8BXQGpiwLbiVYQ0J0tlMDQDtuGLjqJVsj60NVWqWlg2CcTRmLzhCrfQ/2JSap3dZbH+heEjoN92bMf8F86Vv4Rg+XRDxySf5+3DPrLczzmaJ8Z9ppn+M1hzxnynb8mAP74EDiy/mTl+/3/OP/Wir3ODoeeC48Yrxew1pRehzxzQmcMQq25igS1AOrXWQfHeMbZ1MvnUvYfjBXYo4dL7XFOOTtCKenMc9pDJfvvYUurMP3ETV3ac38fNTyO6s+2+nOt7gznPwAAAP//AwAxlBe5HywAAA==
+  recorded_at: Mon, 19 Dec 2022 16:11:10 GMT
+- request:
+    method: get
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/subscriptions/hzfhfb
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:11:11 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"a3a481f2fa544309e588f5ee4a2e213f"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.206898'
+      X-Request-Id:
+      - 5afcf501-984a-42eb-b3d9-027d20a08961
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - 5afcf501-984a-42eb-b3d9-027d20a08961
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - c6737f84e5af4
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAB6NoGMAA+Qa23LbNva9X6HROy1Rki/KyEy92yabztjd5lY7Lx6QhETYJMCAoCzl6/eA4AUkAUqO087urCeTkc4NwMG5Q6vXuyQebTHPCKOXY/dkOh5hGrCQ0M3l+NPHN87F+LX30yrL/SzgJBVA5v00Gq1QGDqMZiOxT/HlGHGO9uNJgfFRjGiAvenJdLqaVN8KDIljkOuEaO+wtZMwKqJSAKECbzAfe+4SeAx0LQEp5oSFDqYh0AhcypAfx95sOps7U9dxLxpBHXqTrEwgLozSZo4L/5Y9aQ1HIS/gGD6GDhKaAEGSlpCP7tkr133lTr+sJg1DwZ+n4fP4Gwa1fs45psKpdhnsgxj3tAvLmugKCaDuzElRBofK8YiS+HIseI7Law1JFrCcCtOVrxGJc46dgqC7JhhBC684CM+aPQyqvU9aSCChF31bR2t/NYGPEpJgHkQIjoaCYiEH4CnaryYmhGSgGAzfwbuUcFwdy2csxoiOPXn01aRFUjLt1G4clBTHcZWh9+AtYs1uLGx9ip4Au60vO4JqLdE88eEA4EWt+85615siEjoi4izfRMNO1aMs+feJNKsEiwiOINgjpt7X/X7r7md7yWRAF3wQHuR9hHiN8lgAZQkokJxA6Cg1pb5IMHieyDPvKhBkC3dUfpUYwQmKwXw5koGqa4nnq0mbwMDj5JQIL5RmY0I0DOquulazRnGGK1ZForwHq/DJuPwqLwYlPR+TJ44YNcFzHveubNIWWq8hT96lFRzRDAUS13bgUr6GVxDlYe566qdnT7WPFfBS35ASEiIgAt2vGb/PsBAxlnesX4iSDct5GYqlXuTHCq4iUbB3SMYgNITY+/ThlypA6eCKoe05jZdoSIfjrznOYFd9JX5HiFDnzX3HgDcvAOET/O1YcsZDoLYgn5NRpsteRlF287KsUt5TJhicqAIo0zidu/Pzs7P5uW4bdWSX5u3dgC1X8bsANFQxqmCfMsxXk+Z7QxOwJEV0b9INYHECScWjsMTPeIeSNMYnjG9WEwVv6J6wnxFh8Kkhf1MnQTsLZhMzqGukjdzNP38L3y7Fl9vf1jcfr3fX34LZzcP1fDVpaCo9TrqKrGqQtmLT0KpRy3Zq5Vnww4rMBMcYLDUMIcX1EkOl7Z2A6knaxSBZzAIUE2FbiuONIThVV8EgbsTK45cLdwqGpYP044BH8f3wiRWJ5HRQnEZodjTl/BhKyKsQ3AOj30461wrHXudQelrcvMYaKiuNAHSvBWmbsBRqUpl6mnDc4bItgnJIzJx8O24ZTbyPRBBZ6SKSpl0Lt7nb/52ZHzC0/1r77t5qmSGcNcFxmGk2VSY/ab6y9NQMy1I3DXA0UreZgzlnHHJ9lkI9g63KLGg1hbc5vGtYcJBAF9O2nw7hOyVpkKZW1nbb5+4DK/INpOMnaIQ5fsDKJyHLZ2bzgoKZBbAy6KbyZ1W7FhLdP+ZfbpaykB4g6ktqb8udqlrcjB3gFuBb3lUKmC0OjRIKilrlYUjkrmQZ3SM1nn3LoD8AkjUYB3CpzsespVxWZ7CiKr8GKAXald2YFY13OEmFrQ+oCZqQGKASpO5yqFwtTw7x6ImIyKFYPDH+qLony4pDLHplCdp1AsT1OqPbs7V4imqFeoupO7soJiu0G5kXnntx4Zal3EIPLLCMU1T+n0mGwNbr73rghQ5bmaEa97gzKOW6QCP9HiNeNKgthgKq7aEsvRwZuotw8ulDU5A10PauIxYXBmIPxCRBG+xAd+ZFQqTZq8kEgfJFduJzBH0nhIPSf08gO1Vd8L3qgu9jtmGTLejkJKWb15huCWdUElxmiIY+20EhWMvX1sza1yqTtsUaTKR6LuJYdvNQqEvDUZ8bbIRRLCLQAxTp9JGyJ7qaaLCGMMQ+tMY1jfqqoXMO5gKmvslj2VtolF1MK5nLJgpqmYZcg2lnQHvOYo2qAugKy3KZTXxEHxu6FrSfBtnakRTF8FLbQR+pq5OFeVD0js1uGpipfwjevjn1//ych2/dOHwbbb+8WT7cucsdvo1n17ePe/yHoZPQUqu8dotp5pRAbCmjG3CDXRHI0NzD2J2dLvzzxQxdLP0Qz6fr8HwRuiGeLdB8AR5qZW2kbzFNmJOFjxbLq/GGTZczYXNxYYhN5cTBiQi4K98b5hc6FYalNfOTgQ36XUAm6ZE9cE3fklJONZpCuTvoUGccmFGoa4F+13uQGfzn4n/IRJziTMYHUHymK7k9l3EyBnkLexzLCQlYrhwz9bCNOiZmffxNajp2OvS/oLQaWhpgk58HhpdKGdqziaNNrLtwE30r8/6wdw+zxJe+fpRaMuze/lBUYAdeFRS+MzctgAP5eGieY5ihqn33F1nV9mJ+FqjRTUkVIUqxeQGwz62sTdcYD1WTchfsyVG2ZqQAbfk5z1TjHWKBSKw5UgeNrEMvrXu3b6dN1xvKPoMF76RyoIzhR23Jl5X5s5hltwjOCc2nTXoeBJZuHm5/QKlSpWku8KGpiao5UfgABaWUY6OvnkEIhVYxV+MZWQirpHcvk17zVtIl6jdXmtbafZjeX1mJjpNXdGWH5LVat6ribK92eyvfqEwYK18hNStmu6MSOapbQIk0SGztRERQgDsQrKS7YlDomlnHVJmz5ixxDoxn6onWkCNXQW2Ipi7LW8M2bypDrjtzl+6Z606XzQE7dEONtrQVNNho69bUNuHypXPovWB2pr852Ni1SCoL5qHppuDkuKljOSmt62G7lw0OQQ/yGweuNZd50GQenw4zNYV9+K/fIp/eRHfz96k/O11f/3n3dEevZuHsneklQen0iHP0VTu8I8WxBYJijgIRuOoCoCGfL07PzmXus9I0g78IkCLn1O5IMrqhOFapwuomGtXB2zqKtnQBnGxlhkTmywy+5mDGvHfA4TfFqk9So4SO3i6WUznSOEBcBy7ME0KLezKRTdWfC8XsMGFvj8UT2y+/fvjn+3f//vj7+5ur61+1TekPcNpbqRpntloIfc7pyfq4BehPyr1/VPOQ1aSGdSfm3vWVNK9Nu/jVH4GmM/diYXsXKmo/77T+A7oCUmd624lWENCdLdS10OPaJik6iVad+tCqVqlpYIInE0Zi84Qq30NRiUmqt2qWF/gXhI6DzdazX+VfOiv+EdPiHzn5/j5vGfSX53jM0T4z7DXP8JvDnjPkO39NAPzxIXBk/R3K9/v/cf6tFXudHQ69AR4xMy9grdG7Dnnm2M0YhFrDEglqAdRPrg7O5owDp5cPm+y/AiuwR0+M2jOaciCEUtIZ0rQnRfYfuZZWYfrdmrq05/7oaXjG1B9Y9YdV3cHMfwAAAP//AwB9ktN49CsAAA==
+  recorded_at: Mon, 19 Dec 2022 16:11:11 GMT
+- request:
+    method: get
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/payment_methods/any/qyyv1y2y
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:11:11 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"601cbb0ef8ed7f4df28bab2c175dc0de"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.309784'
+      X-Request-Id:
+      - e2950f17-a576-4c31-b9c6-53e18a624718
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - e2950f17-a576-4c31-b9c6-53e18a624718
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - 170d067fccbe4
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAB+NoGMAA+xbW3PbthJ+96/w+J2WKNmOlVGYpidNTjJj9zRXOy8ZiIRMxhTJgKBs+defBcALQAIgaTmd6Uw7nU4FfLhwsbtYfLtevrzfxIdbTPIoTV4cucfTo0Oc+GkQJTcvjj5/euOcH730DpY+wUFEHR+RwDs4PFyuojgGiIOCgOA8Z23QGgVeFiwnUVD+9oucphtMHGg5nbvzZ2dn82fLidwsgOuI5NRJ0AYfJlH84oiSAh9Nys4Ymfv8dJOhZKfpySnBmFYb1ADwPcVJgAMLJE59FEdUNz3BNyAxTUeW5hTFDogQe4sTdwrfKzdV2y4SSna8yUFxFqKZ9uPaqHkfKilArpFvgRkEmYVpwoevMNGNJhhRJit6SHcZfnEUwE8abfCRN5vOZo4L/y4+uWfPXff5dPENzrgeUM5QZMG4GZoBXOMmGpUDNUy8k6k7Oz9n/QlvYzrqsCW8L1GOYCf176o3TOMAtE8nCaZQIEE/QrH3OblN0rsEZmjaDiRJpmsnyvMCJT6Wsd3Og/0FONCUGthNnK5A56D5ev7lIXi7oN+u3q8vP13cXzz4s8sfF3NpcANW5mDqT0HLvc8fJXDdyrABXkW0+XrxU3SsURFXH7tK0xij5MhjkmYw3imABYGTc8Ceiph9sDRZu+eAW20WEb6+s0kTGnrubDnpNLaQO4wIE/NcgfLWGomD9l7XKM5xOaJcvRGU//bN6errlyJ468bB23D77c3ix7W7uMdX8ezi6naH/1pOVLGGGMU0BP2TtEVqY5Bog26wU5DYCynN8ueTCcpzTPPjFUFRwhzaDQjiDu2OQSUnGdptcEK/bzAN0+B7nN6kky2o/HGW3LzEyTYiacIAL3KUBKv0HhxzPT9fDfSTGdQKJbfNlpTWg8r9nnju+bm7nJQ/WDssT9JYMpOqgXcSnCH48MsU2sv/F+1pUPiUyaQZ17QxSF6scp9EGTujvDwTRAjaHVWeXQKIJmgEr+C08ZO6F46BW+L0eDoFT1H+qntLzxIgbrdchcqJQOr4BpMjz100HkjGdSbJwP+mgQNXi8NMXLJ2bulzZ+o67nkzWQtvmg9uEEK1M5a+ozNjM6Kec4wTcqcaLz7Sj/M5VD9exgWEgGI61Y79nR/jjsSZz9Hg6lngGHInYwoZFJorjSGinPtjk1qsURQXBDsc1F4fFEXpb0bxYKVRBsuRdKH1LKDt4cM6XK+aeAla2T0TIvhk5PNFmVGAXS0nuo5qUIIhgHOEn8r1HleBSAPvxe4ctOGf6AoD6bR3Bkh6ZhjaRWgnMdvIojWZIj0RqDArVHRDE8RxTxVBBBCStLgJ7UbZQUpzcGfrCGfr0PQWJ97P3W7r7ma75UTbXY8Fd8POq7z2AF021AAI2XAlQfGj6gIrpkXuvfJptIVzLH9WvZRAUALqL260tgZDfKACDOOcIoFbO2BqputQB4kzNdyVMqSxQizcdUqqJnaA2jBUSIOFooY+uLu0RzzpLlKvq43T+fegJEe+6Z5pY5pWYb3uerrKzu4U+5WPDK6pTUTB831fp+Q7XOM0xkxH2oco1mHxaY5iJsMyVK37hBf0dxBQpuIR8fnj68o5ys3yINUqVQuUABBd/SxwDrvUC/yRLknIoVg5Gox5IXDlYNNjhqQk4LGvEbD3u6XSu/1vvfIsRRQtNwp1koJ6VY7K8xgCqgRX9wpvUJH1W9n7nGNSxmsanPHdXCPwBi4/L4HlfsP3aJPF+DglNxAO83YVe4dXeUQNNssRFpsWX4juLb1DHjNKsF2PnOgEXsVW3UOQ2QuN9C1btJAUI4TeR1o0p9NLXjQ7M5IYNcREZjTHN4DUkD7TxjR0YFYOxILWcCF6tJETKcETjTqASNYFhOQW11IjDNGlBIJzki4S26QZxOzsCm2ui9ZI22KogOCDRA/Dl5OWWSHqh1ZsGGWZzmpsZv2v6Uh2MkBh/zE2o9OG8nZz1hGOg7ylm+VlzsyBheuSghpiScsIdeZt7mBCUgKxTJ5BLIetwuZ46VDUUd4FLGwFtKdS9a4Ffidms2IUAW633Rm6jfKQkhECxA8s7B0imNyskoyC8WEXIK/KX4hYn8/s/jX/drngnIwZpJ9N3aI7FW8ZfW/PDBRs1HuVQc8WB9pZOEI5iiCI2A7Z86MDN8pim8JbC2BrUCAYaaK/q50WLDKF1UXY2YOm6L58+Voh+B5vsg5PWr2naoDqin1UNovz7gvhS4mAz7uLaOgkmN6l5Fa8Ug0r24a0I2w5MyR/XeuN3Bl7qCXwpV4D9SivbiP7Jdxg2lg/xk4gy/sZzp23vsKSlJCQfytDLK+bqyrAggyD5uig7TtRzw5LiH6yXAKbkhAyZFSWQT6a3nyQ/F0WSlwR5hDiXdnE+IyTIu4+0l0C75HikGapLm+mIhZ1LpIIfFfpSWEW0MUIogfiYezOTk9Wz05m6HyxCvB8ug6enQRugGcnaH4Clm4cqq6wxckmdfLg1qCtdb/hA8pcgTkQMvi/kgVywghMn+wM/JKMxLCVltoyJxptwLfD+3sg71DjOzOVrFPzSNARUeLbe7gjcXQ5yPoHizR+4/+Fm5EkOGd+Bw4nbx+EyqU5eQp3KfYIZiwWaD2jDju9qpgmZjn9zSIcw+z9EwVa95TKq8YSPWS2EJSUonOkTEe73TSmEyU8aW5NP+tTZNhK6Rm+xJ6k5IiejJXAaPh03tETO/RxcAZuXXyTftFlrW/6tFPdrYaMIUoSbF4MdH3L4vI1xn0RNNtVeucIfTWiQKqrguSC6AgwRVHcMtIWBFnJTIk1sW9PxXYI+5HD8D0THIRnZPD2Vuy1MnoC9uIG44dHvG2Vwvct7AloTI/QmcizguIhjJaIt1HwAwJpNp9tTJWKixJ4dheCQmMPAnFRf2cXdZOva4P0D1NJouo7Vn6bGkHD5+Sv2r45O0/fKtpWV726YvlTXY91LJ8953z/Ydl5WD+jWadm1s6OaAgPEQccJDN/DEJep1ZaMXfWJN04A6iymoXscwyVI+3D1U8VhTD1psztuzN34Z657nTRfHQL10dkMJ1CViKjrXWqypcZe1veaXYm569Mw1temz0Y+phrSqLhTHLJhtfvAbuFWknuQXNoifV6pJn801Pk/QObh07w3/fhKrkMr+cfstXsdH3x9fruOnk1C2bvTFkoIe+B39UVe//uxKgtgDiXBd6+ehl57mx+cnr2jN3FRoxK1IYAoAVJ7IbIPCeKY3FFWU1MQg460cH40oTwZstubGQ+dP9nAWZAOh/en/Ou3pWCtmnJ9HwxZTRSD1hxjJhsooSfpQ46Ff+4ELzbgdq98jTv6z8+/ufDu/99+vPD5auLP6TNtZPAUl5fruGuu1XO2mNvAqVBnynxfq94qOWkbtNlTLyLV0wlb7rBvpxYnM7c8xNbrpHHtN5p/Q9geYsSidi+dAmXibOFeH4dGRktGdKKxFfw9K+uyR72lV1aG5tFVTEJBM04ytpPXEvFyZ7uadAD9VFVKE+RH3iqDMFTZz4eb3m9tjfW+kbZX78FjrTBYVbYZ4e/zun+Grd7aK3Z2s+vDPcZUgDb2nFfvnlg3oS3K2kYueWRlKnR0SmkVdWsNDalj4P4VSMx+DSkoL06kyNGsXoqb1aSdiiLWsRZl82zF7iXGmWqMRUH/Zgiw34uUE8y6gnGLnGmtog/+TFmFX9VMmHvv1walYJYCocgrFj75w8yoGUNXuVNOoXC3RqCC0thwZiaiieqp3jSWopRRRGPq7nfK67ZP6IZX+9QxXi6EG+09e/PdQzliFjcSzbUfchnSm1mt4azt9isr9DMXmQ2qMBsYHFZT2GZtahscC1mb01Zp/BRX8vRV8dhruGw128MiUHG1m2MrdkYX68xrFbj1ya2lex6yWs39XItCe6dz7dXawyu1Oip0nhUhcbg6owBlRmjqjL2qMgYWI2hLSwY9+cM5/v/AZ8mnOFzPA1r/tjMxdNnLWT+ZPNlh75+y65nb6bo66K4mr+nwes3Z/7D+9uOfbDgTY3G1BYRsu5dPNVShv8DAAD//wMAJo2cW7VBAAA=
+  recorded_at: Mon, 19 Dec 2022 16:11:11 GMT
+recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/test_braintree_sync_canceled_subscription.yml
+++ b/test/vcr_cassettes/test_braintree_sync_canceled_subscription.yml
@@ -1,0 +1,453 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/customers
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <customer>
+          <email>none@example.org</email>
+          <first-name>None</first-name>
+          <last-name>User</last-name>
+          <payment-method-nonce>fake-valid-visa-nonce</payment-method-nonce>
+        </customer>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:22:54 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"829639167ccc639a26e8d2eeac870224"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.529542'
+      X-Request-Id:
+      - 1b2a2268-99a7-46a0-ab6d-c6c18e0a3b0b
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - 1b2a2268-99a7-46a0-ab6d-c6c18e0a3b0b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - 970bd4b48ec94
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAN6PoGMAA7RY227bOBB971cYfldkKXYbB466CxQJWmCz2DZJ07wUlEjbiiVSISnHytfvkLpRliUrmyzgB3PmcEjOhXPExeddHI22hIuQ0YuxczIZjwgNGA7p6mJ8e3NpnY0/ex8WQSokiwn3PoxGixB7s+nH6Xw+c92FDSMlBGWwRlRaMH7Jls/Ji8zixyccBLPVwja1Cr0MuZAWRTHxrhklC9sQKH2EytGtIHxh12OlDVicIJqNaBhdjCVPydjWchKjMPIoGPyD7FCcROSEcVg9lytEsgZla94S7VqyZ+KLULaxASdIEmwhOZJZQi7GGIYyjMnYcyeuaznwm984H89d93x2+rCw6wl6fprg182vJ+Tr60hYy5BEWORbWkXMR5Fy7a/Tuxd8NZcP99+W1zf/uNdfNrPrm6/Zwq4xxSFwKK0AcSyKbSDOUTZW2qY+l4DMD6MIssJCGHMiRCnP8yHZlIlQyMqEsZrJYoprcB38fXcXgCr8HfqOhCi0QnJCZLnxDhDZSUKx8nMvLGIBikLZtRQnKyikDmXChIQYQHURbz51Jp8Wtikyj5NSyTMttlCUrJHbefB95OkQJE0hBmFwBNrjcF1HyoxPeJeVtxVKYeWN5aJt2B2pCylNvenEcc/OFIZWcpX3llrOuwsFgp1VYxOxZhGGTO7ykkpKde2FKPJu6YayZwqWalkNy73NllYoRIpoQEx8W1lNfLuDX1GmNXTIdXMA3LKjSklCtXi3P4wJlbTEY+KHsvZIPqyVS5RGpQN8xiKC6NhTkVBQrazBKYcoW1CjaaQcYRjd15RTyC4Jud6PFTMq154D3mkJD6AzgrgKw2kDrqUNNMH7e1+iSJBilrGT2pHB1eXM/3mX4isnwlfr7cPl/PGXM9/599eZ//h9ild7172evyYokmvIWyO7DFkJC2O0IlbKI28tZSLObRsJQaQ48TkKqbpIV+CgZ5SdQCrbCcpiQuXvmMg1w78jtmL2FkrmJKGrz4RuQ86oAlwIRLHPdtAkKvvVipDXqjh9RDf11hrSEqrbwNRzzs6cghJMKx1shbPIKLVSUAE4SRA45JqBrvhf6xhOA81O6vm1rISJ1BcBDxMVy2bfrKtesg2h3lMsOJ3utgs7H5falIZPaXlxgmnwTQitnHuEOO5s6n+auuhs7mNyOlniT1PsYOJO0ekULqHOqZXtd7gqt4TGzBJ405GVld6YwWEbec0e4hItUC3WrRnJVHi5nuCFXQhMTLDdQmWKBOyTvFP+BfdFS2hOQVthEc4Zb2IOd6oCb7Ti9nL9gH1TTcKxB/6aW+vFmAaLegPEIwn0LQLXuOgiGSYTR4FuHyqDoRgMEm4ozImQ8QHsZd9rnjOZTHQ9HNQesSCBWHl/JqDZqvh2IRouxEA+4aDg7Da8O4axOpM3OVGbLQaNNEo5h0+bDBopy3d+++OLajz74mMHUjwA9R7IYArailxDrC1sCQKrESukS9Z5DIgJfjwjInOXTUpdU3BTNoA9a9ARBp17qI9Fa8QQJq2Bw9h0vrNeRq0hfaw6D9NAZl0c8xi9NThjM4Xan0WFpvfWr6J3kG2aATrc28rVj7HSyvev4CztOceZS7mf1xE54xRHmHOB/B97ZbFCeQ9qJ+bBhavDFDbxb+RghZUeIlIghnG1AtzHj0vIq4lvGaxBnzDluY4wsAI2nO9Vm/hvH0iVu4dwOw21Owr8fb5l34eiaTuUyGfGN5bkiAqUswI4y0QZcVxn7nx03RkUcAfukKlmU7+/ryd3t/sWQrdyoV/eRoVyVDVupTxgtdX+67rB8V2Gfj4kv9zLCfo5T+/d709/X929kJtv8cH6UgS1zTSb0vrzPxRW5SB1X4cvnV9jh6DFW9l+0jQEerFF0QTJwbe2/UeJ1mvaaz7S+7lAPwvo6/8DOv+gnt/b7Xv6/MAOP/TlbOi72eBXs6Ok4uiL2bs857z5foH2V6djNSAwrPPN+/AvAAAA//8DAIlLLnU2GAAA
+  recorded_at: Mon, 19 Dec 2022 16:22:54 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/subscriptions
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <subscription>
+          <payment-method-token>qmsrn4xv</payment-method-token>
+          <plan-id>default</plan-id>
+        </subscription>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:22:54 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"1e6471b1830d6e74b11f9f6286ba3dec"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.651029'
+      X-Request-Id:
+      - '097b7c2c-e3ac-400b-8216-03e6657e635e'
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - '097b7c2c-e3ac-400b-8216-03e6657e635e'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - e1ad844378554
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAN6PoGMAA+Qa23LbuPV9v0Kjd1qiLraVkZlNm42bnYm3mzjZJC8ekIRE2iTAAKAs5et7QPACkgAlx2mnnXoyGencABycO7R+uU+T0Q4zHlNyNXbPpuMRJgENY7K9Gn+8feNcjl96v6x57vOAxZkAMu+X0WiNwtChhI/EIcNXY8QYOownBcZHCSIB9qZn0+l6Un0rMHGSgFwnRAeHbpyUEhGVAmIi8BazseeugMdA1xKQYRbT0MEkBBqBSxny49ibTWdzZ+o67mUjqENvksUFYsIobea48G/Vk9ZwFPIChuFj6CChCRBx2hJy656/mM1eLBdf15OGoeDPs/Bp/A2DWj9nDBPhVLsMDkGCe9qFZU10hQRQN3cyxOFQOR6ROLkaC5bj8lrDmAc0J8J05RsUJznDTkHQXROMoIVXHDHjzR4G1d4nLSTEoedvfHFg6wl8lJAUsyBCcDQUFAs5AM/QYT0xISQDwWD4Dt5nMcPVsXxKE4zI2JNHX09aJCXTXu3GQWlxHFcZeg/eItbsxsLWp+gJsNv6qiOo1hLJUx8OAF7Uum/eu94MxaEjIkbzbTTsVD3Kkv+QSrNKsYjgCII+YOJ9Szkji/1OMhnQBR+EB3kfId6gPBFAWQIKJIshdJSaUl8kGDxP5Nx7FYh4B3dUfpUYwWKUgPkyJANV1xIv1pM2gYHHyUksvFCajQnRMKi76lrNBiUcV6yKRHkPVuGTMvlVXgxKez4mTxxRYoLnLOld2aQttF5DnrxLKxgiHAUS13bgUr6GV5DSw75P78lFGlU+VsBLfUNKSGMBEehuQ9kdx0IkWN6xfiFKNizncZRIvciPFVxFouDgxJxCaAix9/HD6ypA6eCKoe05jZdoSIfhbznmsKu+En8gRKjz5r5jwJsXgPAJ/nYqOWUhUFuQz8woym6el1XKe+KCwokqgDKN5eJ8sVotZzPdNurILs3buwFbruJ3AWioElTBPnIMIbz53tAENM0QOZh0A1icQlLxCCzxK96jNEvwGWXb9UTBG7pH7PNYGHxqyN/USdDegtkmFOoaaSNf5p++h9cr8fXz75ub2z9nN68flje3b8GiGppKj5OuIqsapK3Y7MGqUct2auVZ8MOK5IJhDJYahpDieomh0vZeQPUk7WKQLKEBSmJhW4rhrSE4VVdBIW4kyuNXC3cK0VoH6ccBj2KH4RMrEsnpoCSL0OxkyvkplJBXIbgHRr+ddK4Vjr3JofS0uHmNNVRWGgHoXgvSNmEZ1KQy9TThuMNlWwTlkJhZ/P20ZTTxPhJBZKWL4izrWrjN3f7vzPyIof3X2nf3VssM4WxinIRcs6ky+UnzlaWnZliWummAo5G64w5mjDLI9TyDegZblVnQagpvc3jvYMFBAl1M2346hG+VpEGaWlm7XZ+7D6zIt5COH6ERZvgeK5+ELM/N5gUFMw1gZdBN5c+qdlVBdT7983opC+kBor6k9rbcqarFzdgBbgG+5b3KALPDoVFCQVGrPAxjuStZRvdIjWffUegPgGQDxgFcqvMxaymX1RmsqMqvAUqB9mU3ZkXjPU4zYesDaoImJAaoBKm7HCpXy5NDPHqMReQQLB4pe1Ddk2XFIRa9sgTtOgFiep3R7dlaPEW1QrzF1J1dFpMV0o3MC8+9vHTLUm6hBxZYxikq/08xR2Dr9Xc98EKHrcxQjXtcqCt7QCP9ASNWNKgthgKq7aEsvRwZuotw8vFDU5A10PauI5oUBmIPxHGKttiB7syLhMj4i8kEgfIFP/MZgr4TwkHpv2eQnaou+E51wXcJ3dLJDnRylpHtS0x2MaNEElxxREKf7qEQrOVra/L2tcqkbbEGE6meixiW3TwU6tJw1OcGG2GUiAj0AEU6eSD0kawnGqwhDLEPrXFNo75q6JyBuYCpb/NE9hYaZRfTSuayiYJapiHXYNoZ0IHRRKOqALrCeC6ziY/IQ0PXgvbTIN04kqIYXmo76CN1ddIwD4resdlNAzP1D8H1m6X/16c8vHaT8DrafX2zuv/irvb+55uDf/9+EW4NnYSWWuW1W0wzJzHEljK6ATfYVQwZmnkYu7Plwr9YzNDlyg/xfLoJLxahG+LZAs0X4KFW1kb6DpOUOjx8sFhejTdsupwJm4sLQ2wqJw5OFIO7soNhfqFTYVhaMz8Z2KDfBWSandgD1/QtKeVUoymUu4MOdcaBGYW6Fuh3vXuZwX8t/odMxAjmMj6A4rmu5PZcxuEU8hb2GJYTErBcOWbqYRt1TMz6+A+p6dTp0P+C0mpoaYBNfh4YXiplaM8mjjax7sJN9K3M+9PePcwSn/v6UWrJsHv7Q1GBHXhVUPjO3LQADuTjoXmOYYaq9t1fZF3bi/lZoEY3JVWECMHmBcA+d7I23WA8VE3KXdBHR9makQK05eeMq8Y7xALFieZIHTSyDr207t2+nTZdbyj7BBa8l8qBMoadtCVfVuZPYpbdIjgnNJ826XkQWLp5uP0BpUqVZrnA1qlJEEH1InJG6t7k2IBFlacovIfaUy5po69eTGICXWWuJjmyZlb58U7mx+ZZpUvU78M0BbdbNr0VsxKdJq9o4I7Ja3V5VXHaXu3zZ/mcZcJY+QqpvBgDj0rkqO4WJdIgsbUTEUGt7kBck56NQaEbap1ocWfDaOocmeTUw68hn6/i3xBNXcG35nLeVEZnd+au3PMZ1HPNATt0Qz25tBU02JPr1tQ24fJRdOhpYXau1ws2di3oytp6aBAqWHzagLIcqtals93LBuelR/mNs9mayzyTMk9ah5maHiD8x++RT26iL/P3mT9bbr5An4HSxdz/y9QqlDo94Rx91Q7vSHHsgKAYuUCwrhoG6N3ni+X5hUyTVhpDBLU6koxuKElUVrG6iUZ19LZOoi1dAKc7mUyR+TKDbzmYMesdcPj5sWqp1NSho7fL1VROP44Q14ELszQmxT2ZyKbqz4W6d5iwt8fiNe71bx/+/v7tP2//eH/z6t1v2qb0tzrtWVVNPlvdhj4S9WQp3QJoQ6RyqO79rRqdrCc1rCFTw3Xv3StpXtt2nay/F01n7uXC9oRUlInesv4DugJSFwW2E60hoDs7KIGhHbYNXXQSrZD1oautUtPAsE8mjNTmCVW+h/oTx5ne1Vke658ROo72ZU9+wH/uWPlnDJZHP3FI/mPeMugvT/GYk31m2Gue4DfHPWfId/49AfDnh8CR9ScrP+7/p/m3Vux1djj0XHjCeL2Atab0OuSJEzpjEGrNVSSoBVC/zjo6xjPOpp4/l7L/YKzAnjxcao9zytkRyuLOPKc9VLL/Hra0CtNP3NSlPfX3UcPjqP5sqz/X6s5w/gUAAP//AwDgTyY5HywAAA==
+  recorded_at: Mon, 19 Dec 2022 16:22:54 GMT
+- request:
+    method: get
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/subscriptions/bfbtyr
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:22:55 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"7299bffd48d90540169818c7abe4dfba"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.205775'
+      X-Request-Id:
+      - '0864df9f-e24d-4da4-b98a-b3fc6db7354d'
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - '0864df9f-e24d-4da4-b98a-b3fc6db7354d'
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - b7b67b083e6c4
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAN+PoGMAA+Qa23LbuPV9v8Ljd1iiLF+UkZlNm42bnYm3mzjZJC8ekIRE2iTAAKAs5et7QPACkgAlx2mnnXoyGencABycO7R8uc3Sow3hImH06tg7mR4fERqyKKHrq+OPt2/Q5fFL/5elKAIR8iSXQOb/cnS0xFGEGBVHcpeTq2PMOd4dT0pMgFNMQ+JPT6bT5aT+VmKSNAW5KMI7xFYoY1TGlYCESrIm/Nj3FsBjoesIyAlPWIQIjYBGkkqG+njsz6azUzT1kHfZCurR22QJibm0SpshD/4tBtJajlJeyAl8jBCWhgCZZB0ht975i9nsxdn863LSMpT8RR49jb9l0OsXnBMqUb3LcBemZKBdWNZGV0oAdQuUYwGHKsgRTdKrY8kLUl1rlIiQFVTarnyFk7TgBJUE/TXBCDp4zZFw0e5hVO1D0lJCEvnBKpA7vpzARwXJCA9jDEfDYbkQAniOd8uJDaEYKAHDR2SbJ5zUxwoYSwmmx746+nLSIamYtno3CGflcTxt6AN4h9iwGwfbkGIgwG3ri56gRku0yAI4AHhR577F4HpznERIxpwV63jcqQaUFf8uU2aVERnDESR7INT/lglO59uNYrKgSz4ID+o+IrLCRSqBsgKUSJ5A6Kg0pb8oMHieLIT/KpTJBu6o+qowkic4BfPlWAWqviVeLCddAgsPKmgi/UiZjQ3RMui76lvNCqeC1KyaRHsP0eGTcfVVXQzOBj6mThwzaoMXPB1c2aQrtFlDnbxPKzmmAocK13XgSr6B15DKw75P7+lFFtc+VsIrfUNKyBIJEehuxfidIFKmRN2xeSFaNiznC5wqvaiPNVxHonCHEsEgNETE//jhdR2gTHDN0PWc1ksMJOLkW0EE7GqoxB8IEfq8RYAsePsCED7B3w4lZzwCagfymRlF283zskp1T0IyOFEN0KZxNj+fLxZns5lpG01kV+bt34At1/G7BLRUKa5hHwWBEN5+b2lCluWY7my6ASzJIKn4FJb4lWxxlqfkhPH1cqLhLd0jCUQiLT415m/6JHjrwKxTBnWNspEvp5++R9cL+fXz76ub2z9nN68fzm5u34JFtTS1Hid9RdY1SFex+YNTo47tNMpz4McVKSQnBCw1iiDFDRJDre2thOpJ2cUoWcpCnCbStRQna0twqq+CQdxItccv5t4UorUJMo8DHsV34yfWJIoT4TSP8exgytNDKCGvQnAPrX476V0rHHtVQOnpcPMGa6msDALQvRGkXcJyqElV6mnDcY/LtQguIDHz5PthyxjiAyzD2EkXJ3net3CXu/3fmfkeQ/uvte/+rVYZAq0SkkbCsKkq+SnzVaWnYViOummEo5W6EYhwzjjkepFDPUOcyixpDYV3Ofx3sOAogSmmaz89wrda0ihNo6zNZsg9BNbka0jHj9AIc3JPtE9Clhd284KCmYWwMuim9mddu+qgejr98/pMFdIjRENJ3W15U12L27Ej3BJ8y3+VA2ZDIquEkqJReRQlaleqjB6QWs++YdAfAMkKjAO4dOdj11KhqjNYUZdfI5QSb6tuzIkmW5Ll0tUHNARtSAxxBdJ3OVauVieHePSYyBhRIh8Zf9Ddk2PFMRazsgTtohBzs87o92wdnrJaof586s0uy8kK7Ufmue9dXnpVKTc3Awssg8rK/1MiMNh6890MvNBhazPU4x4P6soB0Eq/I5iXDWqHoYQae6hKL6RCdxlOPn5oC7IW2t11zNLSQNyBOMnwmiDozvxYyly8mEwwKF+Kk4Bj6DshHFT+ewLZqe6C73QXfJeyNZtsQCcnOV2/JHSTcEYVwZXANArYFgrBRr6xpuheq0raDmuwkZq5iBPVzUOhrgxHf26xMcGpjEEPUKTTB8oe6XJiwFrCiATQGjc0+quBLjiYC5j6ukhVb2FQ9jGdZK6aKKhlWnIDZpwB7zhLDaoaYCpMFCqbBJg+tHQd6DANshVSFOXw0tjBEGmqk0VFWPaO7W5amK1/CK/fnAV/fSqiay+NruPN1zeL+y/eYht8vtkF9+/n0drSSRipVV27wzQLmkBsqaIbcINdJZChuU+INzubBxfzGb5cBBE5na6ii3nkRWQ2x6dz8FAnayt9Q2jGkIgeHJbX4C2brmbC9uLCEpuqiQOKE3BXvrPML0wqAksb5qcCG/S7gMzyA3vghr4jpZpqtIVyf9Chzzgyo9DXAv2uf68y+K/l/5CJOCVCxQdQvDCV3J3LIMEgbxGfEzUhActVY6YBtlXHxK6P/5CaDp0O/S8orYFWBtjm55HhpVaG8WyCjIl1H26j72Ten/buYZf43NePSkuW3bsfikrsyKuCxvfmpiVwJB+PzXMsM1S97+Eiy8Ze7M8CDbotqWJMKbEvAPa5UbXpipCxalLtgj0ibWtWCtBWUHChG++ISJykhiP10Ng59DK6d/d2unSDoewTWMhWKQfKGH7QlgJVmT+JWXWL4JzQfLqkF2Ho6Obh9keUqlSaF5Lsm5romhNH91BQKjku+voZJKHQKhZ6PKMKYZ307lTSa99K+kTD5srQWrcPM/srJ9Fh8squbJ+8TutWV5zd1T5/Vm9UNoyTr5QqytnuUYU8alpAhbRI7OxExlCAIwhWyl0JKHTFnGMqgVacZWjPeKaZaI05ch3UxmiasrwzbPOnKuR6M2/hnc+gSGsP2KMba7SVreDRRtu0pq4JVy+dY+8Fs3OzCHCxG5FUFcxj003Jk8OmjtWktKmH3V42OgTdy28duDZc9kGTfXw6ztQW9tE/fo8DehN/OX2fB7Oz1RdoHnA2Pw3+stX/lU4POMdQteM70hwbICjnKBCB6y4AGvLT+dn5hcp9Tpp28BcDUhacuh1JRTecpjpVON3EoNp7WwfRVi5Aso3KkNh+meG3AsyYDw44/qZY90l6lNDT2+ViqkYae4ibwEV4ltDynmxkU/3nQTE7TjjYY/nE9vq3D39///aft3+8v3n17jdjU+YDnPFWqseZnRbCnHP6qj7uAIaTcv9v9TxkOWlg/Ym5/+6VMq91t/g1H4GmM+9y7noXKms//6z5A7oS0mR614mWENDRBupa6HFdkxSTxKhOA2hV69Q0MsFTCSNzeUKd76GoJElutmqOF/hnhI69zdaTX+WfOyv+GdPinzn5/jFvGfWXp3jMwT4z7jVP8Jv9njPmO/+eAPjzQ+CR83coP+7/h/m3Uez1djj2BnjAzLyEdUbvJuSJYzdrEOoMSxSoA9A/udo7m7MOnJ4/bHL/CqzEHjwx6s5oqoEQzpPekKY7KXL/yLWyCtvv1vSlPfVHT+MzpuHAajis6g9m/gUAAP//AwACvRPd9CsAAA==
+  recorded_at: Mon, 19 Dec 2022 16:22:55 GMT
+- request:
+    method: put
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/subscriptions/bfbtyr/cancel
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:22:55 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"b1f9e60f678f5bb2f3b4eef48382ea46"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.279244'
+      X-Request-Id:
+      - 633cc814-1d59-4276-8c80-94f0ad4676f5
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - 633cc814-1d59-4276-8c80-94f0ad4676f5
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - c8c826226cc64
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAN+PoGMAA+wa23LbNva9X+HxOyxRlmwrIzPNNk02nYm7TZw0yYsHJCGRNgkwAChL+fo9IHgBSYCW47SzO7ueTEY6NwAH5w6tnu+y9GhLuEgYvTz2TqbHR4SGLEro5vL4w/UrdHH83P9pJYpAhDzJJZD5Px0drXAUIUbFkdzn5PIYc473x5MSE+AU05D405PpdDWpv5WYJE1BLorwHrE1yhiVcSUgoZJsCD/2vSXwWOg6AnLCExYhQiOgkaSSoT4e+7Pp7BRNPeRdtIJ69DZZQmIurdJmyIN/y4G0lqOUF3ICHyOEpSFAJllHyLV39mw2e7aYf1lNWoaSv8ijw/kXwN8y6PULzgmVqN5luA9TMtAuLGujKyWAugXKsYBDFeSIJunlseQFqa41SkTICiptV77GSVpwgkqC/ppgBB285ki4aPcwqvYhaSkhifxgHcg9X03go4JkhIcxhqPhsFwIATzH+9XEhlAMlIDhI7LLE07qYwWMpQTTY18dfTXpkFRMO70bhLPyOJ429AG8Q2zYjYNtSDEQ4Lb1ZU9QoyVaZAEcALyoc99icL05TiIkY86KTTzuVAPKin+fKbPKiIzhCJLdEep/zQSn891WMVnQJR+EB3UfEVnjIpVAWQFKJE8gdFSa0l8UGDxPFsL/RQWWlESrSQVQOMkTnIIBc6xCVd8Wz1eTLoGFBxU0kX6kDMeGaBn0bfXtZo1TQWpWTaL9h+gAyrj6qq4GZwMvU2eOGbXBC54OLm3SFdqsoU7ep5UcU4FDheu6cCXfwGtI5WPfprf0PItrLyvhlb4hKWSJhBh0s2b8RhApU6Ju2bwQLRuW8wVOlV7UxxquY1G4R4lgEBwi4n94/7IOUSa4Zuj6TusnBhJx8rUgAnY1VOJ3BAl93iJAFrx9AQig4HGHkjMeAbUD+cScou3mMXllPsgr1T0JyeBENUCbxmJ+Nl8uF7OZaRtNbFfm7V+BLdcRvAS0VCmuYR8EgSDefm9pQpblmO5tugEsySCt+BSW+JnscJan5ITxzWqi4S3dPQlEIi0+NeZv+iR458BsUgaVjbKRz6cfv0Wvl/LLp9/WV9d/zK5e3i2urt+ARbU0tR4nfUXWVUhXsfmdU6OO7TTKc+DHFSkkJwQsNYogyQ1SQ63tnYT6SdnFKFnKQpwm0rUUJxtLcKqvgkHcSLXHL+feFKK1CTKPAx7F9+Mn1iSKE+E0j/HsYMrTQyghs0JwD61+O+ldKxx7XUDx6XDzBmuprQwC0L0RpF3CcqhKVeppw3GPy7UILiA18+TbYcsY4gMsw9hJFyd53rdwl7v9z5n5A4b2H2vf/VutMgRaJySNhGFTVfJT5quKT8OwHHXTCEcrdSsQ4ZxxyPUih3qGOJVZ0hoK73L4b2HBUQJTTNd+eoRvtKRRmkZZ2+2QewisyTeQju+hFebklmifhCwv7OYFJTMLYWXQTe3PunbVQfV0+sfrhSqlR4iGkrrb8qa6GrdjR7gl+Jb/IgfMVhXtLopG5VGUqF2pMnpAaj37lkGHACRrMA7g0r2PXUuFqs5gRV1+jVBKvKv6MSea7EiWS1cf0BC0ITHEFUjf5Vi5Wp0c4tF9ImNEibxn/E73T44Vx1jMyhK0i0LMzTqj37V1eMpqhfrzqTe7KGcrtB+Z5753ceFVpdzcDCywDCor/4+JwGDrzXcz8EKPrc1QD3w8qCsHQCv9nmBetqgdhhJq7KEqvZAK3WU4+fC+LchaaHfXMUtLA3EH4iTDG4KgO/NjKXPxbDLBoHwpTgKOoe+EcFD57wlkp7oPvtF98E3KNmyyBZ2c5HTznNBtwhlVBJcC0yhgOygEG/nGmqJ7rSppO6zBRmrmIk5UPw+FujIc/bnFxgSnMgY9QJFO7yi7p6uJAWsJIxJAa9zQ6K8GuuBgLmDqmyJVvYVB2cd0krlqoqCWackNmHEGvOcsNahqgKkwUahsEmB619J1oMM0yNZIUZTjS2MHQ6SpThYVYdk7trtpYbb+IXz9ahH8+bGIXntp9Drefnm1vP3sLXfBp6t9cPtuHm0snYSRWtW1O0yzoAnEliq6ATfYVQIZmvuEeLPFPDifz/DFMojI6XQdnc8jLyKzOT6dg4c6WVvpW0IzhkR057C8Bm/ZdDUVthcXlthUTRxQnIC78r1lfmFSEVjaMD8V2KDfBWSWH9gDN/QdKdVUoy2U+4MOfcaRGYW+Fuh3/VuVwX8u/4dMxCkRKj6A4oWp5O5cBgkGeYv4nKgJCViuGjMNsK06JnZ9/E1qOnQ69N+gtAZaGWCbn0fGl1oZxsMJMmbWfbiNvpN5f9jLh13iU98/Ki1Zdu9+KiqxI+8KGt+bm5bAkXw8Ns+xzFD1voeLrBp7sT8MNOi2pIoxpcS+ANjnVtWma0LGqkm1C3aPtK1ZKUBbQcGFbrwjInGSGo7UQ2Pn0Mvo3t3b6dINhrKPYCE7pRwoY/hBWwpUZf4oZtUtgnNC8+mSXoSho5uH2x9RqlJpXkjy0NRE15w4uoWCUslx0dcPIQmFVrHQ4xlVCOukd6OSXvta0icaNleG1rp9mNlfOYkOk1d2ZQ/J67RudcXZXe3TJ/VKZcM4+UqpopztHlXIo6YFVEiLxM5OZAwFOIJgpdyVgELXzDmmEmjNWYYeGM80E60xR66D2hhNU5Z3hm3+VIVcb+YtvbMZFGntAXt0Y422shU82mib1tQ14eqtc+y9YHZmFgEudiOSqoJ5bLopeXLY1LGalDb1sNvLRoegD/JbB64Nl33QZB+fjjO1hX30z9/igF7Fn0/f5cFssf4MzQPO5qfBn7b6v9LpAecYqnZ8R5pjCwTlHAUicN0FQEN+Ol+cnavc56RpB38xIGXBqduRVHTDaapThdNNDKoHb+sg2soFSLZVGRLbLzP8WoAZ88EBx98U6z5JjxJ6ertYTtVI4wHiJnARniW0vCcb2VT/eVDMjhMO9lg+sb389f0v79786/r3d1cv3v5qbMp8gDPeSvU4s9NCmHNOX9XHHcBwUu7/o56HrCYNrD8x99++UOa16Ra/5iPQdOZdzF3vQmXt5y+aP6ArIU2md51oBQEdbaGuhR7XNUkxSYzqNIBWtU5NIxM8lTAylyfU+R6KSpLkZqvmeIF/Quh4sNl69Kv8U2fFP2Ja/CMn39/nLaP+8hiPOdhnxr3mEX7zsOeM+c5fEwB/fAg8cv4O5fv9/zD/Noq93g7H3gAPmJmXsM7o3YQ8cuxmDUKdYYkCdQD6J1cPzuasA6dHDZsWtmHT2O/ASvzBM6PulKYaCeE86Y1purMi9w9dK7uw/XZNX9tjf/Y0PmWyjayernLrfK9W+Qu4/i35v8Jr7Q7ng/1Z2L8BAAD//wMA9zs6L2ktAAA=
+  recorded_at: Mon, 19 Dec 2022 16:22:55 GMT
+- request:
+    method: get
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/subscriptions/bfbtyr
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:22:56 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"54d269cbdede8d0436d0f73370e9b35c"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.157066'
+      X-Request-Id:
+      - 10d9c950-1286-40e0-98eb-e44b5e7de32f
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - 10d9c950-1286-40e0-98eb-e44b5e7de32f
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - 1288441b0cfe4
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAOCPoGMAA+wa23LbNva9X+HxOyxRlmwrIzPNNk02nYm7TZw0yYsHJCGRNgkwAChL+fo9IHgBSYCW47SzO7ueTEY6NwAH5w6tnu+y9GhLuEgYvTz2TqbHR4SGLEro5vL4w/UrdHH83P9pJYpAhDzJJZD5Px0drXAUIUbFkdzn5PIYc473x5MSE+AU05D405PpdDWpv5WYJE1BLorwHrE1yhiVcSUgoZJsCD/2vSXwWOg6AnLCExYhQiOgkaSSoT4e+7Pp7BRNPeRdtIJ69DZZQmIurdJmyIN/y4G0lqOUF3ICHyOEpSFAJllHyLV39mw2e7aYf1lNWoaSv8ijw/kXwN8y6PULzgmVqN5luA9TMtAuLGujKyWAugXKsYBDFeSIJunlseQFqa41SkTICiptV77GSVpwgkqC/ppgBB285ki4aPcwqvYhaSkhifxgHcg9X03go4JkhIcxhqPhsFwIATzH+9XEhlAMlIDhI7LLE07qYwWMpQTTY18dfTXpkFRMO70bhLPyOJ429AG8Q2zYjYNtSDEQ4Lb1ZU9QoyVaZAEcALyoc99icL05TiIkY86KTTzuVAPKin+fKbPKiIzhCJLdEep/zQSn891WMVnQJR+EB3UfEVnjIpVAWQFKJE8gdFSa0l8UGDxPFsL/RQWWlESrSQVQOMkTnIIBc6xCVd8Wz1eTLoGFBxU0kX6kDMeGaBn0bfXtZo1TQWpWTaL9h+gAyrj6qq4GZwMvU2eOGbXBC54OLm3SFdqsoU7ep5UcU4FDheu6cCXfwGtI5WPfprf0PItrLyvhlb4hKWSJhBh0s2b8RhApU6Ju2bwQLRuW8wVOlV7UxxquY1G4R4lgEBwi4n94/7IOUSa4Zuj6TusnBhJx8rUgAnY1VOJ3BAl93iJAFrx9AQig4HGHkjMeAbUD+cScou3mMXllPsgr1T0JyeBENUCbxmJ+Nl8uF7OZaRtNbFfm7V+BLdcRvAS0VCmuYR8EgSDefm9pQpblmO5tugEsySCt+BSW+JnscJan5ITxzWqi4S3dPQlEIi0+NeZv+iR458BsUgaVjbKRz6cfv0Wvl/LLp9/WV9d/zK5e3i2urt+ARbU0tR4nfUXWVUhXsfmdU6OO7TTKc+DHFSkkJwQsNYogyQ1SQ63tnYT6SdnFKFnKQpwm0rUUJxtLcKqvgkHcSLXHL+feFKK1CTKPAx7F9+Mn1iSKE+E0j/HsYMrTQyghs0JwD61+O+ldKxx7XUDx6XDzBmuprQwC0L0RpF3CcqhKVeppw3GPy7UILiA18+TbYcsY4gMsw9hJFyd53rdwl7v9z5n5A4b2H2vf/VutMgRaJySNhGFTVfJT5quKT8OwHHXTCEcrdSsQ4ZxxyPUih3qGOJVZ0hoK73L4b2HBUQJTTNd+eoRvtKRRmkZZ2+2QewisyTeQju+hFebklmifhCwv7OYFJTMLYWXQTe3PunbVQfV0+sfrhSqlR4iGkrrb8qa6GrdjR7gl+Jb/IgfMVhXtLopG5VGUqF2pMnpAaj37lkGHACRrMA7g0r2PXUuFqs5gRV1+jVBKvKv6MSea7EiWS1cf0BC0ITHEFUjf5Vi5Wp0c4tF9ImNEibxn/E73T44Vx1jMyhK0i0LMzTqj37V1eMpqhfrzqTe7KGcrtB+Z5753ceFVpdzcDCywDCor/4+JwGDrzXcz8EKPrc1QD3w8qCsHQCv9nmBetqgdhhJq7KEqvZAK3WU4+fC+LchaaHfXMUtLA3EH4iTDG4KgO/NjKXPxbDLBoHwpTgKOoe+EcFD57wlkp7oPvtF98E3KNmyyBZ2c5HTznNBtwhlVBJcC0yhgOygEG/nGmqJ7rSppO6zBRmrmIk5UPw+FujIc/bnFxgSnMgY9QJFO7yi7p6uJAWsJIxJAa9zQ6K8GuuBgLmDqmyJVvYVB2cd0krlqoqCWackNmHEGvOcsNahqgKkwUahsEmB619J1oMM0yNZIUZTjS2MHQ6SpThYVYdk7trtpYbb+IXz9ahH8+bGIXntp9Drefnm1vP3sLXfBp6t9cPtuHm0snYSRWtW1O0yzoAnEliq6ATfYVQIZmvuEeLPFPDifz/DFMojI6XQdnc8jLyKzOT6dg4c6WVvpW0IzhkR057C8Bm/ZdDUVthcXlthUTRxQnIC78r1lfmFSEVjaMD8V2KDfBWSWH9gDN/QdKdVUoy2U+4MOfcaRGYW+Fuh3/VuVwX8u/4dMxCkRKj6A4oWp5O5cBgkGeYv4nKgJCViuGjMNsK06JnZ9/E1qOnQ69N+gtAZaGWCbn0fGl1oZxsMJMmbWfbiNvpN5f9jLh13iU98/Ki1Zdu9+KiqxI+8KGt+bm5bAkXw8Ns+xzFD1voeLrBp7sT8MNOi2pIoxpcS+ANjnVtWma0LGqkm1C3aPtK1ZKUBbQcGFbrwjInGSGo7UQ2Pn0Mvo3t3b6dINhrKPYCE7pRwoY/hBWwpUZf4oZtUtgnNC8+mSXoSho5uH2x9RqlJpXkjy0NRE15w4uoWCUslx0dcPIQmFVrHQ4xlVCOukd6OSXvta0icaNleG1rp9mNlfOYkOk1d2ZQ/J67RudcXZXe3TJ/VKZcM4+UqpopztHlXIo6YFVEiLxM5OZAwFOIJgpdyVgELXzDmmEmjNWYYeGM80E60xR66D2hhNU5Z3hm3+VIVcb+YtvbMZFGntAXt0Y422shU82mib1tQ14eqtc+y9YHZmFgEudiOSqoJ5bLopeXLY1LGalDb1sNvLRoegD/JbB64Nl33QZB+fjjO1hX30z9/igF7Fn0/f5cFssf4MzQPO5qfBn7b6v9LpAecYqnZ8R5pjCwTlHAUicN0FQEN+Ol+cnavc56RpB38xIGXBqduRVHTDaapThdNNDKoHb+sg2soFSLZVGRLbLzP8WoAZ88EBx98U6z5JjxJ6ertYTtVI4wHiJnARniW0vCcb2VT/eVDMjhMO9lg+sb389f0v79786/r3d1cv3v5qbMp8gDPeSvU4s9NCmHNOX9XHHcBwUu7/o56HrCYNrD8x99++UOa16Ra/5iPQdOZdzF3vQmXt5y+aP6ArIU2md51oBQEdbaGuhR7XNUkxSYzqNIBWtU5NIxM8lTAylyfU+R6KSpLkZqvmeIF/Quh4sNl69Kv8U2fFP2Ja/CMn39/nLaP+8hiPOdhnxr3mEX7zsOeM+c5fEwB/fAg8cv4O5fv9/zD/Noq93g7H3gAPmJmXsM7o3YQ8cuxmDUKdYYkCdQD6J1cPzuasA6dHDZsWtmHT2O/ASvzBM6PulKYaCeE86Y1purMi9w9dK7uw/XZNX9tjf/Y0PmWyjayernLrfK9W+Qu4/i35v8Jr7Q7ng/1Z2L8BAAD//wMA9zs6L2ktAAA=
+  recorded_at: Mon, 19 Dec 2022 16:22:56 GMT
+- request:
+    method: get
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/payment_methods/any/qmsrn4xv
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:22:56 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"3ab7c3964272e3f11c91b857243d55c9"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.296665'
+      X-Request-Id:
+      - 538ad3b4-5acb-47bb-a14c-1e7dd7a47542
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - 538ad3b4-5acb-47bb-a14c-1e7dd7a47542
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - 488d41099ba74
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAOCPoGMAA+xbW3PbthJ+96/w6J2WSEmJlVGY5jSNTzIT9zRxri8ZkIQk2rwFJGUpv/4sCF4AEgBJy+lMZ9rpdKrFhwsXu4vFh/X6xSEMzveYpH4cPZ+YF7PJOY7c2POj7fPJx5vXxuXkhX22dgn2/MxwEfHss/PzteMHAUAM5HkEpymVgdT37ORuPfW98rebp1kcYmKAZLl4slitlpa1nvJiBtz4JM2MCIX4PPKD55OM5HgyLRsDpG5z4zBB0VHSkmYE46xaoASADxmOPOxpIEHsosDPZMMTvAWNSRqSOM1QYIAKsb1amLOn6ykvqpadRxk5FiIDBckOWdKPa6PmfagoB736rgamUGSyi6Oiu4OJrDfBKKO6ys6zY4KfTzz4mfkhntjWzLIME/5d3ZhPnlnWs+X8G+xx3aEcIU+8cSM0HQqLm0pMDswwshcz07q8pO1RIaM2atAp7E9+imAl9e+qdRcHHlifTBPUoECDro8C+2N0F8X3EYzQyM44TcYbw0/THEUu5rHdxrPTFTjQlRrYNogdsDkQf51/+uldrbJvX95urm/+sq5f3S2vb94cuc4NWBiDmn8GVm5//MCBaynFetjxs+br2U/WsEF5UH2sE8cBRtHEppqmsKKRAXMCO2eAP+UB/WBusHbLWeG1iU+K+Y0wjrKdbYIWOsIW8ogRoWqeC9BCWiOx117rBgUpLnuUszeKcq9eL53Pn3Lvygy8q93+2+vV7VdzdXC+XB+d2/cLb7ueimrdYRRkO7A/zlo4GYX4IdpiIyeBvcuyJH02naI0xVl64RDkRzSgbUER9+h4ASY5TdAxxFH2PcTZLva+B/E2nu7B5C+SaPsCR3ufxBEFPE9R5DnxAQJzPX4xG9gndSgHRXfNkgTpWRV+F7Z5eWmup+UPKofpSRxwblIJikaCEwQffh2DvPx/Jo+93M2oTpp+jYxC0txJXeIndI/Sck8QIeg4qSI7B2AiEEJUMNr4ad0K21B44uxiNoNIUf6qW8vI4qHCbwsTKgcCreMtJhPbXDURiMd1Bkkg/saeAUeLQV2c8/bC0+fGzDTMy2awFl41HpwgJJOOWMaOzohNj3rMUUFoIYniY+P4shPHy7yAEDBMo1qxe3QD3NE4jTkSXD0KbENqJNQgvVxypFGEnxbxWGUWG+QHOcFGAWrPD4YitDe9imSlMQbNlnSh9Shg7c7GyY6kyZdASs+ZHYJPRm4xKXUK8Kv1VNZQdYowJHAGi1OpPOIKEK7jga3OQGHxiSZzkI6804GzM0XXLkI6iNpHVq3BBO2xRIV6oWAbkiSuiFQ+ZAA7Eufbnd4pO0hujCLYGizYGll8hyP7R5iSaHHYr6fS5rovhBu6X+WxB+hSUAMgZcOVBtmPqgm8OMtT+3casALsraeloGrPCKQl4ADsTGvbMCSfIkDRz8gjOLc9amiyBrET21XFaclDGj/ELGDHpBLRLZQmokwfNBlVtMHpJd3kaXeSel5ppl58D4pS5KpOmjamkZb++3N2Gz0Nd7wH85sGB1XoZxD7vm9i8h0O8izA1Eram8jmoRlqigKqwzJZrdtYHHSPkFLG7Brx8cOrKjzyYr6T6JeiD3IAyK9+5DiFVcoV/sCgxPSQO4YEo54Igjl49ZguMfGK7FcJeIQzj9ndmHNvIT33yr1keTQvZObEpfWiHoULMqRUEa5OlkIgIuvbsv0xxaTM2CQ45c25RuAQjj87gul+wwcUJgG+iAmktUwuYu+xk/qZwmcLhMan2Reig6Z1yHVGSLfrnlOZwqvsqrsJPH8h0b5miRqaYoTS+2iLZnd66YtmZUoao4ao6Ixm+wbQGtxn6riGDkzLgmjQEjZEjlayIiV4KjEHUMkmh6RcE1pqhCK/5ECwT9xBohs0gaydHqHNcdHqqZsM5ZB+EP/n8Om4aRyUuTstducnicxrdG79r+twfjLAYP8xPiOzhvJ0MzY+Dry0ZZvlYU7dgSbsnIEqcklND3HkfWpgQmICuUyaQC6Htcou8NymiL3sdzCxFtAeSrS7FvgNG02LERS433dH6Ar5LiUnBIhbzPwdMphUbZKUhHFhFaCvKl6wXJ8F9/nsr6tlwcqoQfLRxCWaM3abkbf2jJCBj9ovE2jZ00uPCiFshef5dIX0+tGBK3Wxj+G2BbANGBD0VBHg1UpzmpnC7Czt7EFn6FDefbUQfMBh0mFKq/tUDRBDsYtKMdvvvhS+1AjEvHs/2xkRzu5jcsfuqYqZdV3aGTb/NsR/XeuW3Ol7LqXwuVYF+cjPrqP7Odxg4ljeR08h8+sZzp63vkLzLMEh/1aOmJ83FU2AJhkKy5FB22einB/mEP10OQdWPUPwkFHvDPzW9L4I8d+lIcUFZQ6h3oVFjH9zEtTdR7tz4BMeObhRqsObmojGnPPIh9hVRlIYBWzRh+yB2Bib1nLhPF1Y6HLleHg+23hPF57pYWuB5gvwdGVXcYY9jsLYSL07hbXW7YoPKF8L1ImQIv6VLJCx88H1yVHBL/FIDEtpmS0Non4IsR3u3wN5hxrfGalknZpLgoyIYt/ewx2xrUtB17c00/it+C+cjCTCKY07sDlpeyNELs1IYzhLsU0wZbHA6il12GkV1TRV6+lvVuEYZu+fqNC6pTReMZfoobOZorhHOoN762jLVX06WcKjvq7JR32MN7ZSe4ov0T9TFoieNyuGkfDpRUNP7tDHwSm4dfZN8knXtb3JH57qZjFl3KEowurJwNb3NC/fYNyXQdNVxfcGs1clCrTq5CRlRIeHM+QHLSdtQZCWzORYE/3yRGyHsB/ZDR+o4iA9I4OX59DbyugB6I0bnB8u8bpZctfVsCdgMT1KpypP8gwPYbRYvo28W0ik6Xi6PtVjnB/BtTtnFBq9ELCD+js9qJsXuzZIfjHlNCreY/m7qRI0fMziVts3ZufqW2Xb4qxfvtAXVFmLtm8xelrw/edl43l9jaaNklE7K8p2cBExIEBS98eg5E2spRVTY0Pi0BhAldUsZF9gqAJpH66+qgiEqT2jYd+0zJX5xIJEtPnoFq6PyKA2hbRERtvqRJMv3+x1707WEz55UXVvRW16YehjrjPiD2eSSza8vg/oPVRLcg8aQ0qs1z3V5J+cIu/v2Fx0vP++3TnR9e7r/H3iWMvNV7hQoXAxdz6r7kOlvgd+V1ft/atjvfYAKrgsiPbVzcg2rfli+eQpPYuVGJGo3QEgy0mkd0QaOVEQsCNK62IcctCODsaXLoTDPT2xkXrT3R85uAHpfHj/m3d1r2S0TUunl6sZpZF6wEJgxCT0o2IvZdAZ+8eE5F0PlK61eOZ99ceH39+/+d/Nn++vX777g1tc+xGYe9fnq7jrZpGztumdQBDIX0rs/1Q81Hpay2QvJva7l9Qkt91kn39YnFnm5UL31ljktPay/gewhUTIRHRfuobDxNhDPr/xlYwWD2ll4g5c/atjsod9pYdWqPOoKieBpBn7SfuKq6k4OTE8DbqgPqgK5THeBx7rheCxXz4e7nm9vjfW+0b5X78HjvTBYV7Y54e/Luj+mrB7rq3ZOi2uDI8ZXALbWnHfe/PAd5NCLjzD8JIHUqbKQCeQVpVYEDalj4P4VSUxOIoUXKpIwb76zAIzitcTmbOStkOJ36LOunyevsi9tClVnSnb6oeUGfazgSqa8XG2RsnXVlvzEsxmj//dmKEbI+d+u5ymKGF/j6V88P1V7zwn/1nZqNehNYvVLMBK/zaFB7QClV0F+k4Nd7e8452m5mNMucsjlbo8apnLqHqVh/1BxEkp5+nJ5vhSlCr9lmXfo73/dBpqKH1HryTe7SVOj9ZG+DOWTj1lbx1gXw2gvv5vUO3fwLq/npo/bb3f4DLZ3nK/Tk2qvMymr8RGXV6jL60Zkh6OLakZW04zvpRmWBnNr605EAofyieHppSxpcGTSy30hTSDi2h6CmgeVDwzuHBmQNHMqIKZE4plBhbKSGs+Tv8b+dPTmWKMQQ8a874HjYc+Kj3+gxJPbYWfjujzt+Sr9XqGPq/yL9b7H39effqJb96GHf+gyZuYjYkSlrKeXNfWMob/AwAA//8DAEFEhj9SQwAA
+  recorded_at: Mon, 19 Dec 2022 16:22:56 GMT
+recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/test_braintree_sync_canceled_subscription_with_trial.yml
+++ b/test/vcr_cassettes/test_braintree_sync_canceled_subscription_with_trial.yml
@@ -1,0 +1,456 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/customers
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <customer>
+          <email>none@example.org</email>
+          <first-name>None</first-name>
+          <last-name>User</last-name>
+          <payment-method-nonce>fake-valid-visa-nonce</payment-method-nonce>
+        </customer>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:22:57 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"41fb8ef3f45db496af7a02e20a5c59de"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.529920'
+      X-Request-Id:
+      - d32f495d-eff7-4c10-b664-9e4a51073fde
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - d32f495d-eff7-4c10-b664-9e4a51073fde
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - '005296563f044'
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAOGPoGMAA7RYbU/jOBD+vr+i6veQJm2hXZVwK63g7qRFOi2wwJeVE0/bQGIH2yktv/7GeU/TpOHgpH6oZx6P7XnxPPHiYhsGgw0I6XN2PrRORsMBMI9Tn63Oh7c3l8ZseOF8WXixVDwE4XwZDBY+daan48l0Nh3ZCxNHWohKb02YMnD8tlu+Rm9qFz69UM+brhZmVavRS19IZTASgnPNGSzMikDrA5KPbiWIhVmOtdbjYUTYbsD84HyoRAxDM5FDSPzAYWjwD9iSMArghAtcPZVrRLRGZWPekmwbsldwpa+aWE8AUUANogZqF8H5kOJQ+SEMHXtk24aFv/mNdfrVtr9Ozx4XZjkhmR9H9H3zywnp+kkkjKUPAZXpllYBd0mgXfswvnujV3P1eP/38vrm4e36++3k+ubbbmGWmOwQ1FeGRwSV2TaIEGQ31Nq6PpWgzPWDALPCIJQKkDKXp/lg7/JEyGR5whj1ZKmKS3AZ/H13Z4Ai/C36loTItFIJAJVvvAUEWwWMaj93wgLukcBXbUsJWGEhtSgjLhXGAKsLnPnEGp0tzKqoepyYKbFLxAYJojWxWw++jxz3QbIYY+B7R6AdDk/qSJtxQbRZ+VihZFY+WC6JDbMldTGlmTMZWfZspjGskOu8N/Ryzp0vCe6sGFcRax5QzOQ2L+mk1NeeTwLnlj0z/srQUikrYam3+dLwpYwJ86CKbyqLiR938DvKtIT2uW4OgBt2dCkprBbn9mdlQiHN8RRcX5UeSYelckniIHeAy3kAhA0dHQkNTZQlOBYYZQNrNA60IypG9zX5FNhGvkj2Y4ScqbVjoXcawgPoHRChwzCuwRNpDQ10f+9LEkjIZlV2UjrSu7qcur/uYnplBfRqvXm8nD89WHP2w74L4M/oyftn77pP5q+BBGqNeVvJroosh/khWYERi8BZKxXJr6ZJpAQlT1xBfKYv0hU66JXsTjCVzYjsQmDqdwhqzenvgK+4ucGSOYnY6gLYxhecacC5JIy6fItNorBfrIh5rYvTJey53FpNmkOTNjBxrNnMyijBpNDhVgQPKqWWCwqAgIigQ6456rL/pY7T2EvYSTm/lOUwGbvSE36kY1nvm2XVK/4MzFmNAbZv3svCTMe5Nmb+S5xfnGgafeNjKxcOgGVPJ+7ZxCazuUthPFrSswm1KNgTMp7gJdQ6tbD9CVflBljIDUmfW7Ky0FdmCNxGWrOHuEQDVIqT1kxULJ1UD3RhZoIqxttssDJlhPYh7ZQ/8L5oCKtTyEYaIAQXdczhTpXhK624uVw3YN9UnXDsgf9KrXViqgazekPEE3jJLYLXuGwjGVUmTrykfegMxmKokPCKojoRM97Dvex7zbFGo1FSDwe1RywoJFbOtwg1Gx3fNkTNhRTJJx4Und2Et8cw1GdyRid6s9mglkaxEPhps8NGytOd3/78rhvPvvjYgTQPIJ0HqjCFxIpaY6wNakjA1cDw2ZK3HgNjsnzx5Izpz569AGU8pirrwZ4T0BEGnXqoi0UniD5MOgH2Y9PpzjoZdQLpYtVpmHoy6+yYx+hthTPWU6j5WZRpOm/9InoH2WY1QId7W776MVZa+P4dnKU55zhzyffzPiJXOcUR5pwh/8dema2Q34OJE9Pg4tVRFdbxH+RgmZUOIpIh+nG1DNzFj3PIu4lvHqxenzD5uY4wsAzWn+8Vm/hvH0iFu/twuwRqthT453zLfg5FS+wwUK9cPBtKECZJygrwLCNtxLKtuXVq21O8BFtwh0zVm/r9fTm5vd03EEkrl8nL2yBTDorGrZUHrDbaf1k3NLzbkV+P0YN9OSK/5vG9/bh9GP+YuCg/WF+aoDaZZl1afv770igcpO9r/631a+wQNHsr20+amiBZbJE1QTj41rb/KNF4TXvPR3o3F+hmAV39v0fn79XzO7t9R5/v2eH7vpz1fTfr/Wp2lFQcfTH7lOecD98v2P7KdCwGgMMy35wv/wIAAP//AwCvb2T6NhgAAA==
+  recorded_at: Mon, 19 Dec 2022 16:22:57 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/subscriptions
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <subscription>
+          <trial-period type="boolean">true</trial-period>
+          <trial-duration type="integer">14</trial-duration>
+          <trial-duration-unit>day</trial-duration-unit>
+          <payment-method-token>g3eexzcq</payment-method-token>
+          <plan-id>default</plan-id>
+        </subscription>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:22:57 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"ab022de5332789de48586cdc98d928f4"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.271075'
+      X-Request-Id:
+      - 7365fbc7-1b14-4c76-be6f-7032d8e03b70
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - 7365fbc7-1b14-4c76-be6f-7032d8e03b70
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - de0c8f62e1f04
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAOGPoGMAA5RVyW7bMBC95ysM3WnJTtdAVlqg6A80ufRGk2OLrUSqXBIrX98hKcmWxQQtEBjhzHujWR6H5f2pbVZPoI1Qcpdt1kW2AskUF/K4yx4fvpNP2X11Uxq3N0yLziKsulmtSso5UdKsbN/BLqNa0z7Lg2dPGyoZVMW6KMp8PAWPaBqMSzjtiTqQVklbDwGEtHAEnVVbpCRgM34HWihOQHLEWFhJ0ewyqx2MGcxxxlJt00imAc2cUDvk4VFWtICJFNst2eDf54fNh7vt9u79x59lfiYEvuv4//HPhPh9pzVIS8aMWc8auG4JdjGJCxGwSYZ01GCBblkfF4YpJ21qTgcqGqeBBEDimzN/ZAhtzjmEhp6rDhXfkmJDCpzhEhoiCF4d9/Xzy3OZ47/e0oJmNcXSKAsfImjvaF/mKYcnSEC1Ejh1QsNY1l6pBqjMKl96mc8gA+kUsyG0DeVsojoX9hn4QkOv0JaIRYA327RARr5r91gAan82b7MYb0cFJ7bWyh3rtMCxla0XTgu2xiSt+g2yOt4CnF7YnzJPugMPb63vOIcDdY1F5GAITi3wRg+9iAdvxntmnam+MiuecArD0XusFrRBgWrq98e11jbvynyOSJCIk8JW3Csj5TgT4jjSwrhExPsBcasp7Y++9bRdNNFXXCuZsjvdLFqez4NO3/CVX2OtptJQ5n2pKxpbSGphMFg/AwwJDAgUfNReMPoFhI62+8elNOGnCK+OMlZtQFe/qFHyS/jFe6olmDVTLW4475ziXDwbxCinUSq0Exgx4RhJrz4gcRRJ8QVX3JKsJ8IoXFscqscf38bleWmeYr2hcj/J6+5OlmEi+DDm85fxLwAAAP//AwCTq6xHUAcAAA==
+  recorded_at: Mon, 19 Dec 2022 16:22:58 GMT
+- request:
+    method: get
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/subscriptions/gbhwzw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:22:58 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"0222f909dc7e07f27fefe9f293cbf882"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.183508'
+      X-Request-Id:
+      - e378aa2f-209f-405f-867b-b703584e12e3
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - e378aa2f-209f-405f-867b-b703584e12e3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - 872e9fa2060b4
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAOKPoGMAA5RVyW7bMBC95ysM3WnJTtdAVlqg6A80ufRGk2OLrUSqXBIrX98hKcmWxQQtEBjhzHujWR6H5f2pbVZPoI1Qcpdt1kW2AskUF/K4yx4fvpNP2X11Uxq3N0yLziKsulmtSso5UdKsbN/BLqNa0z7Lg2dPGyoZVMW6KMp8PAWPaBqMSzjtiTqQVklbDwGEtHAEnVVbpCRgM34HWihOQHLEWFhJ0ewyqx2MGcxxxlJt00imAc2cUDvk4VFWtICJFNst2eDf54fNh7vt9u79x59lfiYEvuv4//HPhPh9pzVIS8aMWc8auG4JdjGJCxGwSYZ01GCBblkfF4YpJ21qTgcqGqeBBEDimzN/ZAhtzjmEhp6rDhXfkmJDCpzhEhoiCF4d9/Xzy3OZ47/e0oJmNcXSKAsfImjvaF/mKYcnSEC1Ejh1QsNY1l6pBqjMKl96mc8gA+kUsyG0DeVsojoX9hn4QkOv0JaIRYA327RARr5r91gAan82b7MYb0cFJ7bWyh3rtMCxla0XTgu2xiSt+g2yOt4CnF7YnzJPugMPb63vOIcDdY1F5GAITi3wRg+9iAdvxntmnam+MiuecArD0XusFrRBgWrq98e11jbvynyOSJCIk8JW3Csj5TgT4jjSwrhExPsBcasp7Y++9bRdNNFXXCuZsjvdLFqez4NO3/CVX2OtptJQ5n2pKxpbSGphMFg/AwwJDAgUfNReMPoFhI62+8elNOGnCK+OMlZtQFe/qFHyS/jFe6olmDVTLW4475ziXDwbxCinUSq0Exgx4RhJrz4gcRRJ8QVX3JKsJ8IoXFscqscf38bleWmeYr2hcj/J6+5OlmEi+DDm85fxLwAAAP//AwCTq6xHUAcAAA==
+  recorded_at: Mon, 19 Dec 2022 16:22:58 GMT
+- request:
+    method: put
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/subscriptions/gbhwzw/cancel
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:22:58 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"92e0447ed26a1fac126d10682e4d45a2"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.178738'
+      X-Request-Id:
+      - 00eaba0e-5b09-4d30-8d26-e99151a733a3
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - 00eaba0e-5b09-4d30-8d26-e99151a733a3
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - f2bedbf525f54
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAOKPoGMAA+xW227bMAx971cEflftpNt6geNu2LAfWPuyN0ViY2225OnSxv36UZKdxLEaFNjrgCCIyUOKPDqkU97v2mbxDNoIJdfZ8rLIFiCZ4kJu19njw3dyk91XF6VxG8O06CzCqovFoqScEyXNwvYdrDOqNe2zPHg2tKGSQVVcFkWZj0/BI5oG8xJOe6KeSKukrYcEQlrYgs6qFYYkYJP4DrRQnIDkiLGwkKJZZ1Y7GCuY4oyl2qaRTAOaOaF2qMOjrGgBCylWK7LEz+3D8tPdanX38fpnmR8CQrzr+PvjbzD+EBDPd1qDtGSsmPWsgVNKkMUkLmRAkgzpqMEG3bw/LgxTTtrUPT1R0TgNJAASZ078MUJoc6ghEHroOnR8RYolKfAO59CQQfBqu6lfXl/KHH96Swua1RRboywcRNDe0b7MUw4fIAHVSmDXCQ1jWxulGqAyq3zrZT6BDEG7WA2hbWhnGdU5s0/ARxp6I2yOmCU4S9MMGeNdu8EGUPuT+zaz6+2o4MTWWrltnRY4Utl64bRgayzSqt8gq+0VwO6V/SnzpDvE4dR6xjk8UddYRA6G4NQCJ3rgIj54M86Zdab66ue9AV7mg8H7rBa0QYlq6jfIqdqWH8p8ikgEESeFrbjXRspxCIgXkpbGMSJOCMS9prR/9OTTdkaj77lWMmV3upmRnk+T7s/wnZ9irabSUOZ9qSGNFJJaGEzWTwBDAQMCJR/VF4x+BaGj7d65lvb4fYYzlxn7NqCrX9Qo+Tl846xqCeaSqRa3nHfuMx29OohRTqNcaCcwY8IxBr35EomXkRRgcMVNyXoijMLVxaF6/PFtXKDH5n2uM0r3dznn998pvz5H+RcUwzP8J3xkd28ZhgD/jeTTvyN/AQAA//8DAJ+wBSHFCAAA
+  recorded_at: Mon, 19 Dec 2022 16:22:58 GMT
+- request:
+    method: get
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/subscriptions/gbhwzw
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:22:58 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"92e0447ed26a1fac126d10682e4d45a2"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.044618'
+      X-Request-Id:
+      - a077c486-266f-4568-bc6a-465edee34728
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - a077c486-266f-4568-bc6a-465edee34728
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - fc09b8b70b144
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAOKPoGMAA+xW227bMAx971cEflftpNt6geNu2LAfWPuyN0ViY2225OnSxv36UZKdxLEaFNjrgCCIyUOKPDqkU97v2mbxDNoIJdfZ8rLIFiCZ4kJu19njw3dyk91XF6VxG8O06CzCqovFoqScEyXNwvYdrDOqNe2zPHg2tKGSQVVcFkWZj0/BI5oG8xJOe6KeSKukrYcEQlrYgs6qFYYkYJP4DrRQnIDkiLGwkKJZZ1Y7GCuY4oyl2qaRTAOaOaF2qMOjrGgBCylWK7LEz+3D8tPdanX38fpnmR8CQrzr+PvjbzD+EBDPd1qDtGSsmPWsgVNKkMUkLmRAkgzpqMEG3bw/LgxTTtrUPT1R0TgNJAASZ078MUJoc6ghEHroOnR8RYolKfAO59CQQfBqu6lfXl/KHH96Swua1RRboywcRNDe0b7MUw4fIAHVSmDXCQ1jWxulGqAyq3zrZT6BDEG7WA2hbWhnGdU5s0/ARxp6I2yOmCU4S9MMGeNdu8EGUPuT+zaz6+2o4MTWWrltnRY4Utl64bRgayzSqt8gq+0VwO6V/SnzpDvE4dR6xjk8UddYRA6G4NQCJ3rgIj54M86Zdab66ue9AV7mg8H7rBa0QYlq6jfIqdqWH8p8ikgEESeFrbjXRspxCIgXkpbGMSJOCMS9prR/9OTTdkaj77lWMmV3upmRnk+T7s/wnZ9irabSUOZ9qSGNFJJaGEzWTwBDAQMCJR/VF4x+BaGj7d65lvb4fYYzlxn7NqCrX9Qo+Tl846xqCeaSqRa3nHfuMx29OohRTqNcaCcwY8IxBr35EomXkRRgcMVNyXoijMLVxaF6/PFtXKDH5n2uM0r3dznn998pvz5H+RcUwzP8J3xkd28ZhgD/jeTTvyN/AQAA//8DAJ+wBSHFCAAA
+  recorded_at: Mon, 19 Dec 2022 16:22:58 GMT
+- request:
+    method: get
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/payment_methods/any/g3eexzcq
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:22:59 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"20eb4db2dcc4af6becbfb86e8985d2aa"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.222600'
+      X-Request-Id:
+      - 3ccbc1f9-a4a9-42d0-b591-44dd10fe95e6
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - 3ccbc1f9-a4a9-42d0-b591-44dd10fe95e6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - 5d46670839784
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAOOPoGMAA+xY3W/bNhB/z18R+J2RJTuNXTjqig3pNqABhiZpkpeCFmlbiUyqJOXE+et3FPVBSZScrN2eBgSBdffjkbxv3uLD8zY53lEhY87OR/7JeHRMWcRJzNbno+urCzQbfQiPFpGgJFYowoKER8fHi2WcJABBmBBBpdQ0oMYkDPYLLybFd5RJxbdUIKCcvptMT2en42Dh2WQDXMVCKsTwlh6zODkfKZHRkVcwE9zPi/g2xWzv4EglKFXlAR0A+qwoI5QMQBIe4SRWLvGCrkFjDkbKpcIJAhXScD71x2cLzyaVx86YEvuchHCSbnDgvFwbNTmEYhnoNY4GYD2KTDec5cuXVLhWC4qV1pU6VvuUno8IfKp4S0dhMA4C5MPf/Mp/9z4I3p+e3YONqwWFhCwlb5NQL8g9znO4HLghC6djP5jNNJ/lNO2jSG8R3sQSw0mq75K74QkB73NpQjsUaDCKcRJes0fGnxhIqGlHlib5CsVSZphF1MZ2mUc/rsBXhlINWyd8CT4H5LvJzQv5NFf3t3+uLq/uXi5/u55eXn3cW4trcEOGdn8FXh5ef7HAFVVjCV3Gqr69+TSMFc6S8rJLzhOK2SjUmtawnGmAmQDLIYinLNEXtoS1OUd51KaxyPdHW87UJvRBCx1iC7mnWGg1TxrQnFohKWmfdYUTSYsVxe61oqJPF6fLrzcZ+eQn5NNmd38xf7jz5+xzcJPQ39OH6K+F11TrhuJEbcD/LG+xaBoSb/Gaokwk4UapVL73PCwlVfJkKXDMdEJbgyKe8P4EXNJL8X5Lmfq2pWrDybeEr7m3A5c/Sdn6A2W7WHCmAecSM7Lkz5CYK/n5buCfOqCWmD3WR2pQj8r0Ow392cxfeMWHpsP2gidWmJSEnCloiuHilxzoxW9D5ySLlNZJva6maYjMljIScaptJAubYCHwflRmdgtgSECErIDaeK/ighnySByfjMeQKYqviltkFoLzuM1dqBAEWqdrKiBI6wRkwzoyUki/nCCoLEhHeDeVdrFQHITqR/9w6n1r8p11km9RzIUAb0Ll6aN9lNC2msY6UThwlRRQnkSp9iKSue9LYpkn0T5brnCcZIKiHOTYv8GvV+UdRm1CRS1N5FqYoLGPdE7tQisp4KLr5ebp5alucoCqi8MGw5VxlG+qPRmCYeG5GOUiRqHrQia5SHeabECshc/mdAhv8yv6xqs79M4Cy+d6lnYRTiGD6usgaxl5d6Fjp+Ebjs4rTy8xlO2N4Nl60x8cRQ5EJgcixR8pC9cTSp9fou8Lz8mu1kIW0BYpqhGgC0IFgE6KljoyHyULYlZlMvxV55GEkoVXEEq+EtAtgIubUtP2Un+68JqInoUoY1BPifYlF6O5yBjO7Uo2oo40avIoFyVJG8nZHxp96B6xhwdFxWkgr7tJta+zgc6vg5nEUbcAeC39o00MTYnYO6qEjYIwqj3Z7ACpD5jb9JXpsMI3pBxwAqMXSUX4gCVnv+T/IR8IRqUu4JBlNbMh0SptSPJMgMvhNAbJDoa9cLDAHXDmnG2ydrSHrpWbl8r1l9/KZG6TGzIPRJC2v9sGP8c0Z4dM8xGcaEf/N8xrDVNRi8AqOi6v3XI1KeYt1s69VbJdQK76npWPSzgFbBivYtAwpX5wOl2eTQM8my8JnYxX5GxKfEKDKZ5M4fHWu/ToJzwp4eZbjiR57On8K36BFrC1efs4+1Ib0C4UhucoFNFuBy8cmYJMauz4GYzbIVZt7g4sJgQXTb4zjWqsNXrobjMMsMU0hykt4B9G0iCmFFa8X4D7QPMED7909Dkv8I/6KnhNRLB/W0MQYCa+3NyB1Qr6mfBjCpydtl8fwnqIxPpiutx2oG47mU7LJIBW2/XW6HdeQM8+8OAFiumIScAbsCOCZwmNdBsdsxV3Hht0vvoeyRmjotENF72dlWqGpns5YGDCZ7TQN+UrQmx40peDDk/7zEl6J345u2/qZ1T/islfcZ2hUZw167LfgPb4tbRUX8atLNGZjtkK777py92GJmiVPl85h+nih6cxleO/eghlnXpgsleg/qVaVEgv81GuLGM0CGmbWGN/YJZUOpx7yFJwD8+bCmDfDK9kv2lAV7n4oTFqeYeBKVIBed2cqhVbbxnOVuo8NJsywekIxv9+SNNtZ3IZjKonLh6R9YTSZx9rAX7gz/13QXB6ph/pTlxbTLNI3t7WC93ls8PNS6OE7jyBgDTM46oYaqZDYqOc1n5Ptjd7/PU+vQsuxvjrPLsN7p/vJp+nS6B34kM3b81urEmRxQQUVYrQuTN+6Z0Cu6DhUcsZ/gYAAP//AwCs37UTThsAAA==
+  recorded_at: Mon, 19 Dec 2022 16:22:59 GMT
+recorded_with: VCR 6.1.0

--- a/test/vcr_cassettes/test_braintree_sync_subscription_with_trial.yml
+++ b/test/vcr_cassettes/test_braintree_sync_subscription_with_trial.yml
@@ -1,0 +1,310 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/customers
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <customer>
+          <email>none@example.org</email>
+          <first-name>None</first-name>
+          <last-name>User</last-name>
+          <payment-method-nonce>fake-valid-visa-nonce</payment-method-nonce>
+        </customer>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:11:07 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"19129c2c14953123b09c783691117de8"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.585981'
+      X-Request-Id:
+      - c7f079db-1bd9-4779-9319-2077c8e3f97b
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - c7f079db-1bd9-4779-9319-2077c8e3f97b
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - a2d8d716b72a4
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIABuNoGMAA7RY227bOBB971cYfldkyXYTB466C3QTbIGmWDRJ07wUtEjbjCVSJSknztfvkLpRliUrmyzgB3PmcEjOhXPE+afnOBpsiZCUs4uhdzIaDggLOaZsdTG8vbl0zoafgg/zMJWKx0QEHwaDOcWBdzo7nc2ms9O5CyMtBGW4Rkw5MH7ZLZ+SF7WLH3/jMJyu5q6t1eglFVI5DMUkuOaMzF1LoPURKka3koi5W421NuRxgthuwGh0MVQiJUPXyEmMaBQwMPgHeUZxEpETLmD1TK4RyRqUjXlL9NyQPZGFpKqJDQVBimAHqYHaJeRiiGGoaEyGgT/yfceD3+zG+3jueeej04e5W00w89MEv25+NSFb30TCWVISYZltaRXxBYq0a3+O717w1Uw93H9Zfr0Jp9cvm+n1zWY8dytMfghMlRMigWW+DSQE2g21tq7PJCBb0CiCrHAQxoJIWcizfMCbIhFyWZEwTj1ZbHEFroK/7+4cUIa/Rd+SELlWKkGIKjbeAiLPijCs/dwJi3iIIqralhJkBYXUoky4VBADqC4SzCbeCPxhi+zjpEyJnRE7KErWyG89+D5y3AfJUogBDY9AOxxu6kibWRDRZuVthZJbeWO5GBtuS+pCSrNgMvL8szONYaVc572jlwvuqESws3JsI9Y8wpDJbV7SSamvPYqi4JZtGH9iYKmSVbDM23zpUClTxEJi45vKcuLbHfyKMq2gfa6bA+CGHV1KCqoluP1uTSilBR6TBVWVR7JhpVyiNCocsOA8IogNAx0JDTXKCpwKiLIDNZpG2hGW0X1NMYU8J1SY/TgxZ2odeD60k33hAfSOIKHDMK7BjbSGJnh/70sUSZLPsnZSOTK8upwuftyl+MqL8NV6+3A5e/zpzeLrm2v27fOXp2//7F33Zv6aoEitIW+t7LJkBYzGaEWcVETBWqlEnrsukpIoebIQiDJ9ka7AQU9odwKp7CZoFxOmfsVErTn+FfEVd7dQMicJW30ibEsFZxpwIRHDC/4MTaK0X64Iea2Lc4HYptpaTVpATRuYBN7ZmZdTgkmpg60IHlmlVghKgCAJAodcc9Dl/ysdx2lo2Ek1v5IVMJkuZChoomNZ75tV1Su+ISxYTserMz+Zzd1sXGhTRn+nxcUJpsE3FFq5CAjx/OlkcTrx0dlsgcl4tMSnE+xh4k/QeAKXUOvU0vY7XJVbwmLuSLxpycpSb80QsI2sZg9xiQaoEpvWjFQqg0xP8NzNBTYm3G6hMmUC9knWKb/CfdEQ2lPQVjpECC7qmMOdKsdbrbi5XDdg31SdcOyB/86sdWJsg3m9AeKRhOYWgWtctpEMm4mj0LQPncFQDBYJtxT2RMj4EPay77XAG41Gph4Oao9YUECsgj8T0Gx1fNsQNRdiIJ9wUHB2E94ew1ifKRid6M3mg1oapULAp80OGinPdn77/bNuPPviYwfSPAB1HshiCsaKWkOsHexIAqsRh7Ilbz0GxGQzlmS39CZ1Sl1RcFvWgz0b0BEGnXmoi0UbRB8mbYD92HS2s05GbSBdrDoLU09mnR/zGL21OGM9hZqfRbmm89Yvo3eQbdoBOtzbitWPsdLS96/gLM05x5lLsZ/XETnrFEeYc478H3tlvkJxDxonZsGFq8MW1vFv5GC5lQ4ikiP6cbUc3MWPC8iriW8RrF6fMMW5jjCwHNaf75Wb+G8fSKW7+3A7A3VbCvx9vmXfh6IZO4yoJy42jhKISZSxAjjLSBvxfG/mffTMJdiCO2Sq3tTv76vJ7e2+gTCtXJqXt0GuHJSNWysPWG20/6pucHy3Qz8ekp/+5Qj9mKX3vnwJ/bvpw+Nfo4P1pQlqk2nWpdXnP5VO6SB9X9OX1q+xQ9D8rWw/aWoCs9g8b4Lk4Fvb/qNE4zXtNR/p3VygmwV09f8enb9Xz+/s9h19vmeH7/ty1vfdrPer2VFScfTF7F2ec958v0D7q9KxHBAYVvkWfPgXAAD//wMAfgcgJzYYAAA=
+  recorded_at: Mon, 19 Dec 2022 16:11:07 GMT
+- request:
+    method: post
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/subscriptions
+    body:
+      encoding: UTF-8
+      string: |
+        <?xml version="1.0" encoding="UTF-8"?>
+        <subscription>
+          <trial-period type="boolean">true</trial-period>
+          <trial-duration type="integer">14</trial-duration>
+          <trial-duration-unit>day</trial-duration-unit>
+          <payment-method-token>f53g82p9</payment-method-token>
+          <plan-id>default</plan-id>
+        </subscription>
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 201
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:11:07 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"570598edc82319e87b70f0623f09a7ae"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.230664'
+      X-Request-Id:
+      - 903a9366-9ad1-4a1b-a76e-e1241df55997
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - 903a9366-9ad1-4a1b-a76e-e1241df55997
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - 1a868c18e2c34
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIABuNoGMAA5RVyW7bMBC95ysM3WlJdts4gay0QNEfaHLpjSbHFluJFLgE1t93SMqLLDpogcAIZ94bzfI4rF6OXbt4B22EktusXBbZAiRTXMjDNnt7/UE22Uv9UBm3M0yL3iKsflgsKso5UdIs7NDDNqNa0yHLg2dHWyoZ1MWyKKr8dAoe0bYYl3A6ELUnnZK2GQMIaeEAOqtXSEnAJvwetFCcgOSIsbCQot1mVjs4ZTDFGUu1TSOZBjRzQu2Yh0dZ0QEmUqxWpMS/p9fyy3NZPhePv6r8Qgh81/P/418I8ftOa5CWnDJmA2vhtiXYxSQuRMAmGdJTgwW6eX1cGKactKk57alonQYSAIlvTvyRIbS55BAaeqk6VLwmRUkKnOEcGiIIXm8e14whAv/1lg40ayiWRln4EEF7T4cqTzk8QQKqlcCxFxpOZe2UaoHKrPalV/kEMpKOMRtCu1BOGdU5s0/AVxq6Q5sjZgE+bNMMGfmu22EBqP3JvM1svD0VnNhGK3do0gLHVnZeOB3YBpO06g/Iev95fdis+qcqT7oDD2+t7ziHPXWtReRoCE4t8EaPvYgHb8Z7Zp2pvzEr3nEK49F7rBa0RYFq6vfHrdbKT1U+RSRIxElha+6VkXJcCHEcaWFcI+L9gLjVlPZH33razZroK26UTNmdbmctz6dBz9/wld9irabSUOZ9qSsaW0gaYTDYMAGMCYwIFHzUXjD6BYSOrv/HpXTGnyPcHWWs2oCuf1Oj5Nfwi/dUSzBLpjrccN55jnP1bBCjnEap0F5gxITjRLr7gMRRJMUXXHFLsoEIo3Btcajffn4/Lc9r8znWByr3k7zt7tkyTgQfxnz6Mv4FAAD//wMAt+tRYVAHAAA=
+  recorded_at: Mon, 19 Dec 2022 16:11:07 GMT
+- request:
+    method: get
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/subscriptions/873cc2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:11:08 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"86a0e29d6c82129aeaf6be0117801c42"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.059531'
+      X-Request-Id:
+      - 92fed81e-a9b9-46a8-980c-8a45f61c644d
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - 92fed81e-a9b9-46a8-980c-8a45f61c644d
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - 9a889dd2040b4
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAByNoGMAA5RVyW7bMBC95ysM3WlJdts4gay0QNEfaHLpjSbHFluJFLgE1t93SMqLLDpogcAIZ94bzfI4rF6OXbt4B22EktusXBbZAiRTXMjDNnt7/UE22Uv9UBm3M0yL3iKsflgsKso5UdIs7NDDNqNa0yHLg2dHWyoZ1MWyKKr8dAoe0bYYl3A6ELUnnZK2GQMIaeEAOqtXSEnAJvwetFCcgOSIsbCQot1mVjs4ZTDFGUu1TSOZBjRzQu2Yh0dZ0QEmUqxWpMS/p9fyy3NZPhePv6r8Qgh81/P/418I8ftOa5CWnDJmA2vhtiXYxSQuRMAmGdJTgwW6eX1cGKactKk57alonQYSAIlvTvyRIbS55BAaeqk6VLwmRUkKnOEcGiIIXm8e14whAv/1lg40ayiWRln4EEF7T4cqTzk8QQKqlcCxFxpOZe2UaoHKrPalV/kEMpKOMRtCu1BOGdU5s0/AVxq6Q5sjZgE+bNMMGfmu22EBqP3JvM1svD0VnNhGK3do0gLHVnZeOB3YBpO06g/Iev95fdis+qcqT7oDD2+t7ziHPXWtReRoCE4t8EaPvYgHb8Z7Zp2pvzEr3nEK49F7rBa0RYFq6vfHrdbKT1U+RSRIxElha+6VkXJcCHEcaWFcI+L9gLjVlPZH33razZroK26UTNmdbmctz6dBz9/wld9irabSUOZ9qSsaW0gaYTDYMAGMCYwIFHzUXjD6BYSOrv/HpXTGnyPcHWWs2oCuf1Oj5Nfwi/dUSzBLpjrccN55jnP1bBCjnEap0F5gxITjRLr7gMRRJMUXXHFLsoEIo3Btcajffn4/Lc9r8znWByr3k7zt7tkyTgQfxnz6Mv4FAAD//wMAt+tRYVAHAAA=
+  recorded_at: Mon, 19 Dec 2022 16:11:08 GMT
+- request:
+    method: get
+    uri: https://api.sandbox.braintreegateway.com/merchants/zyfwpztymjqdcc5g/payment_methods/any/f53g82p9
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept-Encoding:
+      - gzip
+      Accept:
+      - application/xml
+      User-Agent:
+      - Braintree Ruby Gem 4.9.0
+      X-Apiversion:
+      - '6'
+      Content-Type:
+      - application/xml
+      Authorization:
+      - Basic NXI1OXJyeGhuODlucGM5bjowMGYwZGY3OTMwM2UxMjcwODgxZTVmZWRhNzc4ODkyNw==
+  response:
+    status:
+      code: 200
+      message: ''
+    headers:
+      Date:
+      - Mon, 19 Dec 2022 16:11:08 GMT
+      Content-Type:
+      - application/xml; charset=utf-8
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      Referrer-Policy:
+      - strict-origin-when-cross-origin
+      X-Authentication:
+      - basic_auth
+      X-Braintree-Merchant-Shard:
+      - '2'
+      Vary:
+      - Accept, Accept-Encoding, Origin
+      X-User:
+      - k8kdyxqxh8zjnf35
+      Content-Encoding:
+      - gzip
+      Etag:
+      - W/"c74a6f3908b0b71fe9181b90e533b427"
+      Cache-Control:
+      - max-age=0, private, must-revalidate
+      X-Runtime:
+      - '0.215467'
+      X-Request-Id:
+      - b29bd630-639c-47de-8b13-693a603f36e6
+      Content-Security-Policy:
+      - frame-ancestors 'self'
+      X-Broxyid:
+      - b29bd630-639c-47de-8b13-693a603f36e6
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains
+      Paypal-Debug-Id:
+      - 07d31514c70a4
+      Transfer-Encoding:
+      - chunked
+    body:
+      encoding: ASCII-8BIT
+      string: !binary |-
+        H4sIAByNoGMAA8xYbU/jOBD+3l+B+t2kacvSopK9lfZAt9KyOi2wLF9Wbuy2oamds51C+fU3jvPiJE6A4046CaFm5vHYnnfP4uPTLj7aUyEjzs6H/vFoeERZyEnE1ufDm+sLNBt+DAaLUFASKRRiQYLB0dFiGcUxQBAmRFApNQ2oEQnIduFFJP8OU6n4jgoEFP90fjqfn8xPF55NNsBVJKRCDO/oEYvi86ESKR16OTPG3byQ7xLMDg6OVIJSVRzQAaBPijJCSQ8k5iGOI+USL+gaNOZgJFwqHCNQIQ3mU38E97VJxbFTpsQhIyEcJxs8dl6uiZq8hGIp6DUKe2Adikw2nGXLl1S4VguKldaVOlKHhJ4PCXyqaEeHwXg0HiMf/ubX/ocz3z8bnd6DjcsFuYQ0IW+TUC3IPM5zuBy4IQumI388m2k+y2jaR5HeIriNJIaTlN8Fd8NjAt7n0oR2KNBgGOE4uGFbxh8ZSKhoA0uTfIUiKVPMQmpj28zB+xX4ylCqYOuYL8HngPxzcvtMLufq/u7L6ut1eHL1vD25ut5OrMUVuCZDu78CLw9uvlvgkqqxhC4jVd3efBrGCqdxcdkl5zHFbBhoTWtYxjTAVIDlEMRTGusLW8KanEEWtUkksv3RjjO1CfzxwmsRG8gDxUKreVKDZtQSSUnzrCscS5qvyHevFBVeXpwsf9ym5NKPyeVmf38xf/jpz3dX11fs2+cvj9/+XHh1tW4ojtUG/M/yFoumIdEOrylKRRxslErkmedhKamSx0uBI6YT2hoU8YgPx+CSXoIPO8rUrx1VG05+xXzNvT24/HHC1h8p20eCMw04l5iRJX+CxFzKz3YD/9QBtcRsWx2pRh0U6Xca+LOZv/DyD02H7QWPrTApCBlT0ATDxa840PPfhs5JGiqtk2pdRdMQmS5lKKJE20jmNsFC4MOwyOwWwJCACFkBNfFeyQUzZJE4Oh6NIFPkXyU3zywEZ3GbuVAuCLRO11RAkFYJyIa1ZCSQfjlBUFmQjvB2Km1joTgI1Y1+d+p9f/LNi7kQ4E2oOH14CGPaVNNIJwoHrpQCypMo0V5EUvd9SSSzJNplyxWO4lRQlIEc+9f41aqsw6hMqKiliUwLEzTy0Qjs3IaWUsBFZ6eTMBxXTQ5QdXHYYLgyDrNNtSdDMCw8F6NYxCh0XcgkF+lOkzWItfDJnA7hXXZF33h1i95aYPlcx9I2wimkV30tZCUj6y507NR8w9F5ZeklgrK9ETxdb7qDI8+ByORApPiWsmB1MlnPxsl84TnZ5VrIAtoieTUCdE4oAdBJ0UJH5qNgQcyqVAafQhXtwVL5Z8FVAnoFcHBTaJo+6k8XXh3RsRClDKop0Z7kYtQXGbO5HclGVHFGTRbloiBpEzm7Q6MN3SF28KCkOM3jtTcp93W2z9l1MJM4bKd/r6F9tImgJREHR42wURBElR+bHSDxAXOXvDIZlvialF4XMFqRVAQPWHL2W/YfcoFgVOriDRlWM2vyrLKGJE8FuBtOIpDsYNgLe4vbC46csU3GDg/QsXLzSrn5/rlI5Da5JvOF6NHWd1mgpObWy4u616zqdYpp95vhXcbzAgLir7R4v8ApYMNoFYGGKfXHJ9Pl6XSMZ/MloZPRipxOiU/oeIonU3gfdC4d/AuvFrj5jiNJth3NZcnP0QK2Nu21s/WxAc1cZHiUtLJRuN9DEy0TkEmNHb+CcVvEspPag8WE4KLOd8aqxlqv2/Y2/QBbTP293gD+YST1YgpheYsM3AeaZRH4paPPeYF/VLqhYQ1h/6aGIMBMfLm5PasVlMzgUwKcvbZfF8LqdSN9MZ3TW1C3nUwxNwmgUdnfGv3OC+jnNe69QP4ANwl4A3ZE0PnSUHdqEVtx57FB59uJpIeVLpmWAfL2wUo1fQOkDNAzRDJa6Bok5SHWP0zKQC8PlMxJOodKGbtrsGRU/4rhUn6dvmmPNU6xnxn2hK+wVFfGLS3RGsDYCm8/G4vd+oY0pT5f+dRv4/sf/KXjv3rOYZ26Z3iUo/6jWpRLL/JRpixjNAhpm1hh3zGuKBzO/Y7PuS+PNHJg15ioYL9pBlS6+EuTuuIOPYOKHPK6UUgjtt4y/yvV+dL4wwSnIxj/N3MARtUjF1tk9en67CMtwB/7c/+DnyWmDlxTTL1I3t1VC93ls8XNSqOE7jyGgDTMo7IYaqZDYq2cVn5PdrcH/OM++Tm+GOEf8/RuLJ/D8e3J/cPvo1Z86Oat3o3VKTIfsqFSETp3Rs+dg0YXNBg0nOFvAAAA//8DAH5kvkWxGQAA
+  recorded_at: Mon, 19 Dec 2022 16:11:08 GMT
+recorded_with: VCR 6.1.0


### PR DESCRIPTION
This adds a `sync` method to the Braintree Subscription class.

Also changes Braintree subscriptions webhooks to sync instead of immediately operating on the subscription. This should make it more reliable in case webhooks arrive out of order, etc.