### PR TITLE
Clear trial end when subscription becomes active

### DIFF
--- a/lib/pay/paddle_billing/subscription.rb
+++ b/lib/pay/paddle_billing/subscription.rb
@@ -59,6 +59,10 @@ module Pay
           attributes[:trial_ends_at] = Time.parse(object.next_billed_at)
         when "paused"
           attributes[:pause_starts_at] = Time.parse(object.paused_at)
+        when "active", "past_due"
+          attributes[:trial_ends_at] = nil
+          attributes[:pause_starts_at] = nil
+          attributes[:ends_at] = nil
         end
 
         case object.scheduled_change&.action

--- a/lib/pay/paddle_classic/subscription.rb
+++ b/lib/pay/paddle_classic/subscription.rb
@@ -44,12 +44,15 @@ module Pay
           status: object.state || object.status
         }
 
-        # If paused or delete while on trial, set ends_at to match
         case attributes[:status]
         when "trialing"
           attributes[:trial_ends_at] = Time.zone.parse(object.next_bill_date)
           attributes[:ends_at] = nil
+        when "active", "past_due"
+          attributes[:trial_ends_at] = nil
+          attributes[:ends_at] = nil
         when "paused", "deleted"
+          # If paused or delete while on trial, set ends_at to match
           attributes[:trial_ends_at] = nil
           attributes[:ends_at] = Time.zone.parse(object.next_bill_date)
         end


### PR DESCRIPTION
This fixes an issue with Paddle Classic where a subscription is synced after becoming `active` after `trialing` and the `trial_ends_at` time is not cleared.