### PR TITLE
Fix for `strong_migrations`

### DIFF
--- a/db/migrate/1_create_pay_tables.rb
+++ b/db/migrate/1_create_pay_tables.rb
@@ -11,7 +11,7 @@ class CreatePayTables < ActiveRecord::Migration[6.0]
       t.datetime :deleted_at
       t.timestamps
     end
-    add_index :pay_customers, [:owner_type, :owner_id, :default], name: :pay_customer_owner_index, unique: true
+    add_index :pay_customers, [:owner_type, :owner_id, :deleted_at], name: :pay_customer_owner_index, unique: true
     add_index :pay_customers, [:processor, :processor_id], unique: true
 
     create_table :pay_merchants, id: primary_key_type do |t|

--- a/db/migrate/1_create_pay_tables.rb
+++ b/db/migrate/1_create_pay_tables.rb
@@ -11,7 +11,7 @@ class CreatePayTables < ActiveRecord::Migration[6.0]
       t.datetime :deleted_at
       t.timestamps
     end
-    add_index :pay_customers, [:owner_type, :owner_id, :deleted_at, :default], name: :pay_customer_owner_index
+    add_index :pay_customers, [:owner_type, :owner_id, :default], name: :pay_customer_owner_index, unique: true
     add_index :pay_customers, [:processor, :processor_id], unique: true
 
     create_table :pay_merchants, id: primary_key_type do |t|


### PR DESCRIPTION
Closes https://github.com/pay-rails/pay/issues/849

This PR modifies the `pay_customer_owner_index` index to rely on 3 columns instead of 4, so that migrations pass for people using the `strong_migrations` gem. I've also made this index unique as per [Chris's comment](https://github.com/pay-rails/pay/issues/849#issuecomment-1739146919).

Here's the explanation as to why one should [keep non-unique indexes to three columns or less](https://github.com/ankane/strong_migrations#keeping-non-unique-indexes-to-three-columns-or-less)