### PR TITLE
Update Stripe.js documentation link

### DIFF
--- a/docs/stripe/3_javascript.md
+++ b/docs/stripe/3_javascript.md
@@ -1,6 +1,6 @@
 # Stripe JavaScript
 
-Here's some example Javascript for handling your payment forms with [Stripe.js](https://stripe.com/docs/stripe-js) and [Hotwire / Turbo](https://hotwired.dev).
+Here's some example Javascript for handling your payment forms with [Stripe.js](https://docs.stripe.com/js) and [Hotwire / Turbo](https://hotwired.dev).
 
 #### Form HTML
 


### PR DESCRIPTION
Looks like Stripe change the previous link is not the right one (it's redirecting to [https://docs.stripe.com/payments/elements](https://docs.stripe.com/payments/elements))
