### PR TITLE
Add missing stripe webhook event to documentation

### DIFF
--- a/docs/stripe/5_webhooks.md
+++ b/docs/stripe/5_webhooks.md
@@ -39,6 +39,7 @@ invoice.payment_action_required
 customer.subscription.created
 customer.subscription.updated
 customer.subscription.deleted
+customer.subscription.trial_will_end
 customer.updated
 customer.deleted
 


### PR DESCRIPTION
Pay also handles the `customer.subscription.trial_will_end` event. It should be included in the documentation