### PR TITLE
[b] Fix: Stripe subscription trial will end webhook event with Connect

### DIFF
--- a/lib/pay/stripe/webhooks/subscription_trial_will_end.rb
+++ b/lib/pay/stripe/webhooks/subscription_trial_will_end.rb
@@ -8,7 +8,7 @@ module Pay
           pay_subscription = Pay::Subscription.find_by_processor_and_id(:stripe, object.id)
           return if pay_subscription.nil?
 
-          pay_subscription.sync!
+          pay_subscription.sync!(stripe_account: event.try(:account))
 
           pay_user_mailer = Pay.mailer.with(pay_customer: pay_subscription.customer, pay_subscription: pay_subscription)
 

--- a/test/pay/stripe/webhooks/subscription_trial_will_end_test.rb
+++ b/test/pay/stripe/webhooks/subscription_trial_will_end_test.rb
@@ -54,6 +54,17 @@ class Pay::Stripe::Webhooks::SubscriptionTrialWillEndTest < ActiveSupport::TestC
     assert_enqueued_emails 0
   end
 
+  test "sync! is called with stripe_account" do
+    event = @trial_ended_event.clone
+    event.account = "connect_account_id"
+
+    pay_subscription = Pay::Subscription.new
+    Pay::Subscription.stubs(:find_by_processor_and_id).returns(pay_subscription)
+    pay_subscription.expects(:sync!).with(stripe_account: "connect_account_id")
+
+    Pay::Stripe::Webhooks::SubscriptionTrialWillEnd.new.call(event)
+  end
+
   private
 
   def create_subscription(processor_id:, trial_ends_at:)


### PR DESCRIPTION
## Pull Request

**Summary:**
To fix an issue where subscription.sync! doesn't pass in `stripe_account` params if Connect.

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**
<!-- Any additional information or notes for the reviewers -->
