### PR TITLE
Make sure onboarding_complete? returns a boolean value

### DIFF
--- a/app/models/pay/merchant.rb
+++ b/app/models/pay/merchant.rb
@@ -18,9 +18,7 @@ module Pay
     end
 
     def onboarding_complete?
-      ActiveModel::Type::Boolean.new.cast(
-        data.presence.try(:fetch, "onboarding_complete") || false
-      )
+      ActiveModel::Type::Boolean.new.cast(data&.fetch("onboarding_complete")) || false
     end
   end
 end

--- a/app/models/pay/merchant.rb
+++ b/app/models/pay/merchant.rb
@@ -19,7 +19,7 @@ module Pay
 
     def onboarding_complete?
       ActiveModel::Type::Boolean.new.cast(
-        (data.presence || {})["onboarding_complete"]
+        data.presence.try(:fetch, "onboarding_complete") || false
       )
     end
   end

--- a/test/models/pay/merchant_test.rb
+++ b/test/models/pay/merchant_test.rb
@@ -3,9 +3,9 @@ require "test_helper"
 class Pay::MerchantTest < ActiveSupport::TestCase
   test "should return stripe connect onboarding status" do
     merchant = Pay::Merchant.new
-    refute merchant.onboarding_complete?
+    assert_equal false, merchant.onboarding_complete?
 
     merchant.onboarding_complete = true
-    assert merchant.onboarding_complete?
+    assert_equal true, merchant.onboarding_complete?
   end
 end


### PR DESCRIPTION
This PR ensures we return a proper boolean value when `Pay::Merchant.data` is nil.
Also updated the tests to describe the expected return value.