### PR TITLE
Fix syntax error in lambda for `stripe_attributes` in docs example

### DIFF
--- a/docs/1_installation.md
+++ b/docs/1_installation.md
@@ -85,7 +85,7 @@ For more information about the different attributes Stripe accepts for a custome
 class User < ApplicationRecord
   pay_customer stripe_attributes: :stripe_attributes
   # Or using a lambda:
-  # pay_customer stripe_attributes: ->(pay_customer) { metadata: { { user_id: pay_customer.owner_id } } }
+  # pay_customer stripe_attributes: ->(pay_customer) { { metadata: { user_id: pay_customer.owner_id } } }
 
   def stripe_attributes(pay_customer)
     {


### PR DESCRIPTION
The example in the documentation for passing a lambda to `:stripe_attributes` had a syntax error: an improperly nested curly brace in the hash definition (just a curly brace out of place, really)