### PR TITLE
Update Paddle Billing Payment Methods to use `payment_method_id`

### DIFF
--- a/lib/pay/paddle_billing/payment_method.rb
+++ b/lib/pay/paddle_billing/payment_method.rb
@@ -19,7 +19,7 @@ module Pay
           attrs[:exp_year] = details.card.expiry_year
         end
 
-        payment_method = pay_customer.payment_methods.find_or_initialize_by(processor_id: attributes.stored_payment_method_id)
+        payment_method = pay_customer.payment_methods.find_or_initialize_by(processor_id: attributes.payment_method_id)
         payment_method.update!(attrs)
         payment_method
       end


### PR DESCRIPTION
Paddle have added a new `payment_method_id` field, which returns a Paddle ID. This replaces the `stored_payment_method_id` field which returned a UUID.

For their changelog entry: https://developer.paddle.com/changelog/2024/payment-method-paddle-id

I assume this means they will be adding a Payment Methods API soon, which could be useful. 