### PR TITLE
Subscribe to renamed Stripe event payment_method.automatically_updated

### DIFF
--- a/lib/pay/stripe.rb
+++ b/lib/pay/stripe.rb
@@ -115,6 +115,7 @@ module Pay
         # If a customer's payment source was deleted in Stripe, we should update as well
         events.subscribe "stripe.payment_method.attached", Pay::Stripe::Webhooks::PaymentMethodAttached.new
         events.subscribe "stripe.payment_method.updated", Pay::Stripe::Webhooks::PaymentMethodUpdated.new
+        events.subscribe "stripe.payment_method.automatically_updated", Pay::Stripe::Webhooks::PaymentMethodUpdated.new
         events.subscribe "stripe.payment_method.card_automatically_updated", Pay::Stripe::Webhooks::PaymentMethodUpdated.new
         events.subscribe "stripe.payment_method.detached", Pay::Stripe::Webhooks::PaymentMethodDetached.new
 

--- a/test/pay/stripe/webhooks_test.rb
+++ b/test/pay/stripe/webhooks_test.rb
@@ -1,0 +1,11 @@
+require "test_helper"
+
+class Pay::Stripe::WebhooksTest < ActiveSupport::TestCase
+  test "subscribes to payment_method.automatically_updated" do
+    assert Pay::Webhooks.delegator.listening?("stripe.payment_method.automatically_updated")
+  end
+
+  test "subscribes to payment_method.card_automatically_updated" do
+    assert Pay::Webhooks.delegator.listening?("stripe.payment_method.card_automatically_updated")
+  end
+end


### PR DESCRIPTION
## Problem

Stripe renamed the webhook event `payment_method.card_automatically_updated` to [`payment_method.automatically_updated`](https://docs.stripe.com/api/events/types#event_types-payment_method.automatically_updated). The legacy name can no longer be enabled when creating or editing a webhook endpoint — both the Stripe dashboard and the API reject it — so new endpoints can only send the modern name.

Pay currently subscribes only the legacy name in `Pay::Stripe.configure_webhooks`. When an endpoint delivers `payment_method.automatically_updated`, Pay's webhook controller returns 200, but the delegator instruments a notification with no subscriber, so the event is **silently dropped**: card-network auto-updates (new expiry / new card number pushed by Visa/Mastercard for a saved card) never sync to `pay_payment_methods`.

Note that `docs/stripe/5_webhooks.md` already lists `payment_method.automatically_updated` in the recommended `enabled_events`, so apps following Pay's own docs hit this.

## Fix

Subscribe `stripe.payment_method.automatically_updated` to the existing `Pay::Stripe::Webhooks::PaymentMethodUpdated` handler. The legacy `card_automatically_updated` subscription is kept so older endpoints that still deliver the legacy name continue to work.

Adds a test asserting the delegator is listening for both event names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)