### PR TITLE
Retrieve paddle subscription with options

### DIFF
--- a/lib/pay/paddle_billing/billable.rb
+++ b/lib/pay/paddle_billing/billable.rb
@@ -81,9 +81,7 @@ module Pay
       end
 
       def processor_subscription(subscription_id, options = {})
-        opts = options.except(:id)
-
-        ::Paddle::Subscription.retrieve(id: subscription_id, **opts)
+        ::Paddle::Subscription.retrieve(id: subscription_id, **options)
       rescue ::Paddle::Error => e
         raise Pay::PaddleBilling::Error, e
       end

--- a/lib/pay/paddle_billing/billable.rb
+++ b/lib/pay/paddle_billing/billable.rb
@@ -81,7 +81,9 @@ module Pay
       end
 
       def processor_subscription(subscription_id, options = {})
-        ::Paddle::Subscription.retrieve(id: subscription_id)
+        opts = options.except(:id)
+
+        ::Paddle::Subscription.retrieve(id: subscription_id, **opts)
       rescue ::Paddle::Error => e
         raise Pay::PaddleBilling::Error, e
       end

--- a/lib/pay/paddle_billing/subscription.rb
+++ b/lib/pay/paddle_billing/subscription.rb
@@ -85,8 +85,9 @@ module Pay
         @pay_subscription = pay_subscription
       end
 
-      def subscription
-        ::Paddle::Subscription.retrieve(id: processor_id)
+      def subscription(**options)
+        options[:id] = processor_id
+        @paddle_billing_subscription ||= ::Paddle::Subscription.retrieve(**options)
       end
 
       # Get a transaction to update payment method

--- a/lib/pay/paddle_billing/subscription.rb
+++ b/lib/pay/paddle_billing/subscription.rb
@@ -86,8 +86,7 @@ module Pay
       end
 
       def subscription(**options)
-        options[:id] = processor_id
-        @paddle_billing_subscription ||= ::Paddle::Subscription.retrieve(**options)
+        @paddle_billing_subscription ||= ::Paddle::Subscription.retrieve(id: processor_id, **options)
       end
 
       # Get a transaction to update payment method


### PR DESCRIPTION
The paddle gem accept the option `extra` when retrieving a subscription.

See: https://github.com/deanpcmad/paddle/blob/83120a9e285cfb5daf36f7f56939e985ab029843/lib/paddle/models/subscription.rb#L11

What this PR allows us to do:

```ruby
subscription.processor_subscription(extra: 'next_transaction')
```