### PR TITLE
Add link to create Stripe webhook with all the required events

### DIFF
--- a/docs/stripe/5_webhooks.md
+++ b/docs/stripe/5_webhooks.md
@@ -54,6 +54,8 @@ checkout.session.completed
 checkout.session.async_payment_succeeded
 ```
 
+[Click here](https://dashboard.stripe.com/webhooks/create?events=charge.succeeded%2Ccharge.refunded%2Cpayment_intent.succeeded%2Cinvoice.upcoming%2Cinvoice.payment_action_required%2Ccustomer.subscription.created%2Ccustomer.subscription.updated%2Ccustomer.subscription.deleted%2Ccustomer.subscription.trial_will_end%2Ccustomer.updated%2Ccustomer.deleted%2Cpayment_method.attached%2Cpayment_method.updated%2Cpayment_method.automatically_updated%2Cpayment_method.detached%2Caccount.updated%2Ccheckout.session.completed%2Ccheckout.session.async_payment_succeeded) to create a new Stripe webhook with all the events pre-filled.
+
 ## Next
 
 See [Metered Billing](6_metered_billing.md)


### PR DESCRIPTION
## Pull Request

**Summary:**
Manually setting up a new Stripe webhook and selecting each event is is rather tedious. This makes it a lot easier.

**Description:**
There's no way to copy/paste all the required webhook events into Stripe and enable them in one go. I have made a feature request to Stripe, but in the mean time we can use this trick instead.

When creating a new webhook, I noticed Stripe automatically updates the URL to include each selected event. So I thought: why not provide the full list of events we need and see if those are automatically added when the page is loaded. And guess what, they are!

So we can link to `https://dashboard.stripe.com/webhooks/create?events=comma,separated,list,of,events` and those events will be be pre-selected. Comma's need to URL encoded. (`%2C`). Clicking this link does nothing to the user's Stripe account. Nothing is automatically saved. It simply pre-selects each event as shown in the screenshot.

**Testing:**

I tried clicking the link and it works for me. See screenshot.

**Screenshots (if applicable):**

<img width="1264" alt="image" src="https://github.com/user-attachments/assets/9e50d0c3-72d1-46aa-aea9-eef50058a641">

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**
Feel free to change the text.