### PR TITLE
Fix issue with Paddle Billing Charges when there's no payment details

### DIFF
--- a/lib/pay/paddle/charge.rb
+++ b/lib/pay/paddle/charge.rb
@@ -37,19 +37,22 @@ module Pay
           subscription: pay_customer.subscriptions.find_by(processor_id: object.subscription_id)
         }
 
-        case object.payment.method_details.type.downcase
-        when "card"
-          attrs[:payment_method_type] = "card"
-          attrs[:brand] = details.card.type
-          attrs[:exp_month] = details.card.expiry_month
-          attrs[:exp_year] = details.card.expiry_year
-          attrs[:last4] = details.card.last4
-        when "paypal"
-          attrs[:payment_method_type] = "paypal"
-        end
+        if object.payment
+          case object.payment.method_details.type.downcase
+          when "card"
+            attrs[:payment_method_type] = "card"
+            attrs[:brand] = details.card.type
+            attrs[:exp_month] = details.card.expiry_month
+            attrs[:exp_year] = details.card.expiry_year
+            attrs[:last4] = details.card.last4
+          when "paypal"
+            attrs[:payment_method_type] = "paypal"
+          end
 
-        # Update customer's payment method
-        Pay::Paddle::PaymentMethod.sync(pay_customer: pay_customer, attributes: object.payments.first)
+
+          # Update customer's payment method
+          Pay::Paddle::PaymentMethod.sync(pay_customer: pay_customer, attributes: object.payments.first)
+        end
 
         # Update or create the charge
         if (pay_charge = pay_customer.charges.find_by(processor_id: object.id))
@@ -61,6 +64,7 @@ module Pay
           pay_customer.charges.create!(attrs.merge(processor_id: object.id))
         end
       end
+
     end
   end
 end

--- a/lib/pay/paddle/charge.rb
+++ b/lib/pay/paddle/charge.rb
@@ -49,7 +49,6 @@ module Pay
             attrs[:payment_method_type] = "paypal"
           end
 
-
           # Update customer's payment method
           Pay::Paddle::PaymentMethod.sync(pay_customer: pay_customer, attributes: object.payments.first)
         end
@@ -64,7 +63,6 @@ module Pay
           pay_customer.charges.create!(attrs.merge(processor_id: object.id))
         end
       end
-
     end
   end
 end


### PR DESCRIPTION
While working on updating the docs, I found that Charges weren't being created for transactions such as updating the subscription plan.

This PR updates the payment details to only be updated if there is a `payment`.