### PR TITLE
Create text versions of existing user mailers

### DIFF
--- a/app/views/pay/user_mailer/payment_action_required.text.erb
+++ b/app/views/pay/user_mailer/payment_action_required.text.erb
@@ -1,0 +1,9 @@
+Extra confirmation is needed to process your payment
+
+Your <%= Pay.application_name %> subscription requires confirmation to process your payment to continue access.
+
+Confirm your payment: <%= pay.payment_url(params[:payment_intent_id]) %>
+
+If you have any questions, please hit reply and let us know.
+
+— The <%= Pay.application_name %> Team

--- a/app/views/pay/user_mailer/payment_failed.text.erb
+++ b/app/views/pay/user_mailer/payment_failed.text.erb
@@ -1,0 +1,9 @@
+Your payment was declined
+
+We were unable to charge your payment method for your <%= Pay.application_name %> subscription. Please update your billing information.
+
+Update billing information: <%= root_url %>
+
+Let us know if you have any questions.
+
+— The <%= Pay.application_name %> Team

--- a/app/views/pay/user_mailer/refund.text.erb
+++ b/app/views/pay/user_mailer/refund.text.erb
@@ -1,0 +1,21 @@
+We have processed your <%= Pay.application_name %> refund.
+Please allow up to 7 business days for your refund to appear in your account
+
+Questions? Please reply to this email.
+
+------------------------------------
+RECEIPT - REFUND
+
+<%= Pay.application_name %>
+Amount: <%= params[:pay_charge].amount_refunded_with_currency %>
+
+Refunded to: <%= params[:pay_charge].charged_to %>
+Transaction ID: <%= params[:pay_charge].id %>
+Date: <%= l params[:pay_charge].created_at %>
+<% if params[:pay_charge].customer.owner.try(:extra_billing_info?) %>
+<%= params[:pay_charge].customer.owner.extra_billing_info %>
+<% end %>
+
+<%= Pay.business_name %>
+<%= Pay.business_address %>
+------------------------------------

--- a/app/views/pay/user_mailer/subscription_renewing.text.erb
+++ b/app/views/pay/user_mailer/subscription_renewing.text.erb
@@ -1,0 +1,8 @@
+Your upcoming <%= Pay.application_name %> subscription renewal
+
+This is a friendly reminder that your <%= Pay.application_name %> subscription will renew automatically on <%= l params[:date].to_date, format: :long %>.
+
+You may manage your subscription via your account: <%= root_url %>
+If you have any questions, please hit reply and let us know.
+
+— The <%= Pay.application_name %> Team

--- a/app/views/pay/user_mailer/subscription_trial_ended.text.erb
+++ b/app/views/pay/user_mailer/subscription_trial_ended.text.erb
@@ -1,0 +1,8 @@
+Your <%= Pay.application_name %> trial has ended
+
+This is just a friendly reminder that your <%= Pay.application_name %> trial has ended.
+
+You may manage your subscription via your account: <%= root_url %>
+If you have any questions, please hit reply and let us know.
+
+— The <%= Pay.application_name %> Team

--- a/app/views/pay/user_mailer/subscription_trial_will_end.text.erb
+++ b/app/views/pay/user_mailer/subscription_trial_will_end.text.erb
@@ -1,0 +1,8 @@
+Your <%= Pay.application_name %> trial is ending soon
+
+This is just a friendly reminder that your <%= Pay.application_name %> trial will be ending soon.
+
+You may manage your subscription via your account: <%= root_url %>
+If you have any questions, please hit reply and let us know.
+
+— The <%= Pay.application_name %> Team

--- a/test/mailers/pay/user_mailer_test.rb
+++ b/test/mailers/pay/user_mailer_test.rb
@@ -1,35 +1,35 @@
-require 'test_helper'
+require "test_helper"
 
 class UserMailerTest < ActionMailer::TestCase
   setup do
     @charge = pay_charges(:stripe)
     @pay_customer = @charge.customer
     @user = @pay_customer.owner
-    @user.update(extra_billing_info: 'extra billing info')
+    @user.update(extra_billing_info: "extra billing info")
 
-    @charge.update stripe_invoice: JSON.parse(file_fixture('stripe/invoice.json').read)
+    @charge.update stripe_invoice: JSON.parse(file_fixture("stripe/invoice.json").read)
   end
 
-  test 'from address with Pay.support_email' do
-    Pay.stub :support_email, 'pay@test.org' do
-      assert_equal 'pay@test.org', Pay::ApplicationMailer.default_from_address
+  test "from address with Pay.support_email" do
+    Pay.stub :support_email, "pay@test.org" do
+      assert_equal "pay@test.org", Pay::ApplicationMailer.default_from_address
     end
   end
 
-  test 'from address fallback to ::ApplicationMailer.default_params' do
+  test "from address fallback to ::ApplicationMailer.default_params" do
     Pay.stub :support_email, nil do
-      assert_equal 'from@example.com', Pay::ApplicationMailer.default_from_address
+      assert_equal "from@example.com", Pay::ApplicationMailer.default_from_address
     end
   end
 
-  test 'receipt' do
+  test "receipt" do
     email = Pay::UserMailer.with(pay_customer: @pay_customer, pay_charge: @charge).receipt
 
     assert_equal [@user.email], email.to
-    assert_equal I18n.t('pay.user_mailer.receipt.subject', application: Pay.application_name), email.subject
+    assert_equal I18n.t("pay.user_mailer.receipt.subject", application: Pay.application_name), email.subject
   end
 
-  test 'render receipt with missing support email' do
+  test "render receipt with missing support email" do
     Pay.stub :support_email, nil do
       assert_nothing_raised do
         @charge.receipt
@@ -37,11 +37,11 @@ class UserMailerTest < ActionMailer::TestCase
     end
   end
 
-  test 'attaches refunds to receipt' do
-    filename = 'receipt.pdf'
+  test "attaches refunds to receipt" do
+    filename = "receipt.pdf"
 
-    receipt = mock('receipt')
-    receipt.stubs(:render).returns('render content')
+    receipt = mock("receipt")
+    receipt.stubs(:render).returns("render content")
     receipt.stubs(:length).returns(1024)
 
     @charge.stubs(:filename).returns(filename)
@@ -52,70 +52,70 @@ class UserMailerTest < ActionMailer::TestCase
     assert_equal filename, email.attachments.first.filename
   end
 
-  test 'refund' do
+  test "refund" do
     email = Pay::UserMailer.with(pay_customer: @pay_customer, pay_charge: @charge).refund
 
     assert_equal [@user.email], email.to
-    assert_equal I18n.t('pay.user_mailer.refund.subject', application: Pay.application_name), email.subject
+    assert_equal I18n.t("pay.user_mailer.refund.subject", application: Pay.application_name), email.subject
   end
 
-  test 'subscription_renewing' do
+  test "subscription_renewing" do
     time = Time.current
     email = Pay::UserMailer.with(pay_customer: @pay_customer, pay_subscription: Pay::Subscription.new, date: time).subscription_renewing
 
     assert_equal [@user.email], email.to
-    assert_equal I18n.t('pay.user_mailer.subscription_renewing.subject', application: Pay.application_name),
-                 email.subject
+    assert_equal I18n.t("pay.user_mailer.subscription_renewing.subject", application: Pay.application_name),
+      email.subject
     assert_includes email.html_part.decoded, I18n.l(time.to_date, format: :long)
   end
 
-  test 'payment_action_required' do
-    email = Pay::UserMailer.with(pay_customer: @pay_customer, payment_intent_id: 'x', pay_subscription: Pay::Subscription.new).payment_action_required
+  test "payment_action_required" do
+    email = Pay::UserMailer.with(pay_customer: @pay_customer, payment_intent_id: "x", pay_subscription: Pay::Subscription.new).payment_action_required
 
     assert_equal [@user.email], email.to
-    assert_equal I18n.t('pay.user_mailer.payment_action_required.subject', application: Pay.application_name), email.subject
-    assert_includes email.html_part.decoded, Pay::Engine.instance.routes.url_helpers.payment_path('x')
+    assert_equal I18n.t("pay.user_mailer.payment_action_required.subject", application: Pay.application_name), email.subject
+    assert_includes email.html_part.decoded, Pay::Engine.instance.routes.url_helpers.payment_path("x")
   end
 
-  test 'receipt with no extra billing info column' do
+  test "receipt with no extra billing info column" do
     team = teams(:one)
     @pay_customer.update!(owner: team)
     email = Pay::UserMailer.with(pay_customer: @pay_customer, pay_charge: @charge).receipt
 
     assert_equal [team.owner.email], email.to
-    assert_equal I18n.t('pay.user_mailer.receipt.subject', application: Pay.application_name), email.subject
+    assert_equal I18n.t("pay.user_mailer.receipt.subject", application: Pay.application_name), email.subject
   end
 
-  test 'refund with no extra billing info column' do
+  test "refund with no extra billing info column" do
     team = teams(:one)
     @pay_customer.update!(owner: team)
     email = Pay::UserMailer.with(pay_customer: @pay_customer, pay_charge: @charge).refund
 
     assert_equal [team.owner.email], email.to
-    assert_equal I18n.t('pay.user_mailer.refund.subject', application: Pay.application_name), email.subject
+    assert_equal I18n.t("pay.user_mailer.refund.subject", application: Pay.application_name), email.subject
   end
 
-  test 'subscription_trial_will_end' do
+  test "subscription_trial_will_end" do
     email = Pay::UserMailer.with(pay_customer: @pay_customer).subscription_trial_will_end
 
     assert_equal [@user.email], email.to
-    assert_equal I18n.t('pay.user_mailer.subscription_trial_will_end.subject', application: Pay.application_name), email.subject
-    assert_includes email.html_part.decoded, 'trial is ending soon'
+    assert_equal I18n.t("pay.user_mailer.subscription_trial_will_end.subject", application: Pay.application_name), email.subject
+    assert_includes email.html_part.decoded, "trial is ending soon"
   end
 
-  test 'subscription_trial_ended' do
+  test "subscription_trial_ended" do
     email = Pay::UserMailer.with(pay_customer: @pay_customer).subscription_trial_ended
 
     assert_equal [@user.email], email.to
-    assert_equal I18n.t('pay.user_mailer.subscription_trial_ended.subject', application: Pay.application_name), email.subject
-    assert_includes email.html_part.decoded, 'trial has ended'
+    assert_equal I18n.t("pay.user_mailer.subscription_trial_ended.subject", application: Pay.application_name), email.subject
+    assert_includes email.html_part.decoded, "trial has ended"
   end
 
-  test 'subscription payment failed' do
+  test "subscription payment failed" do
     email = Pay::UserMailer.with(pay_customer: @pay_customer).payment_failed
 
     assert_equal [@user.email], email.to
-    assert_equal I18n.t('pay.user_mailer.payment_failed.subject', application: Pay.application_name), email.subject
-    assert_includes email.html_part.decoded, 'payment was declined'
+    assert_equal I18n.t("pay.user_mailer.payment_failed.subject", application: Pay.application_name), email.subject
+    assert_includes email.html_part.decoded, "payment was declined"
   end
 end

--- a/test/mailers/pay/user_mailer_test.rb
+++ b/test/mailers/pay/user_mailer_test.rb
@@ -1,35 +1,35 @@
-require "test_helper"
+require 'test_helper'
 
 class UserMailerTest < ActionMailer::TestCase
   setup do
     @charge = pay_charges(:stripe)
     @pay_customer = @charge.customer
     @user = @pay_customer.owner
-    @user.update(extra_billing_info: "extra billing info")
+    @user.update(extra_billing_info: 'extra billing info')
 
-    @charge.update stripe_invoice: JSON.parse(file_fixture("stripe/invoice.json").read)
+    @charge.update stripe_invoice: JSON.parse(file_fixture('stripe/invoice.json').read)
   end
 
-  test "from address with Pay.support_email" do
-    Pay.stub :support_email, "pay@test.org" do
-      assert_equal "pay@test.org", Pay::ApplicationMailer.default_from_address
+  test 'from address with Pay.support_email' do
+    Pay.stub :support_email, 'pay@test.org' do
+      assert_equal 'pay@test.org', Pay::ApplicationMailer.default_from_address
     end
   end
 
-  test "from address fallback to ::ApplicationMailer.default_params" do
+  test 'from address fallback to ::ApplicationMailer.default_params' do
     Pay.stub :support_email, nil do
-      assert_equal "from@example.com", Pay::ApplicationMailer.default_from_address
+      assert_equal 'from@example.com', Pay::ApplicationMailer.default_from_address
     end
   end
 
-  test "receipt" do
+  test 'receipt' do
     email = Pay::UserMailer.with(pay_customer: @pay_customer, pay_charge: @charge).receipt
 
     assert_equal [@user.email], email.to
-    assert_equal I18n.t("pay.user_mailer.receipt.subject", application: Pay.application_name), email.subject
+    assert_equal I18n.t('pay.user_mailer.receipt.subject', application: Pay.application_name), email.subject
   end
 
-  test "render receipt with missing support email" do
+  test 'render receipt with missing support email' do
     Pay.stub :support_email, nil do
       assert_nothing_raised do
         @charge.receipt
@@ -37,11 +37,11 @@ class UserMailerTest < ActionMailer::TestCase
     end
   end
 
-  test "attaches refunds to receipt" do
-    filename = "receipt.pdf"
+  test 'attaches refunds to receipt' do
+    filename = 'receipt.pdf'
 
-    receipt = mock("receipt")
-    receipt.stubs(:render).returns("render content")
+    receipt = mock('receipt')
+    receipt.stubs(:render).returns('render content')
     receipt.stubs(:length).returns(1024)
 
     @charge.stubs(:filename).returns(filename)
@@ -52,69 +52,70 @@ class UserMailerTest < ActionMailer::TestCase
     assert_equal filename, email.attachments.first.filename
   end
 
-  test "refund" do
+  test 'refund' do
     email = Pay::UserMailer.with(pay_customer: @pay_customer, pay_charge: @charge).refund
 
     assert_equal [@user.email], email.to
-    assert_equal I18n.t("pay.user_mailer.refund.subject", application: Pay.application_name), email.subject
+    assert_equal I18n.t('pay.user_mailer.refund.subject', application: Pay.application_name), email.subject
   end
 
-  test "subscription_renewing" do
+  test 'subscription_renewing' do
     time = Time.current
     email = Pay::UserMailer.with(pay_customer: @pay_customer, pay_subscription: Pay::Subscription.new, date: time).subscription_renewing
 
     assert_equal [@user.email], email.to
-    assert_equal I18n.t("pay.user_mailer.subscription_renewing.subject", application: Pay.application_name), email.subject
-    assert_includes email.body.decoded, I18n.l(time.to_date, format: :long)
+    assert_equal I18n.t('pay.user_mailer.subscription_renewing.subject', application: Pay.application_name),
+                 email.subject
+    assert_includes email.html_part.decoded, I18n.l(time.to_date, format: :long)
   end
 
-  test "payment_action_required" do
-    email = Pay::UserMailer.with(pay_customer: @pay_customer, payment_intent_id: "x", pay_subscription: Pay::Subscription.new).payment_action_required
+  test 'payment_action_required' do
+    email = Pay::UserMailer.with(pay_customer: @pay_customer, payment_intent_id: 'x', pay_subscription: Pay::Subscription.new).payment_action_required
 
     assert_equal [@user.email], email.to
-    assert_equal I18n.t("pay.user_mailer.payment_action_required.subject", application: Pay.application_name), email.subject
-    assert_includes email.body.decoded, Pay::Engine.instance.routes.url_helpers.payment_path("x")
+    assert_equal I18n.t('pay.user_mailer.payment_action_required.subject', application: Pay.application_name), email.subject
+    assert_includes email.html_part.decoded, Pay::Engine.instance.routes.url_helpers.payment_path('x')
   end
 
-  test "receipt with no extra billing info column" do
+  test 'receipt with no extra billing info column' do
     team = teams(:one)
     @pay_customer.update!(owner: team)
     email = Pay::UserMailer.with(pay_customer: @pay_customer, pay_charge: @charge).receipt
 
     assert_equal [team.owner.email], email.to
-    assert_equal I18n.t("pay.user_mailer.receipt.subject", application: Pay.application_name), email.subject
+    assert_equal I18n.t('pay.user_mailer.receipt.subject', application: Pay.application_name), email.subject
   end
 
-  test "refund with no extra billing info column" do
+  test 'refund with no extra billing info column' do
     team = teams(:one)
     @pay_customer.update!(owner: team)
     email = Pay::UserMailer.with(pay_customer: @pay_customer, pay_charge: @charge).refund
 
     assert_equal [team.owner.email], email.to
-    assert_equal I18n.t("pay.user_mailer.refund.subject", application: Pay.application_name), email.subject
+    assert_equal I18n.t('pay.user_mailer.refund.subject', application: Pay.application_name), email.subject
   end
 
-  test "subscription_trial_will_end" do
+  test 'subscription_trial_will_end' do
     email = Pay::UserMailer.with(pay_customer: @pay_customer).subscription_trial_will_end
 
     assert_equal [@user.email], email.to
-    assert_equal I18n.t("pay.user_mailer.subscription_trial_will_end.subject", application: Pay.application_name), email.subject
-    assert_includes email.body.decoded, "trial is ending soon"
+    assert_equal I18n.t('pay.user_mailer.subscription_trial_will_end.subject', application: Pay.application_name), email.subject
+    assert_includes email.html_part.decoded, 'trial is ending soon'
   end
 
-  test "subscription_trial_ended" do
+  test 'subscription_trial_ended' do
     email = Pay::UserMailer.with(pay_customer: @pay_customer).subscription_trial_ended
 
     assert_equal [@user.email], email.to
-    assert_equal I18n.t("pay.user_mailer.subscription_trial_ended.subject", application: Pay.application_name), email.subject
-    assert_includes email.body.decoded, "trial has ended"
+    assert_equal I18n.t('pay.user_mailer.subscription_trial_ended.subject', application: Pay.application_name), email.subject
+    assert_includes email.html_part.decoded, 'trial has ended'
   end
 
-  test "subscription payment failed" do
+  test 'subscription payment failed' do
     email = Pay::UserMailer.with(pay_customer: @pay_customer).payment_failed
 
     assert_equal [@user.email], email.to
-    assert_equal I18n.t("pay.user_mailer.payment_failed.subject", application: Pay.application_name), email.subject
-    assert_includes email.body.decoded, "payment was declined"
+    assert_equal I18n.t('pay.user_mailer.payment_failed.subject', application: Pay.application_name), email.subject
+    assert_includes email.html_part.decoded, 'payment was declined'
   end
 end


### PR DESCRIPTION
## Pull Request

**Summary:**
This introduces text versions of all existing user mailers for pay.

**Description:**
Since I recently made a PR for the receipt mailer that was merged it was realized that what would have been the better move would have been to make text versions for all of the mailers thus this PR is now created.