### PR TITLE
Enhance Strip checkout button using javascript_tag instead of script element

### DIFF
--- a/app/views/pay/stripe/_checkout_button.html.erb
+++ b/app/views/pay/stripe/_checkout_button.html.erb
@@ -5,7 +5,7 @@
 %>
 <%= tag.div id: "error-for-#{session.id}" %>
 
-<script>
+<%= javascript_tag nonce: true do %>
   (() => {
     const checkoutButton = document.getElementById("checkout-<%= session.id %>");
     checkoutButton.addEventListener('click', function () {
@@ -18,4 +18,4 @@
       });
     });
   })()
-</script>
+<% end %>


### PR DESCRIPTION
## Pull Request

**Summary:**
Using the setup mentioned in the GoRails video ([here](https://www.youtube.com/watch?v=MKWq_soCzsQ)), @excid3 mentioned to use the `pay/stripe/checkout_button` partial.

This partial uses an inline script which will cause issues when your Rails app uses a Content-Security-Policy (`config/initializers/content_security_policy.rb`) that forbids inline_script, which should always be the case.

Using Rails helper `javascript_tag`, along `nonce: true` instead of a raw `<script>` will smoothly integrate for those using the Rails CSP feature.

Obviously, I could generate the views using `bin/rails generate pay:views` and do this change if this PR is not accepted.

**Related Issue:**
N/A

**Description:**
I am using a CSP on all my apps to prevent several security breaches, notably XSS attacks.

**Testing:**
I have used the `<%= javascript_tag nonce: true do %> ... <% end %>` syntax with and without a CSP. It works in both cases, not having a CSP will not raise because of the `nonce: true` that will be ignored.

**Screenshots (if applicable):**
Using the actual `pay/stripe/checkout_button` partial with a CSP activated:<br>
<img width="841" alt="image" src="https://github.com/user-attachments/assets/d49a57f8-fe96-497a-80d4-0477b54d202f">

CSP example (Rails default):
```ruby
Rails.application.configure do
  config.content_security_policy do |policy|
    policy.default_src :self, :https
    policy.font_src    :self, :https, :data
    policy.img_src     :self, :https, :data
    policy.object_src  :none
    policy.script_src  :self, :https
    policy.style_src   :self, :https
    # Specify URI for violation reports
    # policy.report_uri "/csp-violation-report-endpoint"
  end

  # Generate session nonces for permitted importmap, inline scripts, and inline styles.
  config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
  config.content_security_policy_nonce_directives = %w[script-src style-src]

  # Report violations without enforcing the policy.
  # config.content_security_policy_report_only = true
end
```

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**

1. **Other inline scripts occurences**
@excid3 I searched for `<script` occurrences in the repo, I think this change could be also applied to the `pay/payments/show` view. But I do not know in which scenario this partial is used (or if it's used at all?).

2. **Documentation**
This is not related to this PR, but maybe mentioning in the Stripe documentation what you showed in the GoRails video (ie the astonishing simplicity of setting up a Stripe checkout) could be a nice addition?