### PR TITLE
Safely handle Stripe payment methods without extra details

### DIFF
--- a/lib/pay/stripe/charge.rb
+++ b/lib/pay/stripe/charge.rb
@@ -29,7 +29,7 @@ module Pay
         refunds = []
         object.refunds.auto_paging_each { |refund| refunds << refund }
 
-        payment_method = object.payment_method_details.send(object.payment_method_details.type)
+        payment_method = object.payment_method_details.try(object.payment_method_details.type)
         attrs = {
           amount: object.amount,
           amount_captured: object.amount_captured,

--- a/lib/pay/stripe/payment_method.rb
+++ b/lib/pay/stripe/payment_method.rb
@@ -60,7 +60,7 @@ module Pay
 
       # Extracts payment method details from a Stripe::PaymentMethod object
       def self.extract_attributes(payment_method)
-        details = payment_method.send(payment_method.type)
+        details = payment_method.try(payment_method.type)
 
         {
           payment_method_type: payment_method.type,


### PR DESCRIPTION
I wasn't able to test this fix with BLIK payments on my account, but this should safely handle any payment methods that don't provide additional details.

@WozniakMac give this a try and see if it fixes your issue?