### PR TITLE
Change meter event to use the customer's processor ID

### DIFF
--- a/app/models/pay/stripe/customer.rb
+++ b/app/models/pay/stripe/customer.rb
@@ -236,6 +236,18 @@ module Pay
         charge(amount, options.merge(capture_method: :manual))
       end
 
+      # Creates a meter event to bill for usage
+      #
+      # create_meter_event(:api_request, value: 1)
+      # create_meter_event(:api_request, token: 7)
+      def create_meter_event(event_name, payload: {}, **options)
+        api_record unless processor_id?
+        ::Stripe::Billing::MeterEvent.create({
+          event_name: event_name,
+          payload: {stripe_customer_id: processor_id}.merge(payload)
+        }.merge(options))
+      end
+
       private
 
       # Options for Stripe requests

--- a/app/models/pay/stripe/subscription.rb
+++ b/app/models/pay/stripe/subscription.rb
@@ -301,21 +301,6 @@ module Pay
         raise Pay::Stripe::Error, e
       end
 
-      # Creates a meter event to bill for usage
-      #
-      # create_meter_event(:api_request, value: 1)
-      # create_meter_event(:api_request, token: 7)
-      def create_meter_event(event_name, **payload)
-        api_record unless processor_id?
-        ::Stripe::Billing::MeterEvent.create({
-          event_name: event_name,
-          payload: {
-            stripe_customer_id: processor_id,
-            **payload
-          }
-        })
-      end
-
       # Creates a metered billing usage record
       #
       # Uses the first subscription_item ID unless `subscription_item_id: "si_1234"` is passed

--- a/docs/stripe/6_metered_billing.md
+++ b/docs/stripe/6_metered_billing.md
@@ -9,7 +9,7 @@ Metered billing are subscriptions where the price fluctuates monthly. For exampl
 This will create a new metered billing subscription. You can then create meter events to bill for usage:
 
 ```ruby
-pay_subscription.create_meter_event(:api_request, value: 1)
+@user.payment_processor.create_meter_event(:api_request, payload: { value: 1 })
 ```
 
 If your price is using the legacy usage records system, you will need to use the below method:


### PR DESCRIPTION
## Pull Request

**Summary:**

Following on from https://github.com/pay-rails/pay/pull/1051#discussion_r1735276015, I didn't realise that the `processor_id` in the subscription is the ID for the subscription itself rather than the customer. The API requires the ID to be the customer's rather than the subscription's. Stripe throws an error as it stands.

As such I've moved the method into the `Customer` class as I feel it belongs there.

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines
