### PR TITLE
Preserve an existing Stripe API key during setup

### DIFF
--- a/lib/pay/stripe.rb
+++ b/lib/pay/stripe.rb
@@ -41,7 +41,7 @@ module Pay
     end
 
     def self.setup
-      ::Stripe.api_key = private_key
+      ::Stripe.api_key ||= private_key
 
       # When private_key is a Stripe Organizations API key (sk_org_...),
       # every request must identify the target account with the

--- a/test/pay/stripe/processor_test.rb
+++ b/test/pay/stripe/processor_test.rb
@@ -18,6 +18,30 @@ class Pay::Stripe::ProcessorTest < ActiveSupport::TestCase
     ENV.update(old_env)
   end
 
+  test "setup uses Pay's configured API key when Stripe is not configured" do
+    original_api_key = ::Stripe.api_key
+    ::Stripe.api_key = nil
+    Pay::Stripe.stubs(:private_key).returns("configured")
+
+    Pay::Stripe.setup
+
+    assert_equal "configured", ::Stripe.api_key
+  ensure
+    ::Stripe.api_key = original_api_key
+  end
+
+  test "setup preserves an existing Stripe API key" do
+    original_api_key = ::Stripe.api_key
+    ::Stripe.api_key = "existing"
+    Pay::Stripe.stubs(:private_key).returns("configured")
+
+    Pay::Stripe.setup
+
+    assert_equal "existing", ::Stripe.api_key
+  ensure
+    ::Stripe.api_key = original_api_key
+  end
+
   test "setup leaves stripe_context unset with regular account keys" do
     old_env = ENV.to_hash
     ENV.delete("STRIPE_CONTEXT")


### PR DESCRIPTION
## Pull Request

**Summary:**

Preserve an API key configured directly through `stripe-ruby`, while continuing to use Pay’s configured private key as a fallback.

**Related Issue:**

Related to #456.

**Description:**

`Pay::Stripe.setup` currently assigns `Stripe.api_key = private_key` unconditionally. This can overwrite an API key already configured by the host application, including replacing it with `nil` when Pay does not have its own Stripe credentials.

Changing the assignment to `Stripe.api_key ||= private_key` allows applications to configure `stripe-ruby` directly without changing Pay’s existing fallback behavior.

**Testing:**

Added regression tests verifying that:

- Pay’s configured private key is used when `Stripe.api_key` is unset.
- An existing `Stripe.api_key` is preserved.

Commands run:

- `bundle exec ruby -Itest test/pay/stripe/processor_test.rb -n /setup/`
- `bundle exec standardrb lib/pay/stripe.rb test/pay/stripe/processor_test.rb`

The focused setup tests pass with 4 tests and 4 assertions. The complete processor test file currently encounters an unrelated existing Rails 8.1 compatibility error involving `Rails.stub`.

**Screenshots (if applicable):**

Not applicable.

**Checklist:**

- [x] Code follows the project's coding standards
- [x] Tests have been added or updated to cover the changes
- [x] Documentation has been updated (not applicable)
- [ ] All existing tests pass
- [ ] Conforms to the contributing guidelines