### PR TITLE
add sync_subscriptions to FakeProcessor::Customer

### DIFF
--- a/app/models/pay/fake_processor/customer.rb
+++ b/app/models/pay/fake_processor/customer.rb
@@ -55,6 +55,10 @@ module Pay
         subscriptions.create!(attributes)
       end
 
+      def sync_subscriptions(**options)
+        []
+      end
+
       def add_payment_method(payment_method_id, default: false)
         # Make to generate a processor_id
         api_record

--- a/test/pay/fake_processor/customer_test.rb
+++ b/test/pay/fake_processor/customer_test.rb
@@ -60,6 +60,12 @@ class Pay::FakeProcessor::CustomerTest < ActiveSupport::TestCase
     assert_equal "Fake", payment_method.brand
   end
 
+  test "fake processor sync_subscriptions" do
+    assert_nothing_raised do
+      @pay_customer.sync_subscriptions
+    end
+  end
+
   test "generates fake processor_id" do
     user = users(:none)
     pay_customer = user.set_payment_processor :fake_processor, allow_fake: true


### PR DESCRIPTION
## Pull Request

**Summary:**
Adds `sync_subscriptions` to `FakeProcessor::Customer` to mimic the Stripe processor API.

**Description:**
My code calls `user.payment_processor.sync_subscriptions(status: "all")` with the Stripe processor. In my tests using the fake processor, this method is missing. Returns `[]` to mimic the "map" return type in [the Stripe processor](https://github.com/pay-rails/pay/blob/main/app/models/pay/stripe/customer.rb#L153-L155).

**Testing:**
Added a unit test.

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines
