### PR TITLE
Allow proration mode argument for paddle_billing subscription update

### DIFF
--- a/app/models/pay/paddle_billing/subscription.rb
+++ b/app/models/pay/paddle_billing/subscription.rb
@@ -102,9 +102,11 @@ module Pay
           quantity: quantity
         }]
 
-        proration_billing_mode = options.delete(:proration_billing_mode) || "prorated_immediately"
-
-        ::Paddle::Subscription.update(id: processor_id, items: items, proration_billing_mode: proration_billing_mode)
+        ::Paddle::Subscription.update(
+          id: processor_id,
+          items: items,
+          proration_billing_mode: options.delete(:proration_billing_mode) || "prorated_immediately"
+        )
         update(quantity: quantity)
       rescue ::Paddle::Error => e
         raise Pay::PaddleBilling::Error, e
@@ -157,9 +159,11 @@ module Pay
           quantity: quantity || 1
         }]
 
-        proration_billing_mode = options.delete(:proration_billing_mode) || "prorated_immediately"
-
-        ::Paddle::Subscription.update(id: processor_id, items: items, proration_billing_mode: proration_billing_mode)
+        ::Paddle::Subscription.update(
+          id: processor_id, 
+          items: items, 
+          proration_billing_mode: options.delete(:proration_billing_mode) || "prorated_immediately"
+        )
         update(processor_plan: plan, ends_at: nil, status: :active)
       end
 

--- a/app/models/pay/paddle_billing/subscription.rb
+++ b/app/models/pay/paddle_billing/subscription.rb
@@ -102,7 +102,9 @@ module Pay
           quantity: quantity
         }]
 
-        ::Paddle::Subscription.update(id: processor_id, items: items, proration_billing_mode: "prorated_immediately")
+        proration_billing_mode = options.delete(:proration_billing_mode) || "prorated_immediately"
+
+        ::Paddle::Subscription.update(id: processor_id, items: items, proration_billing_mode: proration_billing_mode)
         update(quantity: quantity)
       rescue ::Paddle::Error => e
         raise Pay::PaddleBilling::Error, e
@@ -148,12 +150,16 @@ module Pay
       end
 
       def swap(plan, **options)
+        raise ArgumentError, "plan must be a string" unless plan.is_a?(String)
+
         items = [{
           price_id: plan,
           quantity: quantity || 1
         }]
 
-        ::Paddle::Subscription.update(id: processor_id, items: items, proration_billing_mode: "prorated_immediately")
+        proration_billing_mode = options.delete(:proration_billing_mode) || "prorated_immediately"
+
+        ::Paddle::Subscription.update(id: processor_id, items: items, proration_billing_mode: proration_billing_mode)
         update(processor_plan: plan, ends_at: nil, status: :active)
       end
 

--- a/app/models/pay/paddle_billing/subscription.rb
+++ b/app/models/pay/paddle_billing/subscription.rb
@@ -160,8 +160,8 @@ module Pay
         }]
 
         ::Paddle::Subscription.update(
-          id: processor_id, 
-          items: items, 
+          id: processor_id,
+          items: items,
           proration_billing_mode: options.delete(:proration_billing_mode) || "prorated_immediately"
         )
         update(processor_plan: plan, ends_at: nil, status: :active)


### PR DESCRIPTION
## Pull Request

**Summary:**
While swapping plans / updating quantity for a subscription, allow users to set proration mode for paddle billing.

**Description:**
Currently, proration mode is hardcoded to `prorated_immediately`, but users may choose different proration mode depending on their use case. Ref: https://developer.paddle.com/api-reference/subscriptions/update-subscription.

The implementation in this PR is similar to Stripe's subscription model: https://github.com/pay-rails/pay/blob/main/app/models/pay/stripe/subscription.rb#L277

