### PR TITLE
Fix example link in Paddle passthrough example

### DIFF
--- a/docs/6_subscriptions.md
+++ b/docs/6_subscriptions.md
@@ -44,7 +44,7 @@ Paddle.Checkout.open({
 Or with Paddle Button Checkout:
 
 ```html
-<a href="#!" class="paddle_button" data-product="12345" data-email="<%= current_user.email %>" data-passthrough="<%= Pay::Paddle.passthrough(owner: current_user) %>"
+<a href="#!" class="paddle_button" data-product="12345" data-email="<%= current_user.email %>" data-passthrough="<%= Pay::Paddle.passthrough(owner: current_user) %>">Buy now!</a>
 ```
 
 ###### Paddle Passthrough Helper


### PR DESCRIPTION
This PR updates the Paddle checkout example in the documentation to produce a valid hyperlink - the current example doesn't have a closing `</a>` tag or any text.