### PR TITLE
Explicitly require ostruct gem in webhook model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ PATH
   remote: .
   specs:
     pay (8.0.0)
+      ostruct
       rails (>= 6.0.0)
 
 GEM

--- a/app/models/pay/braintree/subscription.rb
+++ b/app/models/pay/braintree/subscription.rb
@@ -1,3 +1,5 @@
+require "ostruct"
+
 module Pay
   module Braintree
     class Subscription < Pay::Subscription

--- a/app/models/pay/webhook.rb
+++ b/app/models/pay/webhook.rb
@@ -1,3 +1,5 @@
+require "ostruct"
+
 module Pay
   class Webhook < Pay::ApplicationRecord
     validates :processor, presence: true

--- a/gemfiles/rails_6_1.gemfile
+++ b/gemfiles/rails_6_1.gemfile
@@ -26,5 +26,6 @@ gem "net-imap", require: false
 gem "net-pop", require: false
 gem "net-smtp", require: false
 gem "rails", "~> 6.1.0"
+gem "ostruct"
 
 gemspec path: "../"

--- a/gemfiles/rails_6_1.gemfile.lock
+++ b/gemfiles/rails_6_1.gemfile.lock
@@ -11,6 +11,7 @@ PATH
   remote: ..
   specs:
     pay (8.0.0)
+      ostruct
       rails (>= 6.0.0)
 
 GEM
@@ -146,6 +147,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
+    ostruct (0.6.0)
     paddle (2.5.1)
       faraday (~> 2.0)
     parallel (1.26.3)
@@ -293,6 +295,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
+  ostruct
   paddle (~> 2.4)
   pay!
   pg

--- a/gemfiles/rails_7.gemfile
+++ b/gemfiles/rails_7.gemfile
@@ -26,5 +26,6 @@ gem "net-imap", require: false
 gem "net-pop", require: false
 gem "net-smtp", require: false
 gem "rails", "~> 7.0.0"
+gem "ostruct"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.gemfile.lock
+++ b/gemfiles/rails_7.gemfile.lock
@@ -11,6 +11,7 @@ PATH
   remote: ..
   specs:
     pay (8.0.0)
+      ostruct
       rails (>= 6.0.0)
 
 GEM
@@ -152,6 +153,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
+    ostruct (0.6.0)
     paddle (2.5.1)
       faraday (~> 2.0)
     parallel (1.26.3)
@@ -299,6 +301,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
+  ostruct
   paddle (~> 2.4)
   pay!
   pg

--- a/gemfiles/rails_7_1.gemfile
+++ b/gemfiles/rails_7_1.gemfile
@@ -26,5 +26,6 @@ gem "net-imap", require: false
 gem "net-pop", require: false
 gem "net-smtp", require: false
 gem "rails", "~> 7.1.0"
+gem "ostruct"
 
 gemspec path: "../"

--- a/gemfiles/rails_7_1.gemfile.lock
+++ b/gemfiles/rails_7_1.gemfile.lock
@@ -11,6 +11,7 @@ PATH
   remote: ..
   specs:
     pay (8.0.0)
+      ostruct
       rails (>= 6.0.0)
 
 GEM
@@ -167,6 +168,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
+    ostruct (0.6.0)
     paddle (2.5.1)
       faraday (~> 2.0)
     parallel (1.26.3)
@@ -325,6 +327,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
+  ostruct
   paddle (~> 2.4)
   pay!
   pg

--- a/gemfiles/rails_7_2.gemfile
+++ b/gemfiles/rails_7_2.gemfile
@@ -26,5 +26,6 @@ gem "net-imap", require: false
 gem "net-pop", require: false
 gem "net-smtp", require: false
 gem "rails", "~> 7.2.0.rc1"
+gem "ostruct"
 
 gemspec path: "../"

--- a/gemfiles/rails_7_2.gemfile.lock
+++ b/gemfiles/rails_7_2.gemfile.lock
@@ -11,6 +11,7 @@ PATH
   remote: ..
   specs:
     pay (8.0.0)
+      ostruct
       rails (>= 6.0.0)
 
 GEM
@@ -162,6 +163,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
+    ostruct (0.6.0)
     paddle (2.5.1)
       faraday (~> 2.0)
     parallel (1.26.3)
@@ -325,6 +327,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
+  ostruct
   paddle (~> 2.4)
   pay!
   pg

--- a/gemfiles/rails_main.gemfile
+++ b/gemfiles/rails_main.gemfile
@@ -26,5 +26,6 @@ gem "net-imap", require: false
 gem "net-pop", require: false
 gem "net-smtp", require: false
 gem "rails", branch: "main", git: "https://github.com/rails/rails.git"
+gem "ostruct"
 
 gemspec path: "../"

--- a/gemfiles/rails_main.gemfile.lock
+++ b/gemfiles/rails_main.gemfile.lock
@@ -109,6 +109,7 @@ PATH
   remote: ..
   specs:
     pay (8.0.0)
+      ostruct
       rails (>= 6.0.0)
 
 GEM
@@ -190,6 +191,7 @@ GEM
       racc (~> 1.4)
     nokogiri (1.16.7-x86_64-linux)
       racc (~> 1.4)
+    ostruct (0.6.0)
     paddle (2.5.1)
       faraday (~> 2.0)
     parallel (1.26.3)
@@ -331,6 +333,7 @@ DEPENDENCIES
   net-imap
   net-pop
   net-smtp
+  ostruct
   paddle (~> 2.4)
   pay!
   pg

--- a/pay.gemspec
+++ b/pay.gemspec
@@ -22,4 +22,5 @@ Gem::Specification.new do |s|
   ]
 
   s.add_dependency "rails", ">= 6.0.0"
+  s.add_dependency "ostruct"
 end

--- a/test/models/pay/webhook_test.rb
+++ b/test/models/pay/webhook_test.rb
@@ -8,6 +8,13 @@ class Pay::Webhook::Test < ActiveSupport::TestCase
     assert_equal "visa", event.payment_method.card_type
   end
 
+  test "rehydrates a Paddle Billing event" do
+    pay_webhook = Pay::Webhook.create processor: :paddle_billing, event_type: :example, event: json_fixture("paddle_billing/subscription.created")
+    event = pay_webhook.rehydrated_event
+    assert_equal OpenStruct, event.class
+    assert_equal "month", event.billing_cycle.interval
+  end
+
   test "rehydrates a Stripe event" do
     pay_webhook = Pay::Webhook.create processor: :stripe, event_type: :example, event: json_fixture("stripe/customer.updated")
     event = pay_webhook.rehydrated_event


### PR DESCRIPTION
## Pull Request

**Summary:**
Running into `Error: NameError: uninitialized constant Pay::Webhook::OpenStruct` error when `Pay::Webhooks::ProcessJob` is running for `paddle_billing`

**Description:**
I'm integrating paddle with pay gem into my application, and have configured multiple webhooks for syncing subscriptions.

However, I'm running into the following error in `Pay::Webhooks::ProcessJob`:

```
Error: NameError: uninitialized constant Pay::Webhook::OpenStruct
/usr/local/bundle/ruby/3.3.0/gems/pay-8.0.0/app/models/pay/webhook.rb:35:in `to_recursive_ostruct'
/usr/local/bundle/ruby/3.3.0/gems/pay-8.0.0/app/models/pay/webhook.rb:21:in `rehydrated_event'
/usr/local/bundle/ruby/3.3.0/gems/pay-8.0.0/app/models/pay/webhook.rb:8:in `process!'
/usr/local/bundle/ruby/3.3.0/gems/pay-8.0.0/lib/pay/webhooks/process_job.rb:5:in `perform'
```

To fix the issue, I have explicitly added `require "ostruct"` to the `Pay::Webhook` model, and added a test case for `paddle_billing` for the same model.

Additionally, added the `require "ostruct"` line to `Pay::Braintree::Subscription` model (the only other place where OpenStruct is used) as well proactively.

**Testing:**
Tested the fixes in this PR on my staging server, the webhook job passes now.

**Screenshots (if applicable):**
<img width="1720" alt="Screenshot 2024-10-01 at 12 50 26 AM" src="https://github.com/user-attachments/assets/e4edf38e-c391-46cc-ba82-4335cb2f1511">

The first (failed) run in above screenshot is with pay-8.0.0, while the second successful run is with the fixes in this PR.

**Additional Notes:**
My setup is:
- Rails 7.2.1
- Ruby 3.3.4
- Pay 8.0.0
- Paddle 2.6.0
