### PR TITLE
Add background job syncing instructions

### DIFF
--- a/docs/1_installation.md
+++ b/docs/1_installation.md
@@ -52,6 +52,12 @@ Make sure you've configured your ActionMailer `default_url_options` so Pay can g
 config.action_mailer.default_url_options = { host: "example.com" }
 ```
 
+## Background jobs
+
+Pay uses ActiveJob for webhook processing (`Pay::Webhooks::ProcessJob`) and for syncing customers to payment processors (`Pay::CustomerSyncJob`). If you use an asynchronous queue adapter (for example [Sidekiq](https://github.com/sidekiq/sidekiq) or [Solid Queue](https://github.com/rails/solid_queue)), you need a worker process running in each environment where you rely on that behavior. Without it, incoming webhooks may never be processed and charges or subscriptions may not appear on your records.
+
+See [Background jobs](2_configuration.md#background-jobs) in the configuration guide for setup details.
+
 ## Models
 
 To add Pay to a model in your Rails app, simply add `pay_customer` to the model:

--- a/docs/2_configuration.md
+++ b/docs/2_configuration.md
@@ -173,9 +173,12 @@ end
 
 ## Background jobs
 
-If a user's email is updated, Pay will enqueue a background job (`CustomerSyncJob`) to sync the email with the payment processors they have setup.
+Pay enqueues ActiveJob work in two places you should be aware of:
 
-It is important you set a queue_adapter for this to happen. If you don't, the code will be executed immediately upon user update. [More information here](https://guides.rubyonrails.org/v6.1/active_job_basics.html#backends)
+1. **Webhooks** – When a payment provider posts a webhook, Pay records the payload and enqueues `Pay::Webhooks::ProcessJob` to run the handlers. If jobs are not processed, charges, subscriptions, and other provider events will not update your application data.
+2. **Customer sync** – If a user's email is updated, Pay enqueues `Pay::CustomerSyncJob` to sync the email with the payment processors they have set up.
+
+Configure `config.active_job.queue_adapter` for your app. With adapters such as Sidekiq or Solid Queue, you must run a worker process (for example the `sidekiq` executable, or `bin/jobs` for Solid Queue) anywhere you need that work to run. With the `:inline` adapter, jobs run immediately in the same process and no worker is required, which is convenient for tests but unusual for production webhooks under load. [Active Job basics](https://guides.rubyonrails.org/active_job_basics.html#backends)
 
 ```ruby
 # config/application.rb

--- a/docs/7_webhooks.md
+++ b/docs/7_webhooks.md
@@ -12,6 +12,8 @@ See [Stripe SCA docs](stripe/4_sca.md)
 
 Pay comes with a bunch of different webhook handlers built-in. Each payment processor has different requirements for handling webhooks and we've implemented all the basic ones for you.
 
+Incoming webhooks are processed asynchronously via `Pay::Webhooks::ProcessJob`. If you use an external or database-backed queue adapter, ensure a worker is running so events are applied; see [Background jobs](2_configuration.md#background-jobs).
+
 ### Routes
 
 Webhooks are automatically mounted at `/pay/webhooks/:provider`

--- a/docs/stripe/5_webhooks.md
+++ b/docs/stripe/5_webhooks.md
@@ -1,6 +1,6 @@
 # Stripe Webhooks
 
-Pay listens to Stripe's webhooks to keep the local payments data in sync. 
+Pay listens to Stripe's webhooks to keep the local payments data in sync. Processing uses ActiveJob (`Pay::Webhooks::ProcessJob`); with an asynchronous queue adapter, run a worker so events are applied. See [Background jobs](../2_configuration.md#background-jobs).
 
 For development, we use the Stripe CLI to forward webhooks to our local server. 
 In production, webhooks are sent directly to our app's domain.


### PR DESCRIPTION
Added instructions for background job syncing to ensure proper Webhook functionality.

## Pull Request

**Summary:**
Added a short reminder/info about required background jobs for this code in docs.

**Related Issue:**
n/a

**Description:**
I was struggled why I have no subscriptions and charges on my user, discovered every documentation and video tutor, but didn't find any answer, then I found it out that there are sync jobs, that is related to jobs.. and of course for this you need a running cli worker. When I started a worker my user received everything I need - subscriptions, charges.

**Testing:**
n/a

**Screenshots (if applicable):**
n/a

**Checklist:**
<!-- Make sure all of these items are completed before submitting the pull request -->

- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (if applicable)
- [x] All existing tests pass
- [x] Conforms to the contributing guidelines

**Additional Notes:**
Might be it's not so clear, if it is, I am open for proposals. I hope this info will be helpful for community and prevent the same issue I had.
