### PR TITLE
Fixed unpause stripe subscription empty params bug

### DIFF
--- a/lib/pay/stripe/subscription.rb
+++ b/lib/pay/stripe/subscription.rb
@@ -274,7 +274,7 @@ module Pay
 
       # Unpauses a subscription
       def unpause
-        @stripe_subscription = ::Stripe::Subscription.update(processor_id, {pause_collection: nil}.merge(expand_options), stripe_options)
+        @stripe_subscription = ::Stripe::Subscription.update(processor_id, {pause_collection: ""}.merge(expand_options), stripe_options)
         pay_subscription.update(
           pause_behavior: nil,
           pause_resumes_at: nil,


### PR DESCRIPTION
## Pull Request

**Summary:**
Fixes the bug where users cannot unpause a Stripe subscription.

**Related Issue:**
#991

**Description:**
Changed the `pause_collection: ""` instead of `pause_collection: nil` in the `unpause` method of the `Pay::Stripe::Subscription` class so that it can be passed on to Stripe.
