### PR TITLE
Updates Stripe gem version in the docs

### DIFF
--- a/docs/1_installation.md
+++ b/docs/1_installation.md
@@ -10,7 +10,7 @@ Add these lines to your application's Gemfile:
 gem "pay", "~> 6.0"
 
 # To use Stripe, also include:
-gem "stripe", "~> 8.0"
+gem "stripe", "~> 9.0"
 
 # To use Braintree + PayPal, also include:
 gem "braintree", "~> 4.7"


### PR DESCRIPTION
The docs still refer to v8 whereas the gem enforces v9

<img width="530" alt="image" src="https://github.com/pay-rails/pay/assets/1650995/82128aaa-d02b-4a3b-9139-882e206e8754">
