### PR TITLE
fix paddle billing docs: .customer --> .api_record

### DIFF
--- a/docs/paddle_billing/1_overview.md
+++ b/docs/paddle_billing/1_overview.md
@@ -17,7 +17,7 @@ Paddle now works similar to Stripe. You create a customer, which subscriptions b
 @user.set_payment_processor :paddle_billing
 
 # Create the customer on Paddle
-@user.payment_processor.customer
+@user.payment_processor.api_record
 ```
 
 ## Prices & Plans


### PR DESCRIPTION
## Pull Request

**Summary:**

The Paddle Billing docs are referring to a broken (probably outdated?) method for creating the customer entity on Paddle's side (see diff).

**Related Issue:**

None.

**Description:**

See above.

**Testing:**

I came across this while integrating the current version of `pay` with Paddle Billing for a new project. Calling `api_record` instead seems to work.

**Screenshots (if applicable):**

None

**Checklist:**

- [x] Code follows the project's coding standards
~~- [ ] Tests have been added or updated to cover the changes~~
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**

None.