### PR TITLE
Removed references to Rails.applications.secrets

### DIFF
--- a/docs/2_configuration.md
+++ b/docs/2_configuration.md
@@ -35,7 +35,7 @@ paddle:
   environment: sandbox
 ```
 
-You can also nest these credentials under the Rails environment if using a shared credentials file or secrets.
+You can also nest these credentials under the Rails environment if using a shared credentials file.
 
 ```yaml
 development:
@@ -78,7 +78,7 @@ bin/rails generate pay:email_views
 
 ## Emails
 
-Emails can be enabled/disabled as a whole by using the `send_emails` configuration option or independently by 
+Emails can be enabled/disabled as a whole by using the `send_emails` configuration option or independently by
 using the `emails` configuration option as shown in the configuration section below (all emails are enabled by default).
 
 When enabled, the following emails will be sent when:

--- a/docs/2_configuration.md
+++ b/docs/2_configuration.md
@@ -6,7 +6,7 @@ Pay comes with a lot of configuration out of the box for you, but you'll need to
 
 Pay automatically looks up credentials for each payment provider. We recommend storing them in the Rails credentials.
 
-##### Rails Credentials & Secrets
+##### Rails Credentials
 
 You'll need to add your API keys to your Rails credentials. You can do this by running:
 

--- a/lib/pay/env.rb
+++ b/lib/pay/env.rb
@@ -9,16 +9,14 @@ module Pay
     # the current environment.
     #
     # 1. Check environment variable
-    # 2. Check environment scoped credentials, then secrets
-    # 3. Check unscoped credentials, then secrets
+    # 2. Check environment scoped credentials
+    # 3. Check unscoped credentials
     #
     # For example, find_value_by_name("stripe", "private_key") will check the following in order until it finds a value:
     #
     #   ENV["STRIPE_PRIVATE_KEY"]
     #   Rails.application.credentials.dig(:production, :stripe, :private_key)
-    #   Rails.application.secrets.dig(:production, :stripe, :private_key)
     #   Rails.application.credentials.dig(:stripe, :private_key)
-    #   Rails.application.secrets.dig(:stripe, :private_key)
     def find_value_by_name(scope, name)
       ENV["#{scope.upcase}_#{name.upcase}"] ||
         credentials&.dig(env, scope, name) ||
@@ -40,11 +38,15 @@ module Pay
     end
 
     def secrets
-      Rails.application.secrets
+      is_rails_version_below_7_2? ? Rails.application.secrets : nil
     end
 
     def credentials
       Rails.application.credentials if Rails.application.respond_to?(:credentials)
+    end
+
+    def is_rails_version_below_7_2?
+      Rails.gem_version < Gem::Version.new("7.2")
     end
   end
 end

--- a/test/pay/stripe_test.rb
+++ b/test/pay/stripe_test.rb
@@ -9,6 +9,10 @@ class Pay::Stripe::Test < ActiveSupport::TestCase
     assert_equal "public", Pay::Stripe.public_key
     assert_equal "private", Pay::Stripe.private_key
     assert_equal "secret", Pay::Stripe.signing_secret
+
+    ENV.delete("STRIPE_PUBLIC_KEY")
+    ENV.delete("STRIPE_PRIVATE_KEY")
+    ENV.delete("STRIPE_SIGNING_SECRET")
   end
 
   test "can generate a client_reference_id for a model" do
@@ -33,5 +37,21 @@ class Pay::Stripe::Test < ActiveSupport::TestCase
 
   test "returns nil if client_reference_id is not an allowed class" do
     assert_nil Pay::Stripe.find_by_client_reference_id("Secret::Agent::Man/9999")
+  end
+
+  test "it reads Rails secrets for Rails versions below (<) 7.2.0" do
+    Rails.application.expects(:credentials).twice.returns(nil)
+    Rails.application.expects(:secrets).twice.returns({stripe: {public_key: "stripe_pk_from_secrets"}})
+    Rails.expects(:gem_version).twice.returns(Gem::Version.new("7.0.6"))
+
+    assert_equal "stripe_pk_from_secrets", Pay::Stripe.public_key
+  end
+
+  test "it doesn't read Rails secrets for Rails versions above (>=) 7.2.0" do
+    Rails.application.expects(:credentials).twice.returns({stripe: {public_key: "stripe_pk_from_credentials"}})
+    Rails.application.expects(:secrets).never.returns({stripe: {public_key: "stripe_pk_from_secrets"}})
+    Rails.expects(:gem_version).returns(Gem::Version.new("7.2.0"))
+
+    assert_equal "stripe_pk_from_credentials", Pay::Stripe.public_key
   end
 end

--- a/test/pay/stripe_test.rb
+++ b/test/pay/stripe_test.rb
@@ -9,10 +9,6 @@ class Pay::Stripe::Test < ActiveSupport::TestCase
     assert_equal "public", Pay::Stripe.public_key
     assert_equal "private", Pay::Stripe.private_key
     assert_equal "secret", Pay::Stripe.signing_secret
-
-    ENV.delete("STRIPE_PUBLIC_KEY")
-    ENV.delete("STRIPE_PRIVATE_KEY")
-    ENV.delete("STRIPE_SIGNING_SECRET")
   end
 
   test "can generate a client_reference_id for a model" do
@@ -39,19 +35,15 @@ class Pay::Stripe::Test < ActiveSupport::TestCase
     assert_nil Pay::Stripe.find_by_client_reference_id("Secret::Agent::Man/9999")
   end
 
-  test "it reads Rails secrets for Rails versions below (<) 7.2.0" do
-    Rails.application.expects(:credentials).twice.returns(nil)
-    Rails.application.expects(:secrets).twice.returns({stripe: {public_key: "stripe_pk_from_secrets"}})
-    Rails.expects(:gem_version).twice.returns(Gem::Version.new("7.0.6"))
-
-    assert_equal "stripe_pk_from_secrets", Pay::Stripe.public_key
+  test "env ignores Stripe secrets when not defined" do
+    Rails.stub(:application, nil) do
+      assert_nil Pay::Stripe.secrets
+    end
   end
 
-  test "it doesn't read Rails secrets for Rails versions above (>=) 7.2.0" do
-    Rails.application.expects(:credentials).twice.returns({stripe: {public_key: "stripe_pk_from_credentials"}})
-    Rails.application.expects(:secrets).never.returns({stripe: {public_key: "stripe_pk_from_secrets"}})
-    Rails.expects(:gem_version).returns(Gem::Version.new("7.2.0"))
-
-    assert_equal "stripe_pk_from_credentials", Pay::Stripe.public_key
+  test "env ignores Stripe credentials when not defined" do
+    Rails.stub(:application, nil) do
+      assert_nil Pay::Stripe.credentials
+    end
   end
 end

--- a/test/pay/stripe_test.rb
+++ b/test/pay/stripe_test.rb
@@ -37,13 +37,13 @@ class Pay::Stripe::Test < ActiveSupport::TestCase
 
   test "env ignores Stripe secrets when not defined" do
     Rails.stub(:application, nil) do
-      assert_nil Pay::Stripe.secrets
+      assert_nil Pay::Stripe.send(:secrets)
     end
   end
 
   test "env ignores Stripe credentials when not defined" do
     Rails.stub(:application, nil) do
-      assert_nil Pay::Stripe.credentials
+      assert_nil Pay::Stripe.send(:credentials)
     end
   end
 end


### PR DESCRIPTION
### Goal
Remove usage of deprecated Rails.applications.secrets

### Deprecation warning on CI
```
DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from secrets at /Users/hac/.rvm/gems/ruby-3.2.2@railsdevs.com/gems/pay-6.6.1/lib/pay/env.rb:43)
```