### PR TITLE
Update stripe_connect.md to reflect Stripe API changes and offer some color on Merchant#onboarding_complete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+* Remove default `type` for Stripe Merchant Account creation
+
 ### 8.3.0
 
 * Ignore Stripe `payment_failed` and `payment_action_required` webhooks on `incomplete` subscriptions as these are already handled by the JavaScript in-browser. #1121

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-* Remove default `type` for Stripe Merchant Account creation
+* [Breaking] Remove default `type` for Stripe Merchant Account creation
 
 ### 8.3.0
 

--- a/app/models/pay/stripe/merchant.rb
+++ b/app/models/pay/stripe/merchant.rb
@@ -2,15 +2,7 @@ module Pay
   module Stripe
     class Merchant < Pay::Merchant
       def create_account(**options)
-        defaults = {
-          type: "express",
-          capabilities: {
-            card_payments: {requested: true},
-            transfers: {requested: true}
-          }
-        }
-
-        stripe_account = ::Stripe::Account.create(defaults.merge(options))
+        stripe_account = ::Stripe::Account.create(options)
         update(processor_id: stripe_account.id)
         stripe_account
       rescue ::Stripe::StripeError => e

--- a/docs/marketplaces/stripe_connect.md
+++ b/docs/marketplaces/stripe_connect.md
@@ -36,8 +36,6 @@ end
 @user.merchant_processor.onboarding_complete? # Updates via webhook based on the Stripe::Account's #charges_enabled attribute
 ```
 
-**IMPORTANT:** [Stripe has updated their account creation mechanism](https://docs.stripe.com/connect/migrate-to-controller-properties) to offer more granularity by providing a `controller` parameter. If you want to use specific `controller` options when creating an account, you'll instead need to map your desired settings to a `type` [following this Stripe guide](https://docs.stripe.com/connect/migrate-to-controller-properties#mapping-account-types-to-controller-parameters). At the moment, Pay defaults to specifying a `type` in the `Merchant#create_account` method, and both parameters cannot be sent simultaneously to Stripe. If you need to use `controller` to have more granular settings, we welcome a PR.
-
 ## When Using Checkout Session
 
 You can add your stripe connect account by passing the connect id to the set_payment_processor

--- a/docs/marketplaces/stripe_connect.md
+++ b/docs/marketplaces/stripe_connect.md
@@ -33,7 +33,10 @@ end
 @user.merchant_processor.account_link
 @user.merchant_processor.login_link
 @user.merchant_processor.transfer(amount: 25_00)
+@user.merchant_processor.onboarding_complete? # Updates via webhook based on the Stripe::Account's #charges_enabled attribute
 ```
+
+**IMPORTANT:** [Stripe has updated their account creation mechanism](https://docs.stripe.com/connect/migrate-to-controller-properties) to offer more granularity by providing a `controller` parameter. If you want to use specific `controller` options when creating an account, you'll instead need to map your desired settings to a `type` [following this Stripe guide](https://docs.stripe.com/connect/migrate-to-controller-properties#mapping-account-types-to-controller-parameters). At the moment, Pay defaults to specifying a `type` in the `Merchant#create_account` method, and both parameters cannot be sent simultaneously to Stripe. If you need to use `controller` to have more granular settings, we welcome a PR.
 
 ## When Using Checkout Session
 
@@ -128,13 +131,13 @@ var stripe = Stripe("<%= @sample_credentials.test_publishable_key %>", {
 pay_charge = @user.charge(100_00, transfer_group: '{ORDER10}')
 
 # Create a Transfer to a connected account (later):
-@other_user.merchant.transfer(
+@other_user.merchant_processor.transfer(
   amount: 70_00,
   transfer_group: '{ORDER10}',
 )
 
 # Create a second Transfer to another connected account (later):
-@another_user.merchant.transfer(
+@another_user.merchant_processor.transfer(
   amount: 20_00,
   transfer_group: '{ORDER10}',
 )
@@ -145,8 +148,12 @@ Alternatively, the `source_transaction` parameter allows you to transfer only on
 See: https://stripe.com/docs/connect/charges-transfers#transfer-availability
 
 ```ruby
-@other_user.merchant.transfer(
+@other_user.merchant_processor.transfer(
   amount: 70_00,
   source_transaction: pay_charge.processor_id
 )
 ```
+
+### Verification
+
+By default, Pay sets up a webhook listener for the `account.updated` event that updates an `onboarding_complete` flag based on whether `charges_enabled` is true, which Stripe updates based on the account's current verification (or lack thereof) status as long as you request a charge or transfer capability when connecting the user's Stripe Connect account to your platform's Stripe account.


### PR DESCRIPTION
Updated docs to provide some detail on the default `onboarding_complete` flag that's set based on account verification, and also felt it worth a callout about the gotcha related to Stripe Connect's API updates. Also updated syntax that might have been outdated