### PR TITLE
Adding self.sync to fake processor for a consistent API

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -110,7 +110,7 @@ This is a major change to add Stripe tax support, Stripe metered billing, new co
 
 ### Method Additions and Changes
 
-In an effort to keep a consistant naming convention, the email parameters of `subscription` and `charge` have been updated to have `pay_` prepended to them (`pay_subscription` and `pay_charge` respectively). If you are directly using any of the built in emails or created custom Pay views, you will want to be sure to update your parameter names to the updated names.
+In an effort to keep a consistent naming convention, the email parameters of `subscription` and `charge` have been updated to have `pay_` prepended to them (`pay_subscription` and `pay_charge` respectively). If you are directly using any of the built in emails or created custom Pay views, you will want to be sure to update your parameter names to the updated names.
 
 You'll need to replace all references to:
 ```ruby
@@ -120,7 +120,7 @@ params[:subscription] with params[:pay_subscription]
 
 The `send_emails` configuration variable has been removed from Pay and replaced by the new configuration system which is discussed below. `Pay.send_emails` is primarily used internally, but if you have been using it in your application code you will need to update those areas to use the new method calls from the email configuration settings. For example, to check if the receipt email should be sent you can now call `Pay.send_email?(:receipt)`. If your email configuration option uses a lambda, you can pass any additional arguments to `send_email?` like so `Pay.send_email?(:receipt, pay_charge)` for use in the lambda.
 
-The `update_email!` method has been replaced with `update_customer!`. When dealing with a `Stripe::Billable` or `Braintree::Billable` object, a hash of additional attributes can be passed in that will be merged into the default atrributes.
+The `update_email!` method has been replaced with `update_customer!`. When dealing with a `Stripe::Billable` or `Braintree::Billable` object, a hash of additional attributes can be passed in that will be merged into the default attributes.
 
 The `Stripe::Subscription#cancel_now!` method now accepts a hash of options such as `cancel_now!(prorate: true, invoice_now: true)` which will be handled automatically by Stripe.
 

--- a/app/models/pay/fake_processor/subscription.rb
+++ b/app/models/pay/fake_processor/subscription.rb
@@ -1,11 +1,15 @@
 module Pay
   module FakeProcessor
     class Subscription < Pay::Subscription
+      def self.sync(processor_id, **options)
+        # Bypass sync operation for FakeProcessor
+      end
+
       def api_record(**options)
         self
       end
 
-      # With trial, sets end to trial end (mimicing Stripe)
+      # With trial, sets end to trial end (mimicking Stripe)
       # Without trial, sets can ends_at to end of month
       def cancel(**options)
         return if canceled?

--- a/test/pay/fake_processor/subscription_test.rb
+++ b/test/pay/fake_processor/subscription_test.rb
@@ -69,4 +69,10 @@ class Pay::FakeProcessor::Subscription::Test < ActiveSupport::TestCase
     assert @subscription.canceled?
     refute @subscription.resumable?
   end
+
+  test "fake processor sync!" do
+    assert_nothing_raised do
+      @subscription.sync!
+    end
+  end
 end


### PR DESCRIPTION
## Pull Request

**Summary:**
Adding `self.sync` to fake processor for API consistency

**Description:**
Currently, the fake processor does not implement `self.sync`, so calling `sync!` if a user is subscribed to a `fake` process (in my case, users whom I gave free access) triggers an error. Ideally, since it does nothing, it should just be a bypass so that clients don't need to check the subscription type before calling the `sync!` or not

Also fixed a couple of typos while going through the upgrade guide. 

**Testing:**

**Screenshots (if applicable):**

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [X] Code follows the project's coding standards
- [X] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated (if applicable)
- [ ] All existing tests pass
- [ ] Conforms to the contributing guidelines

