### PR TITLE
Paddle Billing Client Tokens & docs tweaks

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -31,6 +31,8 @@ Pay::Customer.where(processor: :paddle).update_all(processor: :paddle_classic)
 You'll also need to update the Webhook endpoint from `/pay/webhooks/paddle` to `/pay/webhooks/paddle_classic`
 And rename custom webhooks from `paddle.*` to `paddle_classic.*`
 
+The secrets/environment variables for Paddle have also been renamed to from `PADDLE_*` to `PADDLE_CLASSIC_*`
+
 ## **Pay 5.0 to 6.0**
 This version adds support for accessing the start and end of the current billing period of a subscription. This currently only works with Stripe subscriptions.
 

--- a/docs/2_configuration.md
+++ b/docs/2_configuration.md
@@ -29,7 +29,6 @@ braintree:
   merchant_id: aaaa
   environment: sandbox
 paddle_billing:
-  seller_id: 1111
   client_token: aaaa
   api_key: yyyy
   signing_secret: pdl_ntfset...
@@ -61,7 +60,6 @@ Pay will also check environment variables for API keys:
 * `BRAINTREE_PUBLIC_KEY`
 * `BRAINTREE_PRIVATE_KEY`
 * `BRAINTREE_ENVIRONMENT`
-* `PADDLE_BILLING_SELLER_ID`
 * `PADDLE_BILLING_API_KEY`
 * `PADDLE_BILLING_CLIENT_TOKEN`
 * `PADDLE_BILLING_SIGNING_SECRET`

--- a/docs/2_configuration.md
+++ b/docs/2_configuration.md
@@ -30,6 +30,7 @@ braintree:
   environment: sandbox
 paddle_billing:
   seller_id: 1111
+  client_token: aaaa
   api_key: yyyy
   signing_secret: pdl_ntfset...
   environment: sandbox
@@ -62,6 +63,7 @@ Pay will also check environment variables for API keys:
 * `BRAINTREE_ENVIRONMENT`
 * `PADDLE_BILLING_SELLER_ID`
 * `PADDLE_BILLING_API_KEY`
+* `PADDLE_BILLING_CLIENT_TOKEN`
 * `PADDLE_BILLING_SIGNING_SECRET`
 * `PADDLE_BILLING_ENVIRONMENT`
 * `PADDLE_CLASSIC_VENDOR_ID`

--- a/docs/paddle_billing/1_overview.md
+++ b/docs/paddle_billing/1_overview.md
@@ -59,7 +59,6 @@ this after creating a webhook in the Paddle dashboard. You'll find this page
 Pay will automatically look for the following environment variables, or the equivalent
 Rails credentials:
 
-- `PADDLE_BILLING_SELLER_ID`
 - `PADDLE_BILLING_ENVIRONMENT`
 - `PADDLE_BILLING_API_KEY`
 - `PADDLE_BILLING_CLIENT_TOKEN`

--- a/docs/paddle_billing/1_overview.md
+++ b/docs/paddle_billing/1_overview.md
@@ -35,8 +35,12 @@ automatically create the subscription for you.
 
 ### Paddle API Key
 
-You can generate an API key [here for Production](https://vendors.paddle.com/authentication)
-or [here for Sandbox](https://sandbox-vendors.paddle.com/authentication)
+You can generate an API key [here for Production](https://vendors.paddle.com/authentication-v2)
+or [here for Sandbox](https://sandbox-vendors.paddle.com/authentication-v2)
+
+### Paddle Client Token
+
+Client side tokens are used to work with Paddle.js in your frontend. You can generate one using the same links above.
 
 ### Paddle Environment
 
@@ -58,4 +62,5 @@ Rails credentials:
 - `PADDLE_BILLING_SELLER_ID`
 - `PADDLE_BILLING_ENVIRONMENT`
 - `PADDLE_BILLING_API_KEY`
+- `PADDLE_BILLING_CLIENT_TOKEN`
 - `PADDLE_BILLING_SIGNING_SECRET`

--- a/docs/paddle_billing/2_javascript.md
+++ b/docs/paddle_billing/2_javascript.md
@@ -5,17 +5,13 @@ Paddle Checkout into your website.
 
 ## Setup
 
-Add the Paddle.js script in your application layout and initialize it with either your Paddle
-Seller ID or a Client Side Token. Paddle recommends using a Client Side Token.
+Add the Paddle.js script in your application layout and initialize it with your Paddle Client Side Token.
 
 ```html
 <script src="https://cdn.paddle.com/paddle/v2/paddle.js"></script>
 <script type="text/javascript">
   Paddle.Environment.set("sandbox");
   Paddle.Setup({
-    // Set either your Seller ID or a Client Side Token
-    seller: <%= Pay::PaddleBilling.seller_id %>
-
     token: <%= Pay::PaddleBilling.client_token %>
   });
 </script>

--- a/docs/paddle_billing/2_javascript.md
+++ b/docs/paddle_billing/2_javascript.md
@@ -5,14 +5,18 @@ Paddle Checkout into your website.
 
 ## Setup
 
+Add the Paddle.js script in your application layout and initialize it with either your Paddle
+Seller ID or a Client Side Token. Paddle recommends using a Client Side Token.
+
 ```html
 <script src="https://cdn.paddle.com/paddle/v2/paddle.js"></script>
 <script type="text/javascript">
   Paddle.Environment.set("sandbox");
   Paddle.Setup({
-    // This can be hard-coded or set using environment variables/Rails credentials
-    // It needs to be an integer, not a string
-    seller: <%= Pay::Paddle.seller_id %>
+    // Set either your Seller ID or a Client Side Token
+    seller: <%= Pay::PaddleBilling.seller_id %>
+
+    token: <%= Pay::PaddleBilling.client_token %>
   });
 </script>
 ```

--- a/docs/paddle_classic/1_overview.md
+++ b/docs/paddle_classic/1_overview.md
@@ -16,7 +16,7 @@ The [Paddle Sandbox](https://developer.paddle.com/getting-started/sandbox) can b
 <script src="https://cdn.paddle.com/paddle/paddle.js"></script>
 <script type="text/javascript">
   Paddle.Environment.set('sandbox');
-  Paddle.Setup({ vendor: <%= Pay::Paddle.vendor_id %> });
+  Paddle.Setup({ vendor: <%= Pay::PaddleClassic.vendor_id %> });
 </script>
 ```
 ## Paddle Public Key

--- a/docs/paddle_classic/1_overview.md
+++ b/docs/paddle_classic/1_overview.md
@@ -32,11 +32,11 @@ In either example, you can set the environment variable or in Rails credentials.
 ### File
 
 You can download the public key from the link above and save it to a location which your Rails application
-can access. Then set the `PADDLE_PUBLIC_KEY_FILE` to the location of the file.
+can access. Then set the `PADDLE_CLASSIC_PUBLIC_KEY_FILE` to the location of the file.
 
 ### Key
 
-Set the `PADDLE_PUBLIC_KEY` environment variable with your public key. Replace any spaces with `\n` otherwise
+Set the `PADDLE_CLASSIC_PUBLIC_KEY` environment variable with your public key. Replace any spaces with `\n` otherwise
 you may get a `OpenSSL::PKey::RSAError` error.
 
 ### Base64 Encoded Key
@@ -49,4 +49,4 @@ paddle_public_key = OpenSSL::PKey::RSA.new(File.read("paddle.pem"))
 Base64.encode64(paddle_public_key.to_der)
 ```
 
-Copy what's displayed and set the `PADDLE_PUBLIC_KEY_BASE64` environment variable.
+Copy what's displayed and set the `PADDLE_CLASSIC_PUBLIC_KEY_BASE64` environment variable.

--- a/lib/pay/paddle_billing.rb
+++ b/lib/pay/paddle_billing.rb
@@ -28,10 +28,6 @@ module Pay
       find_value_by_name(:paddle_billing, :environment) || "production"
     end
 
-    def self.seller_id
-      find_value_by_name(:paddle_billing, :seller_id)
-    end
-
     def self.client_token
       find_value_by_name(:paddle_billing, :client_token)
     end

--- a/lib/pay/paddle_billing.rb
+++ b/lib/pay/paddle_billing.rb
@@ -32,6 +32,10 @@ module Pay
       find_value_by_name(:paddle_billing, :seller_id)
     end
 
+    def self.client_token
+      find_value_by_name(:paddle_billing, :client_token)
+    end
+
     def self.api_key
       find_value_by_name(:paddle_billing, :api_key)
     end


### PR DESCRIPTION
Paddle have recently added [client side tokens](https://developer.paddle.com/changelog/2023/client-side-tokens) as a way to interact with the Paddle API using Paddle.js without exposing your API tokens. Paddle recommend using these instead of passing the `seller` option, as new features may require it. 

The latest feature of Paddle.js is the ability to [generate localised price previews](https://developer.paddle.com/changelog/2023/paddle-js-pricing-pages) on the fly, which is great for building pricing pages as it shows the customer's local currency (with taxes too). This was a feature I've been requesting since the start as the previous version had it too.

This PR adds `client_token` to `PaddleBilling`, which is set by environment variables or in the credentials/secrets files. 

I've also updated the Paddle Billing subscription docs and renamed some `Pay::Paddle` examples to `Pay::PaddleClassic`