### PR TITLE
Fix invalid client_reference_id composition

### DIFF
--- a/lib/pay/stripe.rb
+++ b/lib/pay/stripe.rb
@@ -123,13 +123,13 @@ module Pay
 
     def self.to_client_reference_id(record)
       raise ArgumentError, "#{record.class.name} does not include Pay. Allowed models: #{model_names.to_a.join(", ")}" unless model_names.include?(record.class.name)
-      [record.class.name, record.id].join("/")
+      [record.class.name, record.id].join("_")
     end
 
     def self.find_by_client_reference_id(client_reference_id)
       # If there is a client reference ID, make sure we have a Pay::Customer record
       # client_reference_id should be in the format of "User/1"
-      model_name, id = client_reference_id.split("/", 2)
+      model_name, id = client_reference_id.split("_", 2)
 
       # Only allow model names that use Pay
       return unless model_names.include?(model_name)

--- a/test/pay/stripe_test.rb
+++ b/test/pay/stripe_test.rb
@@ -18,7 +18,7 @@ class Pay::Stripe::Test < ActiveSupport::TestCase
 
   test "can generate a client_reference_id for a model" do
     user = users(:none)
-    assert_equal "User/#{user.id}", Pay::Stripe.to_client_reference_id(user)
+    assert_equal "User_#{user.id}", Pay::Stripe.to_client_reference_id(user)
   end
 
   test "raises an error for client_reference_id if the object does not use Pay" do
@@ -29,15 +29,15 @@ class Pay::Stripe::Test < ActiveSupport::TestCase
 
   test "can find a record by client_reference_id" do
     user = users(:none)
-    assert_equal user, Pay::Stripe.find_by_client_reference_id("User/#{user.id}")
+    assert_equal user, Pay::Stripe.find_by_client_reference_id("User_#{user.id}")
   end
 
   test "returns nil if record not found by client_reference_id" do
-    assert_nil Pay::Stripe.find_by_client_reference_id("User/9999")
+    assert_nil Pay::Stripe.find_by_client_reference_id("User_9999")
   end
 
   test "returns nil if client_reference_id is not an allowed class" do
-    assert_nil Pay::Stripe.find_by_client_reference_id("Secret::Agent::Man/9999")
+    assert_nil Pay::Stripe.find_by_client_reference_id("Secret::Agent::Man_9999")
   end
 
   test "env ignores Stripe secrets when not defined" do


### PR DESCRIPTION
I've been trying to integrate the Stripe pricing table without success. I realized that the current method `Pay::Stripe.to_client_reference_id` is creating an invalid string. It includes a forward slash (like `User/42`), which isn't allowed according to Stripe's docs:

> The <stripe-pricing-table> web component supports setting the client-reference-id property. When the property is set, the pricing table passes it to the Checkout Session’s [client_reference_id](https://stripe.com/docs/api/checkout/sessions/object#checkout_session_object-client_reference_id) attribute to help you reconcile the Checkout Session with your internal system. This can be an authenticated user ID or a similar string. client-reference-id can be composed of **alphanumeric characters, dashes, or underscores**, and be any value up to 200 characters. Invalid values are silently dropped and your pricing table will continue to work as expected.

Source: https://stripe.com/docs/payments/checkout/pricing-table#handle-fulfillment-with-the-stripe-api

The resulting webhook `checkout.session.completed` then contains `client_reference_id: null`, so the client cannot be found.

I changed the implementation to use an underscore instead of the slash (like `User_42`).

References: #670, #823