### PR TITLE
Using cancel_now considers the trial to be ended

### DIFF
--- a/app/models/pay/stripe/subscription.rb
+++ b/app/models/pay/stripe/subscription.rb
@@ -47,6 +47,8 @@ module Pay
         if object.trial_end
           trial_ended_at = [object.ended_at, object.trial_end].compact.min
           attributes[:trial_ends_at] = Time.at(trial_ended_at)
+        else
+          attributes[:trial_ends_at] = nil
         end
 
         object.items.auto_paging_each do |subscription_item|
@@ -164,7 +166,7 @@ module Pay
           cancel_now!
         else
           @api_record = ::Stripe::Subscription.update(processor_id, {cancel_at_period_end: true}.merge(expand_options), stripe_options)
-          update(ends_at: (on_trial? ? trial_ends_at : Time.at(@api_record.items.first.current_period_end)))
+          update(ends_at: Time.at(@api_record.cancel_at))
         end
       rescue ::Stripe::StripeError => e
         raise Pay::Stripe::Error, e
@@ -178,7 +180,11 @@ module Pay
         return if canceled? && ends_at.past?
 
         @api_record = ::Stripe::Subscription.cancel(processor_id, options.merge(expand_options), stripe_options)
-        update(trial_ends_at: Time.current, ends_at: Time.current, status: :canceled)
+        update(
+          trial_ends_at: (@api_record.trial_end ? Time.at(@api_record.trial_end) : nil),
+          ends_at: Time.at(@api_record.ended_at),
+          status: :canceled
+        )
       rescue ::Stripe::StripeError => e
         raise Pay::Stripe::Error, e
       end

--- a/app/models/pay/stripe/subscription.rb
+++ b/app/models/pay/stripe/subscription.rb
@@ -183,7 +183,7 @@ module Pay
         update(
           trial_ends_at: (@api_record.trial_end ? Time.at(@api_record.trial_end) : nil),
           ends_at: Time.at(@api_record.ended_at),
-          status: :canceled
+          status: @api_record.status
         )
       rescue ::Stripe::StripeError => e
         raise Pay::Stripe::Error, e

--- a/app/models/pay/subscription.rb
+++ b/app/models/pay/subscription.rb
@@ -66,10 +66,12 @@ module Pay
 
     # Does not include the last second of the trial
     def on_trial?
+      return false if ended?
       trial_ends_at? && trial_ends_at > Time.current
     end
 
     def trial_ended?
+      return true if ended?
       trial_ends_at? && trial_ends_at <= Time.current
     end
 

--- a/test/pay/attributes_test.rb
+++ b/test/pay/attributes_test.rb
@@ -37,7 +37,8 @@ class Pay::AttributesTest < ActiveSupport::TestCase
 
   test "deleting user doesn't remove pay customers" do
     user = users(:stripe)
-    ::Stripe::Subscription.stub(:cancel, user.payment_processor.subscription) do
+    object = stripe_event("subscription.deleted").data.object
+    ::Stripe::Subscription.stub(:cancel, object) do
       assert_no_difference "Pay::Customer.count" do
         user.destroy
       end
@@ -46,7 +47,8 @@ class Pay::AttributesTest < ActiveSupport::TestCase
 
   test "deleting user cancels subscriptions" do
     user = users(:stripe)
-    ::Stripe::Subscription.stub(:cancel, user.payment_processor.subscription) do
+    object = stripe_event("subscription.deleted").data.object
+    ::Stripe::Subscription.stub(:cancel, object) do
       assert user.payment_processor.subscription.active?
       user.destroy
       refute user.payment_processor.subscription.active?
@@ -55,7 +57,8 @@ class Pay::AttributesTest < ActiveSupport::TestCase
 
   test "deleting user ignores canceled subscriptions" do
     user = users(:stripe)
-    ::Stripe::Subscription.stub(:cancel, user.payment_processor.subscription) do
+    object = stripe_event("subscription.deleted").data.object
+    ::Stripe::Subscription.stub(:cancel, object) do
       user.payment_processor.subscription.cancel_now!
       refute user.payment_processor.subscription.active?
       user.destroy

--- a/test/pay/braintree/subscription_test.rb
+++ b/test/pay/braintree/subscription_test.rb
@@ -51,10 +51,9 @@ class Pay::Braintree::SubscriptionTest < ActiveSupport::TestCase
       # Account for time hitting the API because we've frozen time and ends_at is ahead
       travel 2.seconds
 
-      # Canceling during a trial ends the subscription, but continues to give access during the trial period
       assert_equal "canceled", pay_subscription.status
       refute pay_subscription.active?
-      assert pay_subscription.on_trial?
+      refute pay_subscription.on_trial?
       assert pay_subscription.ended?
       assert_not_includes @pay_customer.subscriptions.active, pay_subscription
     end
@@ -135,10 +134,9 @@ class Pay::Braintree::SubscriptionTest < ActiveSupport::TestCase
 
       pay_subscription = Pay::Braintree::Subscription.sync(processor_id)
 
-      # Canceling during a trial ends the subscription, but continues to give acess during the trial period
       assert_equal "canceled", pay_subscription.status
       refute pay_subscription.active?
-      assert pay_subscription.on_trial?
+      refute pay_subscription.on_trial?
       assert pay_subscription.ended?
       assert_not_includes @pay_customer.subscriptions.active, pay_subscription
     end


### PR DESCRIPTION
This updates Stripe to sync ends_at from the API response consistently.

Also fixes #1170 where trial_ends_at was set regardless of a trial existing or not.

