### PR TITLE
Defer receipts include to avoid loading ActiveRecord during boot

### DIFF
--- a/lib/pay/engine.rb
+++ b/lib/pay/engine.rb
@@ -31,19 +31,21 @@ module Pay
       Pay::LemonSqueezy.configure_webhooks if Pay::LemonSqueezy.enabled?
     end
 
+    initializer "pay.receipts" do
+      if defined?(::Receipts::VERSION)
+        raise "[Pay] receipts gem must be version ~> 2" unless Pay::Engine.version_matches?(required: "~> 2", current: ::Receipts::VERSION)
+
+        Rails.autoloaders.main.on_load("Pay::Charge") do |klass, _abspath|
+          klass.include Pay::Receipts
+        end
+      end
+    end
+
     config.to_prepare do
       Pay::Stripe.setup if Pay::Stripe.enabled?
       Pay::Braintree.setup if Pay::Braintree.enabled?
       Pay::PaddleBilling.setup if Pay::PaddleBilling.enabled?
       Pay::LemonSqueezy.setup if Pay::LemonSqueezy.enabled?
-
-      if defined?(::Receipts::VERSION)
-        if Pay::Engine.version_matches?(required: "~> 2", current: ::Receipts::VERSION)
-          Pay::Charge.include Pay::Receipts
-        else
-          raise "[Pay] receipts gem must be version ~> 2"
-        end
-      end
     end
 
     # Determines if a gem version matches requirements


### PR DESCRIPTION
While running my app on edge Rails (5df247f), the new `guard_load_hooks` diagnostic flags this on every dev boot:

```
:active_record_postgresqladapter was loaded before application initialization.
Prematurely executing load hooks will slow down your boot time
and could cause conflicts with the load order of your application.

  ActiveSupport.on_load(:active_record_postgresqladapter) do
    # your code here
  end

Called from:
activerecord/lib/active_record/connection_adapters/postgresql_adapter.rb:1448:in '<module:ConnectionAdapters>'
[...]
activerecord/lib/active_record/connection_adapters.rb:44:in 'ActiveRecord::ConnectionAdapters.resolve'
[...]
activerecord/lib/active_record/connection_handling.rb:53:in 'ActiveRecord::ConnectionHandling#establish_connection'
activerecord/lib/active_record/railtie.rb:279:in 'block (2 levels) in <class:Railtie>'
[...]
activerecord/lib/active_record/base.rb:336:in '<module:ActiveRecord>'
[...]
app/models/application_record.rb:1:in '<compiled>'
[...]
pay-11.6.2/app/models/pay/application_record.rb:2:in '<module:Pay>'
[...]
pay-11.6.2/app/models/pay/charge.rb:2:in '<module:Pay>'
[...]
pay-11.6.2/lib/pay/engine.rb:42:in 'block in <class:Engine>'
[...]
activesupport/lib/active_support/reloader.rb:96:in 'ActiveSupport::Reloader.prepare!'
railties/lib/rails/application/finisher.rb:73:in 'block in <module:Finisher>'
[...]
railties/lib/rails/application.rb:472:in 'Rails::Application#initialize!'
```

So the trace pointing at `pay/lib/pay/engine.rb`'s `to_prepare` → `Pay::Charge` → `Pay::ApplicationRecord` → `ActiveRecord::Base` → adapter load.

Referencing `Pay::Charge` inside the engine's `config.to_prepare` block loads the model , `ActiveRecord::Base`, and the database adapter while the application is still initializing (the first prepare callbacks run inside `Rails::Application#initialize!`).


This PR move the Receipts wiring out of `to_prepare` into an initializer that registers a Zeitwerk `on_load` callback for `Pay::Charge`. The include is applied when the class is actually loaded (lazily in dev, during eager load in production), and Zeitwerk re-fires the callback on every reload, preserving the `to_prepare` semantics.

The receipts gem version check now runs once at boot instead of on every prepare, and still raises on mismatch.

The remaining `to_prepare` contents (`Pay::Stripe.setup` etc.) are untouched because they don't load ActiveRecord.