### PR TITLE
Update Paddle Billing Javascript Documentation

### DIFF
--- a/docs/paddle_billing/2_javascript.md
+++ b/docs/paddle_billing/2_javascript.md
@@ -11,8 +11,8 @@ Add the Paddle.js script in your application layout and initialize it with your 
 <script src="https://cdn.paddle.com/paddle/v2/paddle.js"></script>
 <script type="text/javascript">
   Paddle.Environment.set("sandbox");
-  Paddle.Setup({
-    token: <%= Pay::PaddleBilling.client_token %>
+  Paddle.Initialize({
+    token: "<%= Pay::PaddleBilling.client_token %>"
   });
 </script>
 ```


### PR DESCRIPTION
## Pull Request

**Summary:**
Update deprecated Paddle.Setup() method to Paddle.Initialize() and minor syntax in Paddle Billing documentation.

**Description:**
I'm integrating Paddle in my service, and noticed that Paddle.js has deprecated the Paddle.Setup() method in favor of Initialize() method: `https://developer.paddle.com/paddlejs/methods/paddle-setup`.

Additionally, quotes are required around the `<%= Pay::PaddleBilling.client_token %>` erb; otherwise I'm running into the following error as it's not read as a string while initializing paddle.js.

<img width="585" alt="Screenshot 2024-09-30 at 11 01 40 PM" src="https://github.com/user-attachments/assets/0653d4ce-d4f4-4230-bb41-c313f400f121">

