### PR TITLE
delegate ends_at? to pay_subscription

### DIFF
--- a/lib/pay/fake_processor/subscription.rb
+++ b/lib/pay/fake_processor/subscription.rb
@@ -8,6 +8,7 @@ module Pay
         :on_grace_period?,
         :on_trial?,
         :ends_at,
+        :ends_at?,
         :owner,
         :processor_subscription,
         :processor_id,


### PR DESCRIPTION
I think we missed adding this delegation in a previous commit, this PR addresses that issue.