### PR TITLE
Incorrect Paddle URL

### DIFF
--- a/docs/paddle_billing/1_overview.md
+++ b/docs/paddle_billing/1_overview.md
@@ -51,8 +51,8 @@ set the Environment value to `sandbox`. By default, this is set to `production`.
 
 Paddle uses a signing secret to verify that webhooks are coming from Paddle. You can find
 this after creating a webhook in the Paddle dashboard. You'll find this page
-[here for Production](https://vendors.paddle.com/notifications) or
-[here for Sandbox](https://sandbox-vendors.paddle.com/notifications).
+[here for Production](https://vendors.paddle.com/authentication) or
+[here for Sandbox](https://sandbox-vendors.paddle.com/authentication).
 
 ### Environment Variables
 


### PR DESCRIPTION
## Pull Request

**Summary:**
The docs had the wrong link for getting API keys from Paddle. It now links to the right page. 

**Checklist:**

- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines