### PR TITLE
Add owner association to charge, subscription, and payment method models

### DIFF
--- a/app/models/pay/charge.rb
+++ b/app/models/pay/charge.rb
@@ -3,6 +3,7 @@ module Pay
     # Associations
     belongs_to :customer
     belongs_to :subscription, optional: true
+    has_one :owner, through: :customer
 
     # Scopes
     scope :sorted, -> { order(created_at: :desc) }

--- a/app/models/pay/payment_method.rb
+++ b/app/models/pay/payment_method.rb
@@ -1,6 +1,7 @@
 module Pay
   class PaymentMethod < Pay::ApplicationRecord
     belongs_to :customer
+    has_one :owner, through: :customer
 
     store_accessor :data, :brand # Visa, Mastercard, Discover, PayPal
     store_accessor :data, :last4

--- a/app/models/pay/subscription.rb
+++ b/app/models/pay/subscription.rb
@@ -6,6 +6,7 @@ module Pay
     belongs_to :customer
     belongs_to :payment_method, optional: true, primary_key: :processor_id
     has_many :charges
+    has_one :owner, through: :customer
 
     # Scopes
     scope :for_name, ->(name) { where(name: name) }


### PR DESCRIPTION
This makes handling things like fulfillment after a charge or subscription is created easier so the user doesn't have to jump through the customer association.

```ruby
module ChargeExtensions
  extend ActiveSupport::Concern

  included do
    after_create_commit :create_license
  end

  def create_license
    # previously: `customer.owner.create_license`
    owner.create_license(course_id: metadata.dig("course_id"))
  end
end

Rails.configuration.to_prepare do
  Pay::Charge.include ChargeExtensions
end
```