### PR TITLE
add text version of receipt mailer

### DIFF
--- a/app/views/pay/user_mailer/receipt.text.erb
+++ b/app/views/pay/user_mailer/receipt.text.erb
@@ -1,0 +1,20 @@
+We received payment for your <%= Pay.application_name %> subscription. Thanks for your business!
+
+Questions? Please reply to this email.
+
+------------------------------------
+RECEIPT - SUBSCRIPTION
+
+<%= Pay.application_name %>
+Amount: <%= params[:pay_charge].amount_with_currency %>
+
+Charged to: <%= params[:pay_charge].charged_to %>
+Transaction ID: <%= params[:pay_charge].id %>
+Date: <%= l params[:pay_charge].created_at %>
+<% if params[:pay_charge].customer.owner.try(:extra_billing_info?) %>
+<%= params[:pay_charge].customer.owner.extra_billing_info %>
+<% end %>
+
+<%= Pay.business_name %>
+<%= Pay.business_address %>
+------------------------------------


### PR DESCRIPTION
## Pull Request

**Summary:**
This was created to address an issue arising from an error we encountered in the latest mailpace gem where there is no safety check for the text part of the email.

**Description:**
This copies over the existing receipt html email to a text version.

- [ ] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated (if applicable)
- [ ] All existing tests pass
- [ ] Conforms to the contributing guidelines