### PR TITLE
Prefer active subscriptions in Pay::Customer#subscription

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+* `Pay::Customer#subscription` now prefers an active or paused subscription over a newer canceled one, falling back to the most recently created subscription when none are active
+
 ### 11.7.1
 
 * Preserve existing Stripe api key if already set when Pay initializes #1248

--- a/app/models/pay/customer.rb
+++ b/app/models/pay/customer.rb
@@ -34,8 +34,11 @@ module Pay
       add_payment_method(payment_method_id, default: true)
     end
 
+    # Returns the active or paused subscription for the given name, falling
+    # back to the most recently created subscription when none are active.
     def subscription(name: Pay.default_product_name)
-      subscriptions.order(created_at: :desc).for_name(name).first
+      scope = subscriptions.for_name(name).order(created_at: :desc)
+      scope.active_or_paused.first || scope.first
     end
 
     def subscribed?(name: Pay.default_product_name, processor_plan: nil)

--- a/test/models/pay/customer_test.rb
+++ b/test/models/pay/customer_test.rb
@@ -28,6 +28,36 @@ class Pay::CustomerTest < ActiveSupport::TestCase
     assert pay_customer.update_api_record(promotion_code: "promo_xxx123")
   end
 
+  test "subscription prefers an active subscription over a newer canceled one" do
+    pay_customer = pay_customers(:fake)
+    active = pay_customer.subscriptions.first
+    canceled = pay_customer.subscriptions.create!(processor_id: "fake_2", name: "default", processor_plan: "default", status: "canceled", ends_at: 1.day.ago, created_at: 1.day.from_now)
+
+    assert_equal active, pay_customer.subscription
+    assert_not_equal canceled, pay_customer.subscription
+  end
+
+  test "subscription prefers a paused subscription over a newer canceled one" do
+    pay_customer = pay_customers(:fake)
+    paused = pay_customer.subscriptions.first
+    paused.update!(status: "paused")
+    pay_customer.subscriptions.create!(processor_id: "fake_2", name: "default", processor_plan: "default", status: "canceled", ends_at: 1.day.ago, created_at: 1.day.from_now)
+
+    assert_equal paused, pay_customer.subscription
+  end
+
+  test "subscription falls back to the most recent subscription when none are active" do
+    pay_customer = pay_customers(:fake)
+    pay_customer.subscriptions.first.update!(status: "canceled", ends_at: 2.days.ago)
+    newer = pay_customer.subscriptions.create!(processor_id: "fake_2", name: "default", processor_plan: "default", status: "canceled", ends_at: 1.day.ago, created_at: 1.day.from_now)
+
+    assert_equal newer, pay_customer.subscription
+  end
+
+  test "subscription returns nil when there are no subscriptions for the name" do
+    assert_nil pay_customers(:fake).subscription(name: "nonexistent")
+  end
+
   test "not_fake scope" do
     assert_not_includes Pay::Customer.not_fake_processor, pay_customers(:fake)
     assert_includes Pay::Customer.not_fake_processor, pay_customers(:stripe)

--- a/test/models/pay/subscription_test.rb
+++ b/test/models/pay/subscription_test.rb
@@ -433,13 +433,18 @@ class Pay::Subscription::Test < ActiveSupport::TestCase
 
     subscription_2 = create_subscription(status: "canceled", processor_id: 2)
 
-    assert_equal subscription_2, @pay_customer.subscription
-    assert_equal subscription_2, @pay_customer.subscription
+    # The active subscription is preferred over a newer canceled one
+    assert_equal subscription_1, @pay_customer.subscription
+    assert_equal subscription_1, @pay_customer.subscription
 
     subscription_1.update_columns(status: "canceled")
+    pay_subscriptions(:stripe).update_columns(status: "canceled")
 
     @pay_customer.reload
     assert_not @pay_customer.subscriptions.loaded?
+
+    # With no active subscriptions, the most recently created one is returned
+    assert_equal subscription_2, @pay_customer.subscription
 
     @pay_customer.subscriptions.load
     assert_equal subscription_2, @pay_customer.subscription


### PR DESCRIPTION
## Summary

`Pay::Customer#subscription` returned the most recently created subscription for a name regardless of status. A customer with an older active subscription and a newer canceled one would get the canceled subscription back.

This changes `subscription` to prefer an active or paused subscription, falling back to the most recently created subscription when none are active:

```ruby
def subscription(name: Pay.default_product_name)
  scope = subscriptions.for_name(name).order(created_at: :desc)
  scope.active_or_paused.first || scope.first
end
```

Behavior is unchanged for customers with a single subscription or with no active subscriptions. `active` includes subscriptions on a grace period, so a subscription canceled at period end still counts until it actually ends.

## Tests

- New tests in `customer_test.rb`: active beats newer canceled, paused beats newer canceled, fallback to most recent when all are canceled, nil for an unknown name.
- Updated the existing "consistent regardless of loaded subscriptions" test in `subscription_test.rb`, which was asserting the old newer-canceled-wins behavior; its loaded/unloaded consistency checks are preserved.

Full suite: 552 runs, 0 failures. standardrb clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)