### PR TITLE
Add Paddle Billing and Stripe sync methods

### DIFF
--- a/lib/pay/paddle_billing.rb
+++ b/lib/pay/paddle_billing.rb
@@ -54,5 +54,15 @@ module Pay
         events.subscribe "paddle_billing.transaction.completed", Pay::PaddleBilling::Webhooks::TransactionCompleted.new
       end
     end
+
+    def sync_transaction(transaction_id)
+      transaction = ::Paddle::Transaction.retrieve(id: transaction_id)
+
+      if transaction.subscription_id.present?
+        Pay::PaddleBilling::Subscription.sync(transaction.subscription_id)
+      else
+        Pay::PaddleBilling::Charge.sync(transaction_id, object: transaction)
+      end
+    end
   end
 end


### PR DESCRIPTION
The goal of this PR is to introduce a simple interface for syncing one-time or subscription transactions. For Stripe, this is syncing Checkout Sessions and determining the Charge or Subscription to sync. For Paddle Billing, this retrieves a Transaction and determines if it is a charge or subscription.

We can also take this a step further and provide a method that takes a hash (like `params`) and determines whether to sync from Stripe, Paddle Billing, etc.

The end goal is to provide integrations a single method to call for syncing after checkout.

```ruby
class Checkout::CompletedController < ApplicationController
  def show
    charge_or_subscription = Pay.sync(params)
    # handle fulfillment
    redirect_to root_path, notice: "Thanks for your purchase!"
  end
end
```