### PR TITLE
Webhook listener for invoice.updated

### DIFF
--- a/lib/pay/stripe.rb
+++ b/lib/pay/stripe.rb
@@ -12,6 +12,7 @@ module Pay
       autoload :CheckoutSessionAsyncPaymentSucceeded, "pay/stripe/webhooks/checkout_session_async_payment_succeeded"
       autoload :CustomerDeleted, "pay/stripe/webhooks/customer_deleted"
       autoload :CustomerUpdated, "pay/stripe/webhooks/customer_updated"
+      autoload :InvoiceUpdated, "pay/stripe/webhooks/invoice_updated"
       autoload :PaymentActionRequired, "pay/stripe/webhooks/payment_action_required"
       autoload :PaymentFailed, "pay/stripe/webhooks/payment_failed"
       autoload :PaymentIntentSucceeded, "pay/stripe/webhooks/payment_intent_succeeded"
@@ -83,6 +84,9 @@ module Pay
         # notifying annual users their subscription will renew shortly.
         # This probably should be ignored for monthly subscriptions.
         events.subscribe "stripe.invoice.upcoming", Pay::Stripe::Webhooks::SubscriptionRenewing.new
+
+        # Ensures the local stripe_object is up-to-date anytime the API's record is updated.
+        events.subscribe "stripe.invoice.updated", Pay::Stripe::Webhooks::InvoiceUpdated.new
 
         # Payment action is required to process an invoice
         events.subscribe "stripe.invoice.payment_action_required", Pay::Stripe::Webhooks::PaymentActionRequired.new

--- a/lib/pay/stripe/webhooks/invoice_updated.rb
+++ b/lib/pay/stripe/webhooks/invoice_updated.rb
@@ -1,0 +1,35 @@
+module Pay
+  module Stripe
+    module Webhooks
+      class InvoiceUpdated
+        def call(event)
+          # Grab the invoice from the event 
+          invoice = event.data.object
+
+          # Find the corresponding subscription_id
+          subscription_id = invoice.parent.try(:subscription_details).try(:subscription)
+
+          # Not all invoices have a subscription - could be a one-time or manual payment
+          return if subscription_id.blank?
+
+          # Grab the local subscription
+          subscription = Pay::Subscription.find_by_processor_and_id(:stripe, subscription_id)
+
+          # Return if we don't have a corresponding subscription
+          return unless subscription
+
+          # Grab the local latest_invoice from the subscription stripe_object
+          latest_invoice = subscription.stripe_object.try(:latest_invoice)
+
+          # Compare the local invoice id to the event invoice id and sync if they are the same
+          if latest_invoice.id.to_s == invoice.id.to_s
+            Pay::Stripe::Subscription.sync(subscription_id, stripe_account: event.try(:account))
+          end
+
+        rescue ::Stripe::StripeError => e
+          Rails.logger.error "Stripe Webhook Error (InvoiceUpdated): #{e.message}"
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/files/stripe/invoice.updated.json
+++ b/test/fixtures/files/stripe/invoice.updated.json
@@ -1,0 +1,31 @@
+{
+  "object": {
+    "id": "inpay_1T4AIlGWAy8DppqhYcK0hqe3",
+    "object": "invoice_payment",
+    "amount_paid": 2000,
+    "amount_requested": 2000,
+    "created": 1771896039,
+    "currency": "usd",
+    "invoice": "in_1T4AIkGWAy8DppqhJAdbjaWb",
+    "is_default": true,
+    "livemode": false,
+    "parent": {
+      "quote_details": null,
+      "subscription_details": {
+        "metadata": {},
+        "subscription": "sub_1234"
+      },
+      "type": "subscription_details"
+    },
+    "payment": {
+      "payment_intent": "pi_3T4AIlGWAy8Dppqh3Vsl9Pya",
+      "type": "payment_intent"
+    },
+    "status": "paid",
+    "status_transitions": {
+      "canceled_at": null,
+      "paid_at": 1771896040
+    }
+  },
+  "previous_attributes": null
+}

--- a/test/pay/stripe/webhooks/invoice_updated_test.rb
+++ b/test/pay/stripe/webhooks/invoice_updated_test.rb
@@ -1,0 +1,63 @@
+require "test_helper"
+
+class Pay::Stripe::Webhooks::InvoiceUpdatedTest < ActiveSupport::TestCase
+  setup do
+    @event = stripe_event("invoice.updated")
+    @invoice = @event.data.object
+    @pay_customer = pay_customers(:stripe)
+    @subscription_id = @invoice.parent.subscription_details.subscription
+    @local_subscription = create_subscription(processor_id: @subscription_id)
+  end
+
+  test "the method exits early if the event doesn't send an associated subscription_id" do
+    # Set parent to nil, removing the subscription_id
+    @invoice.stubs(:parent).returns(nil)
+
+    # This should never trigger if subscription_id is nil
+    Pay::Subscription.expects(:find_by_processor_and_id).never
+
+    Pay::Stripe::Webhooks::InvoiceUpdated.new.call(@event)
+  end
+
+  test "the method exits early without a database subscription record" do
+    # Mock a failed DB lookup
+    Pay::Subscription.stubs(:find_by_processor_and_id).returns(nil)
+
+    # Won't be hit if subscription doesn't exist in the database
+    Pay::Stripe::Subscription.expects(:sync).never
+
+    Pay::Stripe::Webhooks::InvoiceUpdated.new.call(@event)
+  end
+
+  test "does NOT sync if the invoice in the event is NOT the latest_invoice" do
+    # Mock a subscription with a different invoice id
+    mock_stripe_sub = OpenStruct.new(latest_invoice: OpenStruct.new(id: "in_another_id"))
+    @local_subscription.stubs(:stripe_object).returns(mock_stripe_sub)
+    
+    # Use the local object to stub the request
+    Pay::Subscription.stubs(:find_by_processor_and_id).returns(@local_subscription)
+
+    Pay::Stripe::Subscription.expects(:sync).never
+
+    Pay::Stripe::Webhooks::InvoiceUpdated.new.call(@event)
+  end
+
+  test "SUCCESSFULLY syncs when the invoice ID matches the latest_invoice ID" do
+    # Mock the object with an id that matches the event invoice
+    mock_stripe_sub = OpenStruct.new(latest_invoice: OpenStruct.new(id: @invoice.id))
+    @local_subscription.stubs(:stripe_object).returns(mock_stripe_sub)
+    
+    # Use the local object to stub the request
+    Pay::Subscription.stubs(:find_by_processor_and_id).returns(@local_subscription)
+    
+    Pay::Stripe::Subscription.expects(:sync).with(@subscription_id, stripe_account: nil).once
+    
+    Pay::Stripe::Webhooks::InvoiceUpdated.new.call(@event)
+  end
+
+  private
+
+  def create_subscription(processor_id:)
+    @pay_customer.subscriptions.create!(processor_id: processor_id, name: "default", processor_plan: "some-plan", status: "active")
+  end
+end

--- a/test/vcr_cassettes/test_the_method_exits_early_if_the_invoice_status_matches_the_latest_invoice_status.yml
+++ b/test/vcr_cassettes/test_the_method_exits_early_if_the_invoice_status_matches_the_latest_invoice_status.yml
@@ -1,0 +1,78 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.stripe.com/v<VENDOR_ID>/subscriptions/sub_<VENDOR_ID>234?e<VENDOR_AUTH_CODE>pand%5B%5D=default_payment_method&e<VENDOR_AUTH_CODE>pand%5B%5D=discounts&e<VENDOR_AUTH_CODE>pand%5B%5D=latest_invoice.confirmation_<PADDLE_API_KEY>&e<VENDOR_AUTH_CODE>pand%5B%5D=latest_invoice.payments&e<VENDOR_AUTH_CODE>pand%5B%5D=latest_invoice.total_discount_amounts.discount&e<VENDOR_AUTH_CODE>pand%5B%5D=pending_setup_intent&e<VENDOR_AUTH_CODE>pand%5B%5D=schedule
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Stripe/v<VENDOR_ID> RubyBindings/<VENDOR_ID>8.<VENDOR_ID>.0 PayRails/<VENDOR_ID><VENDOR_ID>.4.3
+        (https://github.com/pay-rails/pay)
+      Authorization:
+      - Bearer <STRIPE_PRIVATE_KEY>
+      Stripe-Version:
+      - 2025-<VENDOR_ID>2-<VENDOR_ID>5.clover
+      X-Stripe-Client-User-Agent:
+      - '{"application":{"name":"PayRails","partner_id":"pp_partner_IqhY0UE<VENDOR_AUTH_CODE>nJYL<VENDOR_AUTH_CODE>g","url":"https://github.com/pay-rails/pay","version":"<VENDOR_ID><VENDOR_ID>.4.3"},"bindings_version":"<VENDOR_ID>8.<VENDOR_ID>.0","lang":"ruby","lang_version":"3.4.2
+        p28 (2025-02-<VENDOR_ID>5)","platform":"arm64-darwin23","engine":"ruby","publisher":"stripe","uname":"Darwin
+        Brandons-Laptop 23.0.0 Darwin Kernel Version 23.0.0: Fri Sep <VENDOR_ID>5
+        <VENDOR_ID>4:42:57 PDT 2023; root:<VENDOR_AUTH_CODE>nu-<VENDOR_ID>0002.<VENDOR_ID>.<VENDOR_ID>3~<VENDOR_ID>/RELEASE_ARM64_T8<VENDOR_ID><VENDOR_ID>2
+        arm64","hostname":"Brandons-Laptop"}'
+      Accept-Encoding:
+      - gzip;q=<VENDOR_ID>.0,deflate;q=0.6,identity;q=0.3
+      Accept:
+      - "*/*"
+  response:
+    status:
+      code: 401
+      message: Unauthorized
+    headers:
+      Server:
+      - ngin<VENDOR_AUTH_CODE>
+      Date:
+      - Tue, 24 Feb 2026 0<VENDOR_ID>:44:<VENDOR_ID>5 GMT
+      Content-Type:
+      - application/json
+      Content-Length:
+      - "<VENDOR_ID><VENDOR_ID>4"
+      Connection:
+      - keep-alive
+      Access-Control-Allow-Credentials:
+      - 'true'
+      Access-Control-Allow-Methods:
+      - GET, HEAD, PUT, PATCH, POST, DELETE
+      Access-Control-Allow-Origin:
+      - "*"
+      Cache-Control:
+      - no-cache, no-store
+      Content-Security-Policy:
+      - base-uri 'none'; default-src 'none'; form-action 'none'; frame-ancestors 'none';
+        upgrade-insecure-requests
+      Vary:
+      - Origin
+      Www-Authenticate:
+      - Bearer realm="Stripe"
+      X-Robots-Tag:
+      - none
+      X-Wc:
+      - ABHIJ
+      Strict-Transport-Security:
+      - ma<VENDOR_AUTH_CODE>-age=63072000; includeSubDomains; preload
+      Access-Control-E<VENDOR_AUTH_CODE>pose-Headers:
+      - Request-Id, Stripe-Manage-Version, Stripe-Should-Retry, X-Stripe-E<VENDOR_AUTH_CODE>ternal-Auth-Required,
+        X-Stripe-Privileged-Session-Required
+      Access-Control-Ma<VENDOR_AUTH_CODE>-Age:
+      - '300'
+    body:
+      encoding: UTF-8
+      string: |
+        {
+          "error": {
+            "message": "Invalid API Key provided: <STRIPE_PRIVATE_KEY>",
+            "type": "invalid_request_error"
+          }
+        }
+  recorded_at: Tue, 24 Feb 2026 01:44:15 GMT
+recorded_with: VCR 6.4.0


### PR DESCRIPTION
## Pull Request

**Summary:**

[Original Discussion Thread](https://github.com/pay-rails/pay/discussions/1217)

Creating a webhook listener for `invoice.paid` to sync local invoice records with the API to prevent stale local records.

**Related Issue:**
Resolving: [Issue: 1219](https://github.com/pay-rails/pay/issues/1219)

**Description:**
Adding `invoice.paid` listener to sync local records.

**Testing:**
Three tests to ensure the class exits early if the correct conditions are not met. One test check the actual syncing is done correctly.

**Screenshots (if applicable):**
<!-- Include any relevant screenshots or GIFs that demonstrate the changes -->

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [ ] Code follows the project's coding standards
- [ ] Tests have been added or updated to cover the changes
- [ ] Documentation has been updated (if applicable)
- [ ] All existing tests pass
- [ ] Conforms to the contributing guidelines

**Additional Notes:**
<!-- Any additional information or notes for the reviewers -->
