### PR TITLE
Canceled subscriptions are now always inactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+* Subscriptions with `status: :canceled` and `ends_at: future` are now considered canceled. Previously, these were considered active to accomodate canceling a Braintree subscription during trial (and allowing the user to continue using until the end of the trial).
+
 ### 6.8.1
 
 * [Stripe] Skip sync if object is not attached to a customer. Fixes #842

--- a/lib/pay/braintree/subscription.rb
+++ b/lib/pay/braintree/subscription.rb
@@ -77,6 +77,9 @@ module Pay
       end
 
       def cancel(**options)
+        return if canceled?
+
+        # Braintree doesn't allow canceling at period end while on trial, so trials are canceled immediately
         result = if on_trial?
           gateway.subscription.cancel(processor_id)
         else
@@ -90,6 +93,8 @@ module Pay
       end
 
       def cancel_now!(**options)
+        return if canceled?
+
         result = gateway.subscription.cancel(processor_id)
         pay_subscription.sync!(object: result.subscription)
       rescue ::Braintree::BraintreeError => e

--- a/lib/pay/fake_processor/subscription.rb
+++ b/lib/pay/fake_processor/subscription.rb
@@ -29,6 +29,8 @@ module Pay
       # With trial, sets end to trial end (mimicing Stripe)
       # Without trial, sets can ends_at to end of month
       def cancel(**options)
+        return if canceled?
+
         if pay_subscription.on_trial?
           pay_subscription.update(ends_at: pay_subscription.trial_ends_at)
         else
@@ -37,6 +39,8 @@ module Pay
       end
 
       def cancel_now!(**options)
+        return if canceled?
+
         ends_at = Time.current
         pay_subscription.update(
           status: :canceled,

--- a/lib/pay/stripe/subscription.rb
+++ b/lib/pay/stripe/subscription.rb
@@ -159,6 +159,8 @@ module Pay
       end
 
       def cancel(**options)
+        return if canceled?
+
         @stripe_subscription = ::Stripe::Subscription.update(processor_id, {cancel_at_period_end: true}.merge(expand_options), stripe_options)
         pay_subscription.update(ends_at: (on_trial? ? trial_ends_at : Time.at(@stripe_subscription.current_period_end)))
       rescue ::Stripe::StripeError => e
@@ -170,6 +172,8 @@ module Pay
       # cancel_now!(prorate: true)
       # cancel_now!(invoice_now: true)
       def cancel_now!(**options)
+        return if canceled?
+
         @stripe_subscription = ::Stripe::Subscription.cancel(processor_id, options.merge(expand_options), stripe_options)
         pay_subscription.update(ends_at: Time.current, status: :canceled)
       rescue ::Stripe::StripeError => e

--- a/test/models/pay/subscription_test.rb
+++ b/test/models/pay/subscription_test.rb
@@ -305,6 +305,24 @@ class Pay::Subscription::Test < ActiveSupport::TestCase
     refute @subscription.active?
   end
 
+  test "past_due" do
+    @subscription.update!(status: :past_due)
+    refute @subscription.active?
+    assert_not_includes @pay_customer.subscriptions.active, @subscription
+  end
+
+  test "unpaid" do
+    @subscription.update!(status: :unpaid)
+    refute @subscription.active?
+    assert_not_includes @pay_customer.subscriptions.active, @subscription
+  end
+
+  test "canceled subscriptions with a future ends_at are considered active" do
+    @subscription.update(status: :canceled, ends_at: 1.hour.from_now)
+    refute @subscription.active?
+    assert_not_includes @pay_customer.subscriptions.active, @subscription
+  end
+
   test "cancel" do
     @subscription.cancel
     assert @subscription.ends_at?

--- a/test/pay/billable_test.rb
+++ b/test/pay/billable_test.rb
@@ -83,7 +83,7 @@ class Pay::Billable::Test < ActiveSupport::TestCase
 
   test "subscribed? with canceled subscription on grace period" do
     @user.payment_processor.subscription.update(status: :canceled, ends_at: 1.day.from_now)
-    assert @user.payment_processor.subscribed?
+    refute @user.payment_processor.subscribed?
   end
 
   test "subscribed? with different plan" do

--- a/test/pay/braintree/subscription_test.rb
+++ b/test/pay/braintree/subscription_test.rb
@@ -49,9 +49,11 @@ class Pay::Braintree::SubscriptionTest < ActiveSupport::TestCase
       pay_subscription.cancel_now!
 
       # Canceling during a trial ends the subscription, but continues to give access during the trial period
-      assert pay_subscription.active?
+      assert_equal "canceled", pay_subscription.status
+      refute pay_subscription.active?
       assert pay_subscription.on_trial?
       assert pay_subscription.ended?
+      assert_not_includes @pay_customer.subscriptions.active, pay_subscription
     end
   end
 
@@ -130,10 +132,12 @@ class Pay::Braintree::SubscriptionTest < ActiveSupport::TestCase
 
       pay_subscription = Pay::Braintree::Subscription.sync(processor_id)
 
-      # Canceling during a trial ends the subscription, but continues to give access during the trial period
-      assert pay_subscription.active?
+      # Canceling during a trial ends the subscription, but continues to give acess during the trial period
+      assert_equal "canceled", pay_subscription.status
+      refute pay_subscription.active?
       assert pay_subscription.on_trial?
       assert pay_subscription.ended?
+      assert_not_includes @pay_customer.subscriptions.active, pay_subscription
     end
   end
 end


### PR DESCRIPTION
This makes all `status: :canceled` subscriptions as inactive.

Previously, `ends_at` could be set to a future time and a `canceled` subscription would still be considered active until that time. This was implement to make Braintree consisted where canceling a subscription during a trial would have no way of providing access until the end of the trial.

We've decided to make Braintree end the trial immediately and treat all `canceled` subscriptions as inactive.