### PR TITLE
Fix LemonSqueezy sync subscription method

### DIFF
--- a/app/models/pay/lemon_squeezy/subscription.rb
+++ b/app/models/pay/lemon_squeezy/subscription.rb
@@ -9,7 +9,7 @@ module Pay
 
         attributes = {
           current_period_end: object.renews_at,
-          ends_at: (object.ends_at ? Time.parse(object..ends_at) : nil),
+          ends_at: (object.ends_at ? Time.parse(object.ends_at) : nil),
           pause_starts_at: (object.pause&.resumes_at ? Time.parse(object.pause.resumes_at) : nil),
           status: object.status,
           processor_plan: object.first_subscription_item.price_id,


### PR DESCRIPTION
## Pull Request

**Summary:**
There's a bug in the `Pay::LemonSqueezy::Subscription#sync` method that prevents it from succeding. 

**Related Issue:**
[#1086 
](https://github.com/pay-rails/pay/issues/1086)

**Description:**
Just fixed a simple syntax error that I found while testing subscription flows in a LemonSqueezy environment.

**Testing:**
Tested the changes by switching the gem installation to my branch

**Screenshots (if applicable):**
Here are the logs that show the successful webhook processing

```
TRANSACTION (0.1ms)  commit transaction
07:40:53 web.1  | [ActiveJob] Enqueued Pay::Webhooks::ProcessJob (Job ID: bc9605ee-b9ce-4189-9137-6fa2d8731b03) to Async(default) with arguments: #<GlobalID:0x0000000140abed98 @uri=#<URI::GID gid://daisy-solid-template/Pay::Webhook/39>>
07:40:53 web.1  | Completed 200 OK in 143ms (ActiveRecord: 1.0ms | Allocations: 9844)
07:40:53 web.1  | 
07:40:53 web.1  | 
07:40:53 web.1  | [ActiveJob] [Pay::Webhooks::ProcessJob] [bc9605ee-b9ce-4189-9137-6fa2d8731b03]   Pay::Webhook Load (0.1ms)  SELECT "pay_webhooks".* FROM "pay_webhooks" WHERE "pay_webhooks"."id" = ? LIMIT ?  [["id", 39], ["LIMIT", 1]]
07:40:53 web.1  | [ActiveJob] [Pay::Webhooks::ProcessJob] [bc9605ee-b9ce-4189-9137-6fa2d8731b03] Performing Pay::Webhooks::ProcessJob (Job ID: bc9605ee-b9ce-4189-9137-6fa2d8731b03) from Async(default) enqueued at 2024-10-11T05:40:53.160103000Z with arguments: #<GlobalID:0x0000000137dec2f8 @uri=#<URI::GID gid://daisy-solid-template/Pay::Webhook/39>>
07:40:53 web.1  | [ActiveJob] [Pay::Webhooks::ProcessJob] [bc9605ee-b9ce-4189-9137-6fa2d8731b03]   Pay::Customer Load (0.1ms)  SELECT "pay_customers".* FROM "pay_customers" WHERE "pay_customers"."processor" = ? AND "pay_customers"."processor_id" = ? LIMIT ?  [["processor", "lemon_squeezy"], ["processor_id", "3906555"], ["LIMIT", 1]]
07:40:53 web.1  | [ActiveJob] [Pay::Webhooks::ProcessJob] [bc9605ee-b9ce-4189-9137-6fa2d8731b03]   Pay::PaymentMethod Load (0.0ms)  SELECT "pay_payment_methods".* FROM "pay_payment_methods" WHERE "pay_payment_methods"."customer_id" = ?  [["customer_id", 3906555]]
07:40:53 web.1  | [ActiveJob] [Pay::Webhooks::ProcessJob] [bc9605ee-b9ce-4189-9137-6fa2d8731b03]   Pay::LemonSqueezy::Subscription Load (0.0ms)  SELECT "pay_subscriptions".* FROM "pay_subscriptions" WHERE "pay_subscriptions"."type" = ? AND "pay_subscriptions"."customer_id" = ? AND "pay_subscriptions"."processor_id" = ? LIMIT ?  [["type", "Pay::LemonSqueezy::Subscription"], ["customer_id", 11], ["processor_id", "651762"], ["LIMIT", 1]]
07:40:53 web.1  | [ActiveJob] [Pay::Webhooks::ProcessJob] [bc9605ee-b9ce-4189-9137-6fa2d8731b03]   TRANSACTION (0.0ms)  begin transaction
07:40:53 web.1  | [ActiveJob] [Pay::Webhooks::ProcessJob] [bc9605ee-b9ce-4189-9137-6fa2d8731b03]   Pay::LemonSqueezy::Subscription Load (0.6ms)  SELECT "pay_subscriptions".* FROM "pay_subscriptions" WHERE "pay_subscriptions"."type" = ? AND "pay_subscriptions"."id" = ? LIMIT ?   [["type", "Pay::LemonSqueezy::Subscription"], ["id", 3], ["LIMIT", 1]]
07:40:53 web.1  | [ActiveJob] [Pay::Webhooks::ProcessJob] [bc9605ee-b9ce-4189-9137-6fa2d8731b03]   Pay::Subscription Exists? (0.1ms)  SELECT 1 AS one FROM "pay_subscriptions" WHERE "pay_subscriptions"."processor_id" = ? AND "pay_subscriptions"."id" != ? AND "pay_subscriptions"."customer_id" = ? LIMIT ?  [["processor_id", "651762"], ["id", 3], ["customer_id", 11], ["LIMIT", 1]]
07:40:53 web.1  | [ActiveJob] [Pay::Webhooks::ProcessJob] [bc9605ee-b9ce-4189-9137-6fa2d8731b03]   TRANSACTION (0.0ms)  commit transaction
07:40:53 web.1  | [ActiveJob] [Pay::Webhooks::ProcessJob] [bc9605ee-b9ce-4189-9137-6fa2d8731b03]   TRANSACTION (0.0ms)  begin transaction
07:40:53 web.1  | [ActiveJob] [Pay::Webhooks::ProcessJob] [bc9605ee-b9ce-4189-9137-6fa2d8731b03]   Pay::Webhook Destroy (0.4ms)  DELETE FROM "pay_webhooks" WHERE "pay_webhooks"."id" = ?  [["id", 39]]
```

**Checklist:**
- [x] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines
