### PR TITLE
Fix: update pay gem version to 7

### DIFF
--- a/docs/1_installation.md
+++ b/docs/1_installation.md
@@ -7,7 +7,7 @@ Pay's installation is pretty straightforward. We'll add the gems, add some migra
 Add these lines to your application's Gemfile:
 
 ```ruby
-gem "pay", "~> 6.0"
+gem "pay", "~> 7.0"
 
 # To use Stripe, also include:
 gem "stripe", "~> 10.0"


### PR DESCRIPTION
## Pull Request

Simple change to update the Readme docs so new users install the latest version of Pay (v7)