### PR TITLE
Fix: Unset previous default payment methods when adding a new one using FakeProcessor

### DIFF
--- a/lib/pay/fake_processor/billable.rb
+++ b/lib/pay/fake_processor/billable.rb
@@ -79,7 +79,11 @@ module Pay
           }
         )
 
-        pay_customer.reload_default_payment_method if default
+        if default
+          pay_customer.payment_methods.where.not(id: pay_payment_method.id).update_all(default: false)
+          pay_customer.reload_default_payment_method
+        end
+
         pay_payment_method
       end
 

--- a/test/pay/fake_processor/billable_test.rb
+++ b/test/pay/fake_processor/billable_test.rb
@@ -45,12 +45,17 @@ class Pay::FakeProcessor::Billable::Test < ActiveSupport::TestCase
     end
   end
 
-  test "fake processor add payment method" do
+  test "fake processor add new default payment method" do
+    old_payment_method = @pay_customer.add_payment_method("old", default: true)
+    assert_equal old_payment_method.id, @pay_customer.default_payment_method.id
+
+    new_payment_method = nil
     assert_difference "Pay::PaymentMethod.count" do
-      @pay_customer.add_payment_method("x", default: true)
+      new_payment_method = @pay_customer.add_payment_method("new", default: true)
     end
 
     payment_method = @pay_customer.default_payment_method
+    assert_equal new_payment_method.id, payment_method.id
     assert_equal "card", payment_method.type
     assert_equal "Fake", payment_method.brand
   end


### PR DESCRIPTION
## Pull Request

**Summary:**
When using `FakeProcessor`, adding a new `default` payment method does not unset the previous default payment methods, causing the `payment_processor.default_payment_method` method to return an outdated default payment method.