### PR TITLE
Don't modify trial_ends_at in the cancel_now method unless the subscription is actually on trial

### DIFF
--- a/app/models/pay/stripe/subscription.rb
+++ b/app/models/pay/stripe/subscription.rb
@@ -178,7 +178,7 @@ module Pay
         return if canceled? && ends_at.past?
 
         @api_record = ::Stripe::Subscription.cancel(processor_id, options.merge(expand_options), stripe_options)
-        update(trial_ends_at: Time.current, ends_at: Time.current, status: :canceled)
+        update(trial_ends_at: on_trial? ? Time.current : trial_ends_at, ends_at: Time.current, status: :canceled)
       rescue ::Stripe::StripeError => e
         raise Pay::Stripe::Error, e
       end


### PR DESCRIPTION
## Pull Request

**Summary:**
<!-- Provide a brief summary of the changes in this pull request -->
This updates `Pay::Stripe::Subscription#cancel_now!` so it will not set (modify) the `trial_ends_at` property unless the subscription is currently `on_trial?`

We had been using `trial_ends_at` to indicate whether a subscription was a trial but found this was not working on subscriptions where  `cancel_now!` was called.

**Related Commit**
https://github.com/pay-rails/pay/commit/5a719ad90cf4afb2d28419233ab7575df5daec75

**Related Issue:**
<!-- If applicable, reference the GitHub issue that this pull request resolves -->

**Description:**
<!-- Elaborate on the changes made in this pull request. What motivated these changes? -->

**Testing:**
<!-- Describe the steps you've taken to test the changes. Include relevant information for other contributors to verify the modifications -->
I'm not quite sure if / how I can add a new VCR cassette? Is that something you would do or can you provide me a reference / pointer to do so?

**Screenshots (if applicable):**
<!-- Include any relevant screenshots or GIFs that demonstrate the changes -->

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [X] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [X] Documentation has been updated (if applicable)
- [X] All existing tests pass
- [X] Conforms to the contributing guidelines

**Additional Notes:**
<!-- Any additional information or notes for the reviewers -->
