### PR TITLE
Create issue_template.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,0 +1,48 @@
+## Bug Report
+
+**Describe the Bug:**
+<!-- A clear and concise description of the bug -->
+
+**To Reproduce:**
+<!-- Steps to reproduce the behavior -->
+
+1. Step 1
+2. Step 2
+3. ...
+
+**Expected Behavior:**
+<!-- A clear and concise description of what you expected to happen -->
+
+**Actual Behavior:**
+<!-- A clear and concise description of what actually happened -->
+
+**Screenshots (if applicable):**
+<!-- If applicable, add screenshots to help explain your problem -->
+
+**Environment:**
+- Pay gem version: <!-- Specify the version of the Pay gem where the bug occurred -->
+- Ruby version: <!-- Specify the version of Ruby you are using -->
+- Rails version: <!-- Specify the version of Rails you are using -->
+- Operating System: <!-- Specify your operating system -->
+
+**Additional Context:**
+<!-- Add any other context about the problem here -->
+
+**Possible Fix:**
+<!-- If you have suggestions on how to fix the bug, you can provide them here -->
+
+**Steps to Reproduce with Fix (if available):**
+<!-- If you have a fix, outline the steps to reproduce the bug using your fix -->
+
+**Related Issues:**
+<!-- If applicable, reference any related GitHub issues or pull requests -->
+
+**Labels to Apply:**
+<!-- Suggest labels that should be applied to this issue -->
+
+**Checklist:**
+<!-- Make sure all of these items are completed before submitting the issue -->
+
+- [ ] I have searched for similar issues and couldn't find any
+- [ ] I have checked the documentation for relevant information
+- [ ] I have included all the required information


### PR DESCRIPTION
In an effort to get necessary information about bugs upfront, this PR introduces an issue template for folks to use when filing an issue on the repo.