### PR TITLE
feat: find customer in paddle when one already exists

### DIFF
--- a/lib/pay/paddle_billing/billable.rb
+++ b/lib/pay/paddle_billing/billable.rb
@@ -21,12 +21,16 @@ module Pay
       # Retrieves a Paddle::Customer object
       #
       # Finds an existing Paddle::Customer if processor_id exists
+      # Finds and attaches a processor_id to the Pay::Customer if it exists in Paddle
       # Creates a new Paddle::Customer using `email` and `customer_name` if empty processor_id
       #
       # Returns a Paddle::Customer object
       def customer
         if processor_id?
           ::Paddle::Customer.retrieve(id: processor_id)
+        elsif (sc = ::Paddle::Customer.list(email:).data&.first)
+          pay_customer.update!(processor_id: sc.id)
+          sc
         else
           sc = ::Paddle::Customer.create(email: email, name: customer_name)
           pay_customer.update!(processor_id: sc.id)


### PR DESCRIPTION
## Pull Request

**Summary:**
There are times when creating the `Customer` object in the Rails, that the customer does not exist in our local system, but already exists in PaddleBilling. This situation can occur for many different reasons. In this case, instead of attempting to create a new Customer in Paddle, we should look up the existing Paddle customer and attach it to the current User.

**Description:**
This change was motivated by the fact I use the same Paddle account for multiple products, which often share customers across them. Due to this situation, the Customer often already exists in Paddle's system before the Rails code of a specific product knows about it.

**Testing:**
I have been running with this patch in my projects for a while now, and they have allowed me to share customers across various products without needing to manually port data across the applications.

**Screenshots (if applicable):**
<!-- Include any relevant screenshots or GIFs that demonstrate the changes -->

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**
<!-- Any additional information or notes for the reviewers -->
