### PR TITLE
Enhance Stripe billing portal documentation adding return_url option

### DIFF
--- a/docs/stripe/8_stripe_checkout.md
+++ b/docs/stripe/8_stripe_checkout.md
@@ -76,6 +76,9 @@ First, create a session in your controller:
 class SubscriptionsController < ApplicationController
   def index
     @portal_session = current_user.payment_processor.billing_portal
+
+    # You can customize the billing_portal return_url (default is root_url):
+    # @portal_session = current_user.payment_processor.billing_portal(return_url: your_url)
   end
 end
 ```


### PR DESCRIPTION
## Pull Request

**Summary:**
I wanted to customize the return url used by Stripe checkout UI:
<img width="872" alt="image" src="https://github.com/user-attachments/assets/718c5227-e75e-4e03-8a33-6c0986aeec99">

**Related Issue:**
N/A

**Description:**
The gem allows it, but it's not documented, hence my PR.
[https://github.com/pay-rails/pay/blob/33b8c2e9606dac1ff6c78c2e5bd6ce6f7b2a9b0f/app/models/pay/stripe/customer.rb#L226](https://github.com/pay-rails/pay/blob/33b8c2e9606dac1ff6c78c2e5bd6ce6f7b2a9b0f/app/models/pay/stripe/customer.rb#L226)

**Testing:**
N/A

**Screenshots (if applicable):**
N/A

**Checklist:**
- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**
N/A
