### PR TITLE
Prepare 11.6.2 release for Paddle Billing signature fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+* Use constant-time comparison for Paddle Billing webhook signatures.
+
 ### 11.6.0
 
 * Add `invoice.updated` webhook listener for Stripe to keep latest subscription invoice in sync #1220

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    pay (11.6.1)
+    pay (11.6.2)
       rails (>= 7.0.0)
 
 GEM

--- a/lib/pay/version.rb
+++ b/lib/pay/version.rb
@@ -1,3 +1,3 @@
 module Pay
-  VERSION = "11.6.1"
+  VERSION = "11.6.2"
 end

--- a/test/controllers/pay/webhooks/paddle_billing_controller_test.rb
+++ b/test/controllers/pay/webhooks/paddle_billing_controller_test.rb
@@ -27,5 +27,19 @@ module Pay
         perform_enqueued_jobs
       end
     end
+
+    test "uses constant-time comparison for paddle billing signatures" do
+      controller = Pay::Webhooks::PaddleBillingController.new
+      timestamp = "1730000000"
+      body = {event_type: "transaction.completed"}.to_json
+      secret = "paddle-signing-secret"
+      hmac = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new("sha256"), secret, "#{timestamp}:#{body}")
+
+      controller.stubs(:request).returns(stub(raw_post: body))
+      Pay::PaddleBilling.stubs(:signing_secret).returns(secret)
+      ActiveSupport::SecurityUtils.expects(:secure_compare).with(hmac, hmac).returns(true)
+
+      assert controller.send(:valid_signature?, "ts=#{timestamp};h1=#{hmac}")
+    end
   end
 end


### PR DESCRIPTION
## Summary

Prepares a patched release for GHSA-mjgf-xj26-9qf9.

The Paddle Billing webhook verifier on `main` already uses `ActiveSupport::SecurityUtils.secure_compare`, but the latest released gem is still `11.6.1`, which is included in the advisory's affected range (`<= 11.6.1`).

This bumps the gem version to `11.6.2` and adds regression coverage for the constant-time comparison path.

https://github.com/pay-rails/pay/issues/1232

## Changes

- Bump `Pay::VERSION` to `11.6.2`
- Update `Gemfile.lock` path gem version to `11.6.2`
- Add a changelog entry for the Paddle Billing webhook signature fix
- Add regression coverage that verifies signature validation uses `ActiveSupport::SecurityUtils.secure_compare`
