### PR TITLE
Update charges docs to use update_payment_method

### DIFF
--- a/docs/5_charges.md
+++ b/docs/5_charges.md
@@ -7,7 +7,7 @@ Pay allows you to make one-time charges to a customer.
 To charge a customer, you need to assign a payment method token before you can charge them.
 
 ```ruby
-@user.payment_processor.payment_method_token = params[:payment_method_token]
+@user.payment_processor.update_payment_method(params[:payment_method_token])
 @user.payment_processor.charge(15_00) # $15.00 USD
 ```
 


### PR DESCRIPTION
## Pull Request

**Summary:**
This updates the charges docs to use `update_payment_method` instead of the `payment_method_token` virtual attribute which was [removed in 8.0.0](https://github.com/pay-rails/pay/blob/d7b3d7ad749c4624b5357e8264454104179c579c/CHANGELOG.md?plain=1#L173)
