### PR TITLE
add scope resolution operator to calls to Mail::Address

### DIFF
--- a/lib/pay.rb
+++ b/lib/pay.rb
@@ -95,8 +95,8 @@ module Pay
   # Should return String or Array of email recipients
   mattr_accessor :mail_to
   @@mail_to = -> {
-    if ActionMailer::Base.respond_to?(:email_address_with_name)
-      ActionMailer::Base.email_address_with_name(params[:pay_customer].email, params[:pay_customer].customer_name)
+    if ::ActionMailer::Base.respond_to?(:email_address_with_name)
+      ::ActionMailer::Base.email_address_with_name(params[:pay_customer].email, params[:pay_customer].customer_name)
     else
       ::Mail::Address.new.tap do |builder|
         builder.address = params[:pay_customer].email

--- a/lib/pay.rb
+++ b/lib/pay.rb
@@ -4,7 +4,7 @@ require "pay/errors"
 require "pay/adapter"
 
 require "action_mailer"
-require "active_support/dependencies"
+require "active_support"
 
 module Pay
   autoload :Attributes, "pay/attributes"

--- a/lib/pay.rb
+++ b/lib/pay.rb
@@ -3,6 +3,7 @@ require "pay/engine"
 require "pay/errors"
 require "pay/adapter"
 
+require "action_mailer"
 require "active_support/dependencies"
 
 module Pay

--- a/lib/pay.rb
+++ b/lib/pay.rb
@@ -38,7 +38,7 @@ module Pay
   mattr_accessor :support_email
 
   def self.support_email=(value)
-    @@support_email = value.is_a?(Mail::Address) ? value : Mail::Address.new(value)
+    @@support_email = value.is_a?(::Mail::Address) ? value : ::Mail::Address.new(value)
   end
 
   mattr_accessor :automount_routes
@@ -98,7 +98,7 @@ module Pay
     if ActionMailer::Base.respond_to?(:email_address_with_name)
       ActionMailer::Base.email_address_with_name(params[:pay_customer].email, params[:pay_customer].customer_name)
     else
-      Mail::Address.new.tap do |builder|
+      ::Mail::Address.new.tap do |builder|
         builder.address = params[:pay_customer].email
         builder.display_name = params[:pay_customer].customer_name.presence
       end.to_s


### PR DESCRIPTION
This PR adds resolution to `Mail::Address` as a top level constant to avoid any confusion about this constant belonging under the `Pay` namespace.

Closes #770