### PR TITLE
fix: update installation readme file to use stripe 9

### DIFF
--- a/docs/1_installation.md
+++ b/docs/1_installation.md
@@ -10,7 +10,7 @@ Add these lines to your application's Gemfile:
 gem "pay", "~> 6.0"
 
 # To use Stripe, also include:
-gem "stripe", "~> 10.0"
+gem "stripe", "~> 9.0"
 
 # To use Braintree + PayPal, also include:
 gem "braintree", "~> 4.7"


### PR DESCRIPTION
I'm new to RoR and I discovered that I can't use Stripe 10 to copy and run pay db migrations I got this error in the terminal but when I switch back to using stripe 9 gems, it does work 
```
rails aborted!
[Pay] stripe gem must be version ~> 9
/Users/ilias/dev/scheduled_tweets/config/environment.rb:5:in `<main>'
Tasks: TOP => railties:install:migrations => db:load_config => environment
(See full trace by running task with --trace)
```