### PR TITLE
Fixes refund mailer preview rendering receipt

### DIFF
--- a/test/mailers/previews/pay/user_mailer_preview.rb
+++ b/test/mailers/previews/pay/user_mailer_preview.rb
@@ -23,7 +23,7 @@ class Pay::UserMailerPreview < ActionMailer::Preview
     Pay::UserMailer.with(
       pay_customer: Pay::Customer.first,
       pay_charge: Pay::Charge.first
-    ).receipt
+    ).refund
   end
 
   def subscription_renewing


### PR DESCRIPTION
## Pull Request

**Summary:**
This PR fixes the `refund` preview calling `receipt` method on the UserMailerPreview