### PR TITLE
Fix to Paddle Billing Payment Method creation

### DIFF
--- a/docs/4_payment_methods.md
+++ b/docs/4_payment_methods.md
@@ -72,6 +72,20 @@ You can also add a payment method without making it the default.
 @user.payment_processor.add_payment_method(params[:payment_method_token], default: false)
 ```
 
+## Importing Payment Methods
+
+### Paddle Billing
+
+If a Paymment Method doesn't exist in Pay, then you can use the following method to create it from Paddle Billing:
+
+It takes a `Pay::Customer` and a Paddle Transaction ID as arguments.
+
+```ruby
+Pay::PaddleBilling::PaymentMethod.sync_from_transaction pay_customer: @user.payment_processor, transaction: "txn_abc123"
+```
+
+If a Payment Method already exists with the token, then it will be updated with the latest details from Paddle.
+
 ## Next
 
 See [Charges](5_charges.md)

--- a/lib/pay/paddle_billing/charge.rb
+++ b/lib/pay/paddle_billing/charge.rb
@@ -37,8 +37,9 @@ module Pay
           subscription: pay_customer.subscriptions.find_by(processor_id: object.subscription_id)
         }
 
-        if object.payment
-          case object.payment.method_details.type.downcase
+        if object.payments.present?
+          details = object.payments.first.method_details
+          case details.type.downcase
           when "card"
             attrs[:payment_method_type] = "card"
             attrs[:brand] = details.card.type

--- a/lib/pay/paddle_billing/charge.rb
+++ b/lib/pay/paddle_billing/charge.rb
@@ -37,8 +37,7 @@ module Pay
           subscription: pay_customer.subscriptions.find_by(processor_id: object.subscription_id)
         }
 
-        if object.payments.present?
-          details = object.payments.first.method_details
+        if (details = Array.wrap(object.payments).first&.method_details)
           case details.type.downcase
           when "card"
             attrs[:payment_method_type] = "card"

--- a/lib/pay/paddle_billing/payment_method.rb
+++ b/lib/pay/paddle_billing/payment_method.rb
@@ -8,7 +8,8 @@ module Pay
       def self.sync(pay_customer:, attributes:)
         details = attributes.method_details
         attrs = {
-          type: details.type.downcase
+          type: details.type.downcase,
+          default: true
         }
 
         case details.type.downcase

--- a/lib/pay/paddle_billing/payment_method.rb
+++ b/lib/pay/paddle_billing/payment_method.rb
@@ -5,6 +5,13 @@ module Pay
 
       delegate :customer, :processor_id, to: :pay_payment_method
 
+      def self.sync_from_transaction(pay_customer:, transaction:)
+        transaction = ::Paddle::Transaction.retrieve(id: transaction)
+        return unless transaction.status == "completed"
+        return if transaction.payments.empty?
+        sync(pay_customer: pay_customer, attributes: transaction.payments.first)
+      end
+
       def self.sync(pay_customer:, attributes:)
         details = attributes.method_details
         attrs = {

--- a/lib/pay/paddle_billing/payment_method.rb
+++ b/lib/pay/paddle_billing/payment_method.rb
@@ -15,8 +15,7 @@ module Pay
       def self.sync(pay_customer:, attributes:)
         details = attributes.method_details
         attrs = {
-          type: details.type.downcase,
-          default: true
+          type: details.type.downcase
         }
 
         case details.type.downcase


### PR DESCRIPTION
This PR fixes a bug found in this discussion: https://github.com/pay-rails/pay/discussions/922#discussioncomment-8191211

It also adds a new method called `sync_from_transaction` which takes both a `pay_customer` and a `transaction`. This then uses the Paddle API to grab the details for that transaction and create/update a Payment Method for the given Pay Customer.

```ruby
Pay::PaddleBilling::PaymentMethod.sync_from_transaction pay_customer: Customer.last.payment_processor, transaction: "txn_01hmxtm1ep1c2pznfftybn56kk"
```