### PR TITLE
Make it works with custom inheritance column name

### DIFF
--- a/lib/pay/attributes.rb
+++ b/lib/pay/attributes.rb
@@ -38,8 +38,8 @@ module Pay
         with_lock do
           pay_customers.update_all(default: false)
           pay_customer = pay_customers.active.where(
-            Pay::Customer.inheritance_column => klass.name, 
-            :processor => processor_name, 
+            Pay::Customer.inheritance_column => klass.name,
+            :processor => processor_name,
             :stripe_account => stripe_account
           ).first_or_initialize
           pay_customer.update!(attributes.merge(default: true))
@@ -57,8 +57,8 @@ module Pay
         raise ArgumentError, "not a valid payment processor" if klass.ancestors.exclude?(Pay::Customer)
 
         pay_customer = pay_customers.active.where(
-          Pay::Customer.inheritance_column => klass.name, 
-          :processor => processor_name, 
+          Pay::Customer.inheritance_column => klass.name,
+          :processor => processor_name,
           :stripe_account => stripe_account
         ).first_or_initialize
         pay_customer.update!(attributes)
@@ -92,7 +92,7 @@ module Pay
         with_lock do
           pay_merchants.update_all(default: false)
           pay_merchant = pay_merchants.where(
-            Pay::Merchant.inheritance_column => "Pay::#{processor_name.to_s.classify}::Merchant", 
+            Pay::Merchant.inheritance_column => "Pay::#{processor_name.to_s.classify}::Merchant",
             :processor => processor_name
           ).first_or_initialize
           pay_merchant.update!(attributes.merge(default: true))


### PR DESCRIPTION
## Pull Request

**Summary:**
Replacing the hardcoded `type` attr name in the queries with the actual inherithance column name. 

**Testing:**
Didn't add an specific test for testing it with custom inheritance columns names.

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [X] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [X] Documentation has been updated (if applicable)
- [X] All existing tests pass
- [X] Conforms to the contributing guidelines

**Additional Notes:**

Added an extra where clause because otherwise `standardrb` complains about the style: `lib/pay/attributes.rb:98:46: Style/HashSyntax: Don't mix styles in the same hash.`
