### PR TITLE
Update subscription.rb

### DIFF
--- a/app/models/pay/stripe/subscription.rb
+++ b/app/models/pay/stripe/subscription.rb
@@ -297,7 +297,7 @@ module Pay
         )
 
         # Validate that swap was successful and handle SCA if needed
-        if (payment_intent_id = @api_record.latest_invoice.payments.first.payment.payment_intent)
+        if (payment_intent_id = @api_record.latest_invoice.payments.first&.payment&.payment_intent)
           Pay::Payment.from_id(payment_intent_id).validate
         end
 


### PR DESCRIPTION
**Summary:**
Fixes a `NoMethodError` in the Stripe subscription swap process when the plan change results in a credit or a $0 invoice.

**Related Issue:**
<!-- If applicable, reference the GitHub issue that this pull request resolves -->
N/A

**Description:**
When a user changes their subscription plan, and the proration results in a credit or a $0 invoice, Stripe's API returns a `latest_invoice` object with an empty `payments` array. This is because no actual payment is processed, and thus no `payment_intent` is generated for such invoices.

The `Pay::Stripe::Subscription#swap` method was attempting to access `payments.first.payment.payment_intent` without checking if `payments.first` was `nil`. This led to a `NoMethodError: undefined method 'payment' for nil:NilClass` in these scenarios.

This pull request modifies the `swap` method to use Ruby's safe navigation operator (`&.`) when accessing these nested attributes:
