### PR TITLE
Replace outdated update_customer! call in docs

### DIFF
--- a/docs/stripe/1_overview.md
+++ b/docs/stripe/1_overview.md
@@ -34,7 +34,7 @@ Promotion codes are customer-facing coupon codes that can be applied in several 
 You can apply a promotion code on the Stripe::Customer to have it automatically apply to all Subscriptions.
 
 ```ruby
-@user.payment_processor.update_customer!(promotion_code: "promo_1234")
+@user.payment_processor.update_api_record(promotion_code: "promo_1234")
 ```
 
 Promotion codes can also be applied directly to a subscription:

--- a/docs/stripe/7_stripe_tax.md
+++ b/docs/stripe/7_stripe_tax.md
@@ -24,7 +24,7 @@ end
 To update the customer address anytime it's changed, call the following method:
 
 ```ruby
-@user.payment_processor.update_customer!
+@user.payment_processor.update_api_record
 ```
 
 This will make an API request to update the Stripe::Customer with the current `stripe_attributes`.


### PR DESCRIPTION
It seems this was replaced in the 8.0 release, so this should make the docs reflective of that change.

## Pull Request

**Summary:**
Updating the docs to match method name changes in a recent release.

**Related Issue:**
<!-- If applicable, reference the GitHub issue that this pull request resolves -->

**Description:**
Just a simple change to the docs since I happened to be working with this bit of the code for a project.

**Testing:**
Should not be necessary, this is purely a change to the docs.

**Screenshots (if applicable):**
<!-- Include any relevant screenshots or GIFs that demonstrate the changes -->

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**
<!-- Any additional information or notes for the reviewers -->
