### PR TITLE
Fake processor subscriptions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ test/dummy/config/master.key
 
 # Releases
 pay-*.gem
+.ruby-version

--- a/lib/pay/fake_processor/billable.rb
+++ b/lib/pay/fake_processor/billable.rb
@@ -19,8 +19,9 @@ module Pay
         pay_customer
       end
 
-      def update_customer!
-        # pass
+      def update_customer!(**attributes)
+        # return customer to fake an update
+        customer
       end
 
       def charge(amount, options = {})
@@ -55,6 +56,8 @@ module Pay
         if (trial_period_days = attributes.delete(:trial_period_days))
           attributes[:trial_ends_at] = trial_period_days.to_i.days.from_now
         end
+
+        attributes.delete(:promotion_code)
 
         pay_customer.subscriptions.create!(attributes)
       end

--- a/test/dummy/config/application.rb
+++ b/test/dummy/config/application.rb
@@ -13,7 +13,7 @@ module Dummy
 
     config.active_job.queue_adapter = :test
     config.action_mailer.default_url_options = {host: "localhost", port: 3000}
-    config.active_record.legacy_connection_handling = false if ("6.1".."7.0.4").cover?(Rails.version)
+    config.active_record.legacy_connection_handling = false if ("6.1".."7.0.4.2").cover?(Rails.version)
 
     # Set the ActionMailer preview path to the gem test directory
     config.action_mailer.show_previews = true

--- a/test/models/pay/customer_test.rb
+++ b/test/models/pay/customer_test.rb
@@ -23,6 +23,11 @@ class Pay::CustomerTest < ActiveSupport::TestCase
     assert pay_customers(:fake).respond_to?(:update_customer!)
   end
 
+  test "update_customer! with a promotion code" do
+    pay_customer = pay_customers(:fake)
+    assert pay_customer.update_customer!(promotion_code: "promo_xxx123")
+  end
+
   test "not_fake scope" do
     assert_not_includes Pay::Customer.not_fake_processor, pay_customers(:fake)
     assert_includes Pay::Customer.not_fake_processor, pay_customers(:stripe)

--- a/test/pay/fake_processor/billable_test.rb
+++ b/test/pay/fake_processor/billable_test.rb
@@ -33,6 +33,12 @@ class Pay::FakeProcessor::Billable::Test < ActiveSupport::TestCase
     end
   end
 
+  test "fake processor subscribe with promotion code" do
+    assert_difference "Pay::Subscription.count" do
+      @pay_customer.subscribe(promotion_code: "promo_xxx123")
+    end
+  end
+
   test "fake processor add payment method" do
     assert_difference "Pay::PaymentMethod.count" do
       @pay_customer.add_payment_method("x", default: true)


### PR DESCRIPTION
Adds support for…
* arbitrary arguments can be passed to `Pay::FakeProcessor::Billable#update_customer!`
* adds support for `promotion_code` to `Pay::FakeProcessor::Billable#subscribe`