### PR TITLE
Address nillable Paddle Billing values in subscription

### DIFF
--- a/lib/pay/paddle_billing/subscription.rb
+++ b/lib/pay/paddle_billing/subscription.rb
@@ -56,9 +56,9 @@ module Pay
           # Remove payment methods since customer cannot be reused after cancelling
           Pay::PaymentMethod.where(customer_id: object.customer_id).destroy_all
         when "trialing"
-          attributes[:trial_ends_at] = Time.parse(object.next_billed_at)
+          attributes[:trial_ends_at] = Time.parse(object.next_billed_at) if object.next_billed_at
         when "paused"
-          attributes[:pause_starts_at] = Time.parse(object.paused_at)
+          attributes[:pause_starts_at] = Time.parse(object.paused_at) if object.paused_at
         when "active", "past_due"
           attributes[:trial_ends_at] = nil
           attributes[:pause_starts_at] = nil
@@ -109,7 +109,7 @@ module Pay
         )
         pay_subscription.update(
           status: response.status,
-          ends_at: response.scheduled_change.effective_at
+          ends_at: response.scheduled_change&.effective_at
         )
       rescue ::Paddle::Error => e
         raise Pay::PaddleBilling::Error, e

--- a/lib/pay/paddle_billing/subscription.rb
+++ b/lib/pay/paddle_billing/subscription.rb
@@ -109,7 +109,7 @@ module Pay
         )
         pay_subscription.update(
           status: response.status,
-          ends_at: response.scheduled_change&.effective_at
+          ends_at: response.scheduled_change&.effective_at || DateTime.now
         )
       rescue ::Paddle::Error => e
         raise Pay::PaddleBilling::Error, e


### PR DESCRIPTION
## Pull Request

**Summary:**
As listed [here](https://developer.paddle.com/api-reference/subscriptions/overview), Paddle subscription attributes `next_billed_at`, `paused_at` and  `scheduled_change` can all be `nil`. 
I ran into this issue when having Paddle set up in sandbox mode.

**Description:**
`Pay::Subscription.trial_ends_at` and `pause_starts_at` will fallback to `nil` is not present in the Paddle subscription.
`Pay::Subscription.ends_at` will default to the current date if not present, so the `canceled?` method works atleast.
