### PR TITLE
Update Pay::Customer#email to return nil if owner has been deleted

### DIFF
--- a/app/models/pay/customer.rb
+++ b/app/models/pay/customer.rb
@@ -20,7 +20,7 @@ module Pay
     store_accessor :data, :invoice_credit_balance
     store_accessor :data, :currency
 
-    delegate :email, to: :owner
+    delegate :email, to: :owner, allow_nil: true
 
     %w[stripe braintree paddle_billing paddle_classic lemon_squeezy fake_processor].each do |processor_name|
       scope processor_name, -> { where(processor: processor_name) }

--- a/test/pay/customer_test.rb
+++ b/test/pay/customer_test.rb
@@ -14,6 +14,15 @@ class Pay::CustomerTest < ActiveSupport::TestCase
     assert_equal "Pay Customer Name", @user.payment_processor.customer_name
   end
 
+  test "email" do
+    assert_equal "fake@example.org", @user.payment_processor.email
+  end
+
+  test "email after owner deleted" do
+    @user.destroy
+    assert_nil @user.payment_processor.reload.email
+  end
+
   test "customer with processor" do
     assert_equal @user.payment_processor, @user.payment_processor.api_record
   end


### PR DESCRIPTION
## Pull Request

**Summary:**
<!-- Provide a brief summary of the changes in this pull request -->
Updates the `Pay::Customer#email` method to return `nil` if `owner` has been deleted instead of raising an error:
```
ActiveSupport::DelegationError: email delegated to owner, but owner is nil
```

**Related Issue:**
<!-- If applicable, reference the GitHub issue that this pull request resolves -->
https://github.com/pay-rails/pay/pull/403


**Description:**
<!-- Elaborate on the changes made in this pull request. What motivated these changes? -->

**Testing:**
<!-- Describe the steps you've taken to test the changes. Include relevant information for other contributors to verify the modifications -->

**Screenshots (if applicable):**
<!-- Include any relevant screenshots or GIFs that demonstrate the changes -->

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**
<!-- Any additional information or notes for the reviewers -->
