### PR TITLE
Fix `active` scope for when a `trial_ends_at` is in the past

### DIFF
--- a/app/models/pay/subscription.rb
+++ b/app/models/pay/subscription.rb
@@ -13,7 +13,7 @@ module Pay
     scope :canceled, -> { where.not(ends_at: nil) }
     scope :cancelled, -> { canceled }
     scope :on_grace_period, -> { where("#{table_name}.ends_at IS NOT NULL AND #{table_name}.ends_at > ?", Time.current) }
-    scope :active, -> { where(status: ["trialing", "active"]).pause_not_started.where("#{table_name}.ends_at IS NULL OR #{table_name}.ends_at > ?", Time.current).where("trial_ends_at IS NULL OR trial_ends_at > ?", Time.current) }
+    scope :active, -> { where(status: ["trialing", "active"]).pause_not_started.where("#{table_name}.ends_at IS NULL OR #{table_name}.ends_at > ?", Time.current).or(on_trial) }
     scope :paused, -> { where(status: "paused").or(where("pause_starts_at <= ?", Time.current)) }
     scope :pause_not_started, -> { where("pause_starts_at IS NULL OR pause_starts_at > ?", Time.current) }
     scope :active_or_paused, -> { active.or(paused) }


### PR DESCRIPTION
Fixes #939 

This bug was introduced in 4cd286720b80d5a5fa9a4e9bfa9bfbace7ad873f as it changed the way the `active` scope worked.

I've tested it in a Pay test app I have running and it fixes the bug, however 2 Braintree tests are failing so they may need tweaking.