### PR TITLE
Ignore Stripe failed payment webhooks for incomplete subscriptions

### DIFF
--- a/lib/pay/stripe/webhooks/payment_action_required.rb
+++ b/lib/pay/stripe/webhooks/payment_action_required.rb
@@ -8,8 +8,9 @@ module Pay
 
           object = event.data.object
 
+          # Don't send email on incomplete Stripe subscriptions since they're just getting created and the JavaScript will handle SCA
           pay_subscription = Pay::Subscription.find_by_processor_and_id(:stripe, object.subscription)
-          return if pay_subscription.nil?
+          return if pay_subscription.nil? || pay_subscription.status == "incomplete"
 
           if Pay.send_email?(:payment_action_required, pay_subscription)
             Pay.mailer.with(

--- a/lib/pay/stripe/webhooks/payment_failed.rb
+++ b/lib/pay/stripe/webhooks/payment_failed.rb
@@ -8,8 +8,9 @@ module Pay
 
           object = event.data.object
 
+          # Don't send email on incomplete Stripe subscriptions since they're just getting created and the JavaScript will handle SCA
           pay_subscription = Pay::Subscription.find_by_processor_and_id(:stripe, object.subscription)
-          return if pay_subscription.nil?
+          return if pay_subscription.nil? || pay_subscription.status == "incomplete"
 
           if Pay.send_email?(:payment_failed, pay_subscription)
             Pay.mailer.with(

--- a/test/pay/stripe/webhooks/payment_action_required_test.rb
+++ b/test/pay/stripe/webhooks/payment_action_required_test.rb
@@ -5,24 +5,20 @@ class Pay::Stripe::Webhooks::PaymentActionRequiredTest < ActiveSupport::TestCase
     @event = stripe_event("invoice.payment_action_required")
 
     # Create user and subscription
-    @pay_customer = pay_customers(:stripe)
-    @pay_customer.update(processor_id: @event.data.object.customer)
-    @subscription = @pay_customer.subscriptions.create!(
-      processor_id: @event.data.object.subscription,
-      name: "default",
-      processor_plan: "some-plan",
-      status: "requires_action"
-    )
+    pay_customers(:stripe).update!(processor_id: @event.data.object.customer)
   end
 
   test "it sends an email" do
+    Pay::Stripe::Subscription.sync @event.data.object.subscription, object: fake_stripe_subscription(id: @event.data.object.subscription, customer: @event.data.object.customer, status: :past_due)
+
     assert_enqueued_jobs 1 do
       Pay::Stripe::Webhooks::PaymentActionRequired.new.call(@event)
     end
   end
 
-  test "ignores if subscription doesn't exist" do
-    @subscription.destroy!
+  test "skips email if subscription is incomplete" do
+    Pay::Stripe::Subscription.sync @event.data.object.subscription, object: fake_stripe_subscription(id: @event.data.object.subscription, customer: @event.data.object.customer, status: :incomplete)
+
     assert_no_enqueued_jobs do
       Pay::Stripe::Webhooks::PaymentActionRequired.new.call(@event)
     end

--- a/test/pay/stripe/webhooks/payment_failed_test.rb
+++ b/test/pay/stripe/webhooks/payment_failed_test.rb
@@ -16,6 +16,13 @@ class Pay::Stripe::Webhooks::PaymentFailedTest < ActiveSupport::TestCase
     end
   end
 
+  test "skips email if subscription is incomplete" do
+    create_subscription(processor_id: @payment_failed_event.data.object.subscription)
+    assert_no_enqueued_jobs do
+      Pay::Stripe::Webhooks::PaymentFailed.new.call(@payment_failed_event)
+    end
+  end
+
   private
 
   def create_subscription(processor_id:)


### PR DESCRIPTION
Since incomplete subscriptions are just pending and are currently being created by a customer in the browser, the JavaScript will handle these events. We can safely ignore them server-side and prevent sending duplicates.

Stripe Checkout's payment intents are also only usable inside Checkout, so if they were to be used to complete the charge, they may raise an error.

