### PR TITLE
Paddle update payment method

### DIFF
--- a/lib/pay/fake_processor/subscription.rb
+++ b/lib/pay/fake_processor/subscription.rb
@@ -8,6 +8,7 @@ module Pay
         :on_grace_period?,
         :on_trial?,
         :ends_at,
+        :ends_at?,
         :owner,
         :processor_subscription,
         :processor_id,

--- a/lib/pay/paddle/billable.rb
+++ b/lib/pay/paddle/billable.rb
@@ -50,7 +50,7 @@ module Pay
       end
 
       def add_payment_method(token, default: true)
-        Pay::Paddle::PaymentMethod.sync(self)
+        Pay::Paddle::PaymentMethod.sync(pay_customer: pay_customer)
       end
 
       def trial_end_date(subscription)

--- a/lib/pay/paddle/billable.rb
+++ b/lib/pay/paddle/billable.rb
@@ -49,7 +49,9 @@ module Pay
         # pass
       end
 
-      def add_payment_method(token, default: true)
+      # Paddle does not use payment method tokens. The method signature has it here
+      # to have a uniform API with the other payment processors.
+      def add_payment_method(token = nil, default: true)
         Pay::Paddle::PaymentMethod.sync(pay_customer: pay_customer)
       end
 

--- a/test/pay/paddle/billable_test.rb
+++ b/test/pay/paddle/billable_test.rb
@@ -45,4 +45,16 @@ class Pay::Paddle::Billable::Test < ActiveSupport::TestCase
     assert_equal "06", @pay_customer.default_payment_method.exp_month
     assert_equal "2022", @pay_customer.default_payment_method.exp_year
   end
+
+  test "paddle can add payment method" do
+    PaddlePay::Subscription::User.stub(:list, []) do
+      assert @pay_customer.add_payment_method
+    end
+  end
+
+  test "paddle can update payment method" do
+    PaddlePay::Subscription::User.stub(:list, []) do
+      assert @pay_customer.update_payment_method(nil)
+    end
+  end
 end


### PR DESCRIPTION
This resolves an issue that a customer raised in the JSP discord channel around not providing the keyword arg needed to be consistent with the `Pay::Paddle::PaymentMethod::sync` method. 

To read more detail about the issue follow this [link](https://discord.com/channels/874684608686477352/1113960193940803635)

