### PR TITLE
Update Stripe version in docs

### DIFF
--- a/docs/1_installation.md
+++ b/docs/1_installation.md
@@ -10,7 +10,7 @@ Add these lines to your application's Gemfile:
 gem "pay", "~> 7.0"
 
 # To use Stripe, also include:
-gem "stripe", "~> 11.0"
+gem "stripe", "~> 12.0"
 
 # To use Braintree + PayPal, also include:
 gem "braintree", "~> 4.7"


### PR DESCRIPTION
The required version is `~> 12` so this PR updates the docs to say so