### PR TITLE
Update GitHub Actions to use main branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - '*'
   push:
     branches:
-      - master
+      - main
 jobs:
   sqlite:
     runs-on: ubuntu-latest


### PR DESCRIPTION
I saw that the master branch was renamed to main, so this PR updates the GH Actions workflow