### PR TITLE
Lazy instantiate webhook callback classes

### DIFF
--- a/docs/7_webhooks.md
+++ b/docs/7_webhooks.md
@@ -65,6 +65,9 @@ class MyChargeSucceededProcessor
 end
 
 Pay::Webhooks.delegator.subscribe "stripe.charge.succeeded", MyChargeSucceededProcessor.new
+
+# You can also pass a string representation the processor class name.
+Pay::Webhooks.delegator.subscribe "stripe.charge.refunded", "MyChargeRefundedProcessor"
 ```
 
 ### Unsubscribing from a webhook listener

--- a/lib/pay/webhooks/delegator.rb
+++ b/lib/pay/webhooks/delegator.rb
@@ -47,7 +47,13 @@ module Pay
 
         def call(*args)
           payload = args.last
-          @subscriber.call(payload)
+          subscriber_instance.call(payload)
+        end
+
+        private
+
+        def subscriber_instance
+          @subscriber_instance ||= @subscriber.is_a?(String) ? @subscriber.constantize.new : @subscriber
         end
       end
 

--- a/test/pay/webhooks/delegator_test.rb
+++ b/test/pay/webhooks/delegator_test.rb
@@ -5,6 +5,7 @@ class Pay::WebhookDelegatorTest < ActiveSupport::TestCase
     attr_accessor :success
 
     def call(event)
+      event[:result] = true
       @success = true
     end
   end
@@ -38,6 +39,13 @@ class Pay::WebhookDelegatorTest < ActiveSupport::TestCase
     delegator.subscribe "stripe.test_event", processor
     delegator.instrument event: {}, type: "stripe.test_event"
     assert processor.success
+  end
+
+  test "can subscribe with a string" do
+    event_hash = {}
+    delegator.subscribe "stripe.test_event", "Pay::WebhookDelegatorTest::TestEventProcessor"
+    delegator.instrument event: event_hash, type: "stripe.test_event"
+    assert event_hash[:result]
   end
 
   test "can unsubscribe" do


### PR DESCRIPTION
Rails doesn't load (or can access) anything constants in the app directory during app boot. To have custom webhook callbacks, the constants have to be defined in the initializer or manually required from lib.

This change allows `Pay::Webhooks.delegator.subscribe` to take a string argument. When `NotificationAdapter` is invoked and the subscriber is a string, we'll `constantize` and instantiate it before calling it.