### PR TITLE
Update installation doc gem versions

### DIFF
--- a/docs/1_installation.md
+++ b/docs/1_installation.md
@@ -7,10 +7,10 @@ Pay's installation is pretty straightforward. We'll add the gems, add some migra
 Add these lines to your application's Gemfile:
 
 ```ruby
-gem "pay", "~> 11.1"
+gem "pay", "~> 11.4"
 
 # To use Stripe, also include:
-gem "stripe", "~> 17.0"
+gem "stripe", "~> 18.0"
 
 # To use Braintree + PayPal, also include:
 gem "braintree", "~> 4.29"


### PR DESCRIPTION
## Pull Request

**Summary:**
Update the `stripe` gem version in the installation doc to reflect the required version for the latest version of the `pay` gem

**Related Issue:**
N/A

**Description:**
When doing a fresh install of the `pay` gem and using the installation document, I received an error indicating that the required version of `stripe` is `~> 18` ([CHANGELOG](https://github.com/pay-rails/pay/blob/v11.4.3/CHANGELOG.md#1140)) whereas the installation document says `~> 17`.

**Testing:**
N/A - documentation only

**Screenshots (if applicable):**
N/A - documentation only

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**
N/A
