### PR TITLE
Update GitHub actions versions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,3 +12,7 @@ updates:
   - dependency-name: actionpack
     versions:
     - 6.1.2.1
+- package-ecosystem: github-actions
+  directory: "/"
+  schedule:
+    interval: monthly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: SQLite3 version
         run: sqlite3 --version
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -72,7 +72,7 @@ jobs:
         ports: ['5432:5432']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
@@ -115,7 +115,7 @@ jobs:
         options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION
## Pull Request

**Summary:**
<!-- Provide a brief summary of the changes in this pull request -->
While browsing this repo source code I have noticed that some GitHub actions versions are outdated.

This PR updates them to the latests version and configures Dependabot to automatically open PRs for them once a month.
