### PR TITLE
Add Stripe Organization API key support via optional context credential

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+* Add support for Stripe Organization API keys: optional `context` credential (or `STRIPE_CONTEXT`) sets `Stripe-Context` so a single `sk_org_...` key can serve as `private_key`
+
 ### 11.6.2
 
 * Use secure compare for Paddle Billing webhook verification

--- a/docs/stripe/2_credentials.md
+++ b/docs/stripe/2_credentials.md
@@ -10,6 +10,21 @@ You can create (or find) your Stripe private (secret) and public (publishable) k
 >
 > By default we're linking to the "test mode" page for API keys so you can get up and running in development. When you're ready to deploy to production, you'll have to toggle the "test mode" option off and repeat all steps again for live payments.
 
+### Organization API keys (optional)
+
+If you run several businesses under one [Stripe Organization](https://docs.stripe.com/get-started/account/orgs), you can use a single [organization API key](https://docs.stripe.com/keys/organization-api-keys) (`sk_org_…`) as `private_key` instead of a per-account secret key. Org keys require every request to identify the target account, so also set the optional `context` credential to that account's ID:
+
+```yaml
+stripe:
+  private_key: sk_org_xxxx
+  context: acct_xxxx
+  # public_key and signing_secret are still per-account
+```
+
+(Or `ENV["STRIPE_CONTEXT"]`.) Pay passes it to stripe-ruby, which sends the `Stripe-Context` header on every request. With a regular account key, leave `context` unset — nothing changes.
+
+Note: publishable keys and webhook signing secrets remain per-account (organizations can't accept client-side payments), so `public_key` and `signing_secret` stay as they are.
+
 ### Signing secrets
 
 Webhooks use signing secrets to verify the webhook was sent by Stripe. Check out [Webhooks](/docs/stripe/5_webhooks.md#enable-stripe-webhooks) doc for detailed instructions on where/how to get these.

--- a/lib/pay/stripe.rb
+++ b/lib/pay/stripe.rb
@@ -43,6 +43,15 @@ module Pay
     def self.setup
       ::Stripe.api_key = private_key
 
+      # When private_key is a Stripe Organizations API key (sk_org_...),
+      # every request must identify the target account with the
+      # Stripe-Context header. stripe-ruby applies this configuration to all
+      # requests automatically. Regular account keys set no context and are
+      # unaffected. https://docs.stripe.com/keys/organization-api-keys
+      # (Assigned through Stripe.config: the Stripe module delegates
+      # stripe_account but not stripe_context.)
+      ::Stripe.config.stripe_context = context if context
+
       # Used by Stripe to identify Pay for support
       ::Stripe.set_app_info("PayRails", partner_id: "pp_partner_IqhY0UExnJYLxg", version: Pay::VERSION, url: "https://github.com/pay-rails/pay")
 
@@ -58,6 +67,14 @@ module Pay
 
     def self.private_key
       find_value_by_name(:stripe, :private_key)
+    end
+
+    # Optional. The account (acct_...) that API requests should act on when
+    # using a Stripe Organizations API key. Resolved like every other Stripe
+    # credential: ENV["STRIPE_CONTEXT"], then env-scoped, then unscoped
+    # Rails credentials.
+    def self.context
+      find_value_by_name(:stripe, :context)
     end
 
     def self.signing_secret

--- a/test/pay/stripe/processor_test.rb
+++ b/test/pay/stripe/processor_test.rb
@@ -18,6 +18,28 @@ class Pay::Stripe::ProcessorTest < ActiveSupport::TestCase
     ENV.update(old_env)
   end
 
+  test "setup leaves stripe_context unset with regular account keys" do
+    old_env = ENV.to_hash
+    ENV.delete("STRIPE_CONTEXT")
+    ::Stripe.config.stripe_context = nil
+
+    Pay::Stripe.setup
+    assert_nil ::Stripe.config.stripe_context
+  ensure
+    ENV.update(old_env)
+  end
+
+  test "setup applies the context credential for Stripe Organizations API keys" do
+    old_env = ENV.to_hash
+    ENV.update("STRIPE_CONTEXT" => "acct_123")
+
+    Pay::Stripe.setup
+    assert_equal "acct_123", ::Stripe.config.stripe_context.to_s
+  ensure
+    ENV.update(old_env)
+    ::Stripe.config.stripe_context = nil
+  end
+
   test "webhook_receive_test_events default to true" do
     old_env = ENV.to_hash
     ENV.update(


### PR DESCRIPTION
## Motivation

[Stripe Organizations](https://docs.stripe.com/get-started/account/orgs) let one business run many Stripe accounts (one per product), and an [organization-level API key](https://docs.stripe.com/keys/organization-api-keys) (`sk_org_…`) can act on any account in the org — Stripe just requires every request to name the target account via the `Stripe-Context` header. stripe-ruby (≥ the v19 line Pay already requires) supports this as global configuration.

Today, using an org key with Pay requires wiring `Stripe.config.stripe_context` yourself in an initializer. This PR makes it a first-class, opt-in credential.

## What this does

- New optional `Pay::Stripe.context` credential — resolved exactly like the existing Stripe credentials (`ENV["STRIPE_CONTEXT"]` → env-scoped → unscoped), applied during `Pay::Stripe.setup`.
- **No behavior change for regular account keys**: with no `context` credential, nothing is set.
- Docs section in `docs/stripe/2_credentials.md` + CHANGELOG entry.

One implementation note: the assignment goes through `::Stripe.config.stripe_context` because the `Stripe` module delegates `stripe_account` but not `stripe_context`.

## Verification

- Two new tests in `test/pay/stripe/processor_test.rb` (unset by default; applied when the credential exists): **2 runs, 2 assertions, 0 failures**.
- Validated in a production Rails app: livemode customer create/delete through stripe-ruby with an org key + context, and Pay's full flow running against the routed account.
- (One pre-existing, unrelated test errors locally for me — `env ignores Stripe credentials when not defined` via `Rails.stub` — untouched by this change.)

Marked draft to invite maintainer direction — happy to adjust naming (`context` vs `stripe_context`), docs placement, or approach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PqRjZSshq6872LhXvTBaY7