### PR TITLE
Add support for Stripe's Meter Events for usage based billing

### DIFF
--- a/app/models/pay/stripe/subscription.rb
+++ b/app/models/pay/stripe/subscription.rb
@@ -301,6 +301,21 @@ module Pay
         raise Pay::Stripe::Error, e
       end
 
+      # Creates a meter event to bill for usage
+      #
+      # create_meter_event(:api_request, value: 1)
+      # create_meter_event(:api_request, token: 7)
+      def create_meter_event(event_name, **payload)
+        api_record unless processor_id?
+        ::Stripe::Billing::MeterEvent.create({
+          event_name: event_name,
+          payload: {
+            stripe_customer_id: processor_id,
+            **payload
+          }
+        })
+      end
+
       # Creates a metered billing usage record
       #
       # Uses the first subscription_item ID unless `subscription_item_id: "si_1234"` is passed

--- a/docs/stripe/6_metered_billing.md
+++ b/docs/stripe/6_metered_billing.md
@@ -6,9 +6,13 @@ Metered billing are subscriptions where the price fluctuates monthly. For exampl
 @user.payment_processor.subscribe(plan: "price_metered_billing_id")
 ```
 
-This will create a new metered billing subscription.
+This will create a new metered billing subscription. You can then create meter events to bill for usage:
 
-To report usage, you will need to create usage records for the `SubscriptionItem`. You can do that using the Pay helper:
+```ruby
+pay_subscription.create_meter_event(:api_request, value: 1)
+```
+
+If your price is using the legacy usage records system, you will need to use the below method:
 
 ```ruby
 pay_subscription.create_usage_record(quantity: 99)


### PR DESCRIPTION
## Pull Request

**Summary:**
Usage records for usage based billing is now a legacy method in Stripe. Meter events are the new way to track usage: https://docs.stripe.com/api/billing/meter-event?lang=ruby.

**Description:**
I've added a method to make an API call to Stripe to create a meter event. The response from the Stripe SDK is returned to the caller to handle as needed.

**Checklist:**

- [x] Code follows the project's coding standards
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines
