### PR TITLE
Add Square payment processor (card payments, card-on-file, refunds)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+* Add Square payment processor (card payments, card-on-file, refunds, webhooks) with per-merchant OAuth via a configurable `Pay::Square.access_token_provider`. Charges on a tenant's own connected Square account with optional `app_fee_money`. Adds a `square_account` column to scope customers per merchant.
+
 ### 11.7.2
 
 * `Pay::Customer#subscription` now prefers an active or paused subscription over a newer canceled one, falling back to the most recently created subscription when none are active

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ gem "braintree", ">= 2.92.0"
 gem "lemonsqueezy", "~> 1.0"
 gem "paddle", "~> 2.6"
 gem "stripe", "~> 19.0"
+gem "square.rb", "~> 44"
 
 gem "prawn"
 gem "receipts"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,6 +83,22 @@ GEM
       uri (>= 0.13.1)
     addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
+    apimatic_core (0.3.21)
+      apimatic_core_interfaces (~> 0.2.0)
+      certifi (~> 2018.1, >= 2018.01.18)
+      faraday-multipart (~> 1.0)
+      nokogiri (~> 1.13, >= 1.13.10)
+    apimatic_core_interfaces (0.2.3)
+    apimatic_faraday_client_adapter (0.1.6)
+      apimatic_core_interfaces (~> 0.2.0)
+      certifi (~> 2018.1, >= 2018.01.18)
+      faraday (~> 2.0, >= 2.0.1)
+      faraday-follow_redirects (~> 0.2)
+      faraday-gzip (>= 1, < 4)
+      faraday-http-cache (~> 2.2)
+      faraday-multipart (~> 1.0)
+      faraday-net_http_persistent (~> 2.0)
+      faraday-retry (~> 2.0)
     appraisal (3.0.0.rc1)
       bundler
       rake
@@ -95,6 +111,7 @@ GEM
       builder (>= 3.2.4)
       rexml (>= 3.1.9)
     builder (3.3.0)
+    certifi (2018.01.18)
     cgi (0.5.2)
     concurrent-ruby (1.3.8)
     connection_pool (3.0.2)
@@ -110,8 +127,22 @@ GEM
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
+    faraday-follow_redirects (0.5.0)
+      faraday (>= 1, < 3)
+    faraday-gzip (3.1.0)
+      faraday (>= 2.0, < 3)
+      zlib (~> 3.0)
+    faraday-http-cache (2.7.0)
+      faraday (>= 0.8)
+    faraday-multipart (1.2.0)
+      multipart-post (~> 2.0)
     faraday-net_http (3.4.4)
       net-http (~> 0.5)
+    faraday-net_http_persistent (2.3.1)
+      faraday (~> 2.5)
+      net-http-persistent (>= 4.0.4, < 5)
+    faraday-retry (2.4.0)
+      faraday (~> 2.0)
     globalid (1.4.0)
       activesupport (>= 6.1)
     hashdiff (1.2.1)
@@ -145,14 +176,16 @@ GEM
     marcel (1.2.1)
     matrix (0.4.3)
     mini_mime (1.1.5)
-    mini_portile2 (2.8.9)
     minitest (5.27.0)
     mocha (3.1.0)
       ruby2_keywords (>= 0.0.5)
+    multipart-post (2.4.1)
     mysql2 (0.5.7)
       bigdecimal
     net-http (0.9.1)
       uri (>= 0.11.1)
+    net-http-persistent (4.0.8)
+      connection_pool (>= 2.2.4, < 4)
     net-imap (0.6.6)
       date
       net-protocol
@@ -163,9 +196,6 @@ GEM
     net-smtp (0.5.1)
       net-protocol
     nio4r (2.7.5)
-    nokogiri (1.19.4)
-      mini_portile2 (~> 2.8.2)
-      racc (~> 1.4)
     nokogiri (1.19.4-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
@@ -282,10 +312,12 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    sqlite3 (2.9.6)
-      mini_portile2 (~> 2.8.0)
     sqlite3 (2.9.6-x86_64-darwin)
     sqlite3 (2.9.6-x86_64-linux-gnu)
+    square.rb (44.2.0.20251016)
+      apimatic_core (~> 0.3.11)
+      apimatic_core_interfaces (~> 0.2.1)
+      apimatic_faraday_client_adapter (~> 0.1.4)
     standard (1.56.0)
       language_server-protocol (~> 3.17.0.2)
       lint_roller (~> 1.0)
@@ -332,10 +364,11 @@ GEM
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     zeitwerk (2.8.3)
+    zlib (3.2.3)
 
 PLATFORMS
-  ruby
   x86_64-darwin-22
+  x86_64-darwin-24
   x86_64-linux
 
 DEPENDENCIES
@@ -354,6 +387,7 @@ DEPENDENCIES
   receipts
   sprockets-rails
   sqlite3
+  square.rb (~> 44)
   standard
   stimulus-rails
   stripe (~> 19.0)

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Our supported payment processors are:
 - Paddle (SCA Compatible & supports PayPal)
 - Braintree (supports PayPal)
 - Lemon Squeezy (supports PayPal)
+- Square (card payments on a merchant's own connected account via per-merchant OAuth)
 - [Fake Processor](docs/fake_processor/1_overview.md) (used for generic trials without cards, free subscriptions, testing, etc)
 
 Want to add a new payment provider? Contributions are welcome.
@@ -48,6 +49,7 @@ Want to add a new payment provider? Contributions are welcome.
   * [Braintree](docs/braintree/1_overview.md)
   * [Paddle](docs/paddle_billing/1_overview.md)
   * [Lemon Squeezy](docs/lemon_squeezy/1_overview.md)
+  * [Square](docs/square/1_overview.md)
   * [Fake Processor](docs/fake_processor/1_overview.md)
   * [Asaas (Community)](https://github.com/PedroAugustoRamalhoDuarte/pay-asaas)
 * **Marketplaces**

--- a/app/controllers/pay/webhooks/square_controller.rb
+++ b/app/controllers/pay/webhooks/square_controller.rb
@@ -1,0 +1,48 @@
+module Pay
+  module Webhooks
+    class SquareController < ActionController::API
+      def create
+        if valid_signature?(request.headers["x-square-hmacsha256-signature"])
+          queue_event(verify_params.as_json)
+          head :ok
+        else
+          head :bad_request
+        end
+      rescue Pay::Square::Error
+        head :bad_request
+      end
+
+      private
+
+      def queue_event(event)
+        return unless Pay::Webhooks.delegator.listening?("square.#{params[:type]}")
+
+        record = Pay::Webhook.create!(processor: :square, event_type: params[:type], event: event)
+        Pay::Webhooks::ProcessJob.perform_later(record)
+      end
+
+      # Square signs the HMAC-SHA256 over (notification_url + raw body), base64-encoded.
+      # notification_url must match the URL registered with Square; behind a proxy
+      # request.original_url may differ, so it is configurable.
+      def valid_signature?(signature)
+        return false if signature.blank?
+
+        key = Pay::Square.signing_secret
+        return false if key.blank?
+
+        data = notification_url + request.raw_post
+        digest = OpenSSL::Digest.new("sha256")
+        hmac = Base64.strict_encode64(OpenSSL::HMAC.digest(digest, key, data))
+        ActiveSupport::SecurityUtils.secure_compare(hmac, signature)
+      end
+
+      def notification_url
+        Pay::Square.webhook_notification_url.presence || request.original_url
+      end
+
+      def verify_params
+        params.except(:action, :controller).permit!
+      end
+    end
+  end
+end

--- a/app/models/pay/charge.rb
+++ b/app/models/pay/charge.rb
@@ -29,7 +29,7 @@ module Pay
     store_accessor :data, :tax
 
     # Helpers for payment processors
-    %w[braintree stripe paddle_billing paddle_classic lemon_squeezy fake_processor].each do |processor_name|
+    %w[braintree stripe paddle_billing paddle_classic lemon_squeezy square fake_processor].each do |processor_name|
       define_method :"#{processor_name}?" do
         customer.processor == processor_name
       end

--- a/app/models/pay/customer.rb
+++ b/app/models/pay/customer.rb
@@ -22,7 +22,7 @@ module Pay
 
     delegate :email, to: :owner, allow_nil: true
 
-    %w[stripe braintree paddle_billing paddle_classic lemon_squeezy fake_processor].each do |processor_name|
+    %w[stripe braintree paddle_billing paddle_classic lemon_squeezy square fake_processor].each do |processor_name|
       scope processor_name, -> { where(processor: processor_name) }
 
       define_method :"#{processor_name}?" do

--- a/app/models/pay/square/charge.rb
+++ b/app/models/pay/square/charge.rb
@@ -1,0 +1,78 @@
+module Pay
+  module Square
+    class Charge < Pay::Charge
+      store_accessor :data, :square_order_id
+      store_accessor :data, :square_status
+      store_accessor :data, :square_merchant_id
+
+      # Re-fetches authoritative payment state (webhook delivery is unordered), unless a
+      # freshly created payment is passed in.
+      def self.sync(payment_id, object: nil, pay_customer: nil, try: 0, retries: 1)
+        object ||= Pay::Square.with_client(pay_customer) { |client| client.payments.get(payment_id: payment_id) }.payment
+        return if object.nil?
+
+        pay_customer ||= Pay::Customer.find_by(processor: :square, processor_id: object.customer_id)
+        if pay_customer.nil?
+          Rails.logger.debug "Pay::Customer for Square payment #{payment_id} (customer #{object.customer_id}) is not in the database"
+          return
+        end
+
+        card = object.card_details&.card
+        attrs = {
+          amount: object.amount_money&.amount,
+          currency: object.amount_money&.currency&.downcase,
+          application_fee_amount: object.app_fee_money&.amount,
+          amount_refunded: object.refunded_money&.amount || 0,
+          payment_method_type: "card",
+          brand: card&.card_brand,
+          last4: card&.last_4.to_s,
+          exp_month: card&.exp_month&.to_s,
+          exp_year: card&.exp_year&.to_s,
+          square_account: pay_customer.square_account,
+          square_order_id: object.order_id,
+          square_status: object.status,
+          square_merchant_id: (object.respond_to?(:merchant_id) ? object.merchant_id : nil)
+        }
+        attrs[:created_at] = Time.zone.parse(object.created_at.to_s) if object.respond_to?(:created_at) && object.created_at.present?
+
+        if (pay_charge = find_by(customer: pay_customer, processor_id: object.id))
+          pay_charge.with_lock { pay_charge.update!(attrs) }
+          pay_charge
+        else
+          create!(attrs.merge(customer: pay_customer, processor_id: object.id))
+        end
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+        if try >= retries
+          raise
+        else
+          sleep 0.15**(try + 1)
+          retry_args = {object: object, pay_customer: pay_customer, try: try + 1, retries: retries}
+          sync(payment_id, **retry_args)
+        end
+      end
+
+      def api_record
+        Pay::Square.with_client(customer) { |client| client.payments.get(payment_id: processor_id) }.payment
+      end
+
+      # Square refunds are asynchronous (PENDING -> COMPLETED, can fail), so re-sync
+      # amount_refunded from the payment rather than optimistically incrementing.
+      def refund!(amount_to_refund = nil, **options)
+        amount_to_refund ||= amount
+        idempotency_key = options.delete(:idempotency_key) || SecureRandom.uuid
+
+        Pay::Square.with_client(customer) do |client|
+          client.refunds.refund_payment(
+            idempotency_key: idempotency_key,
+            payment_id: processor_id,
+            amount_money: {amount: amount_to_refund, currency: (currency || "usd").to_s.upcase}
+          )
+        end
+
+        self.class.sync(processor_id, pay_customer: customer)
+      end
+    end
+  end
+end
+
+ActiveSupport.run_load_hooks :pay_square_charge, Pay::Square::Charge

--- a/app/models/pay/square/customer.rb
+++ b/app/models/pay/square/customer.rb
@@ -1,0 +1,85 @@
+module Pay
+  module Square
+    class Customer < Pay::Customer
+      has_many :charges, dependent: :destroy, class_name: "Pay::Square::Charge"
+      has_many :payment_methods, dependent: :destroy, class_name: "Pay::Square::PaymentMethod"
+      has_one :default_payment_method, -> { where(default: true) }, class_name: "Pay::Square::PaymentMethod"
+
+      def api_record_attributes
+        attributes = case owner.class.pay_square_customer_attributes
+        when Symbol
+          owner.send(owner.class.pay_square_customer_attributes, self)
+        when Proc
+          owner.class.pay_square_customer_attributes.call(self)
+        end
+        attributes ||= {}
+
+        {email_address: email, given_name: customer_name}.compact.merge(attributes)
+      end
+
+      def api_record
+        if processor_id?
+          Pay::Square.with_client(self) { |client| client.customers.get(customer_id: processor_id) }.customer
+        else
+          result = Pay::Square.with_client(self) { |client| client.customers.create(**api_record_attributes) }.customer
+          update!(processor_id: result.id)
+          result
+        end
+      end
+
+      # Pass a stable idempotency_key (e.g. keyed on the order) to make app-level resubmits
+      # dedupe; otherwise a generated key covers only this call and its 401 retry.
+      def charge(amount, options = {})
+        options = options.dup
+        idempotency_key = options.delete(:idempotency_key) || SecureRandom.uuid
+        currency = (options.delete(:currency) || "usd").to_s.upcase
+        source_id = options.delete(:source_id) || options.delete(:payment_method_id) || default_payment_method&.processor_id
+        raise Pay::Square::Error, "No source_id or default payment method for Square charge" if source_id.blank?
+
+        params = {
+          idempotency_key: idempotency_key,
+          source_id: source_id,
+          amount_money: {amount: amount, currency: currency},
+          customer_id: processor_id || api_record.id
+        }
+        if (app_fee = options.delete(:application_fee_amount) || options.delete(:app_fee_amount))
+          params[:app_fee_money] = {amount: app_fee, currency: currency}
+        end
+        params.merge!(options)
+
+        payment = Pay::Square.with_client(self) { |client| client.payments.create(**params) }.payment
+        Pay::Square::Charge.sync(payment.id, object: payment, pay_customer: self)
+      end
+
+      # source_id is a single-use nonce minted client-side by Square's Web Payments SDK.
+      def add_payment_method(source_id, default: false)
+        api_record unless processor_id?
+        idempotency_key = SecureRandom.uuid
+
+        card = Pay::Square.with_client(self) do |client|
+          client.cards.create(idempotency_key: idempotency_key, source_id: source_id, card: {customer_id: processor_id})
+        end.card
+
+        save_payment_method(card, default: default)
+      end
+
+      def update_payment_method(source_id)
+        add_payment_method(source_id, default: true)
+      end
+
+      def save_payment_method(card, default:)
+        pay_payment_method = payment_methods.where(processor_id: card.id).first_or_initialize
+
+        attributes = Pay::Square::PaymentMethod.extract_attributes(card).merge(default: default, square_account: square_account)
+
+        payment_methods.where.not(id: pay_payment_method.id).update_all(default: false) if default
+        pay_payment_method.update!(attributes)
+
+        reload_default_payment_method
+        pay_payment_method
+      end
+    end
+  end
+end
+
+ActiveSupport.run_load_hooks :pay_square_customer, Pay::Square::Customer

--- a/app/models/pay/square/payment_method.rb
+++ b/app/models/pay/square/payment_method.rb
@@ -1,0 +1,37 @@
+module Pay
+  module Square
+    class PaymentMethod < Pay::PaymentMethod
+      # Pass `object` (the Square card) when you have it; otherwise it is re-fetched.
+      def self.sync(card_id, object: nil, pay_customer: nil, try: 0, retries: 1)
+        object ||= Pay::Square.with_client(pay_customer) { |client| client.cards.get(card_id: card_id) }.card
+        return if object.nil?
+
+        pay_customer ||= Pay::Customer.find_by(processor: :square, processor_id: object.customer_id)
+        return if pay_customer.nil?
+
+        pay_payment_method = pay_customer.payment_methods.where(processor_id: object.id).first_or_initialize
+        pay_payment_method.update!(extract_attributes(object).merge(square_account: pay_customer.square_account))
+        pay_payment_method
+      rescue ActiveRecord::RecordInvalid, ActiveRecord::RecordNotUnique
+        if try >= retries
+          raise
+        else
+          sleep 0.15**(try + 1)
+          sync(card_id, object: object, pay_customer: pay_customer, try: try + 1, retries: retries)
+        end
+      end
+
+      def self.extract_attributes(card)
+        {
+          payment_method_type: "card",
+          brand: card.card_brand,
+          last4: card.last_4.to_s,
+          exp_month: card.exp_month.to_s,
+          exp_year: card.exp_year.to_s
+        }
+      end
+    end
+  end
+end
+
+ActiveSupport.run_load_hooks :pay_square_payment_method, Pay::Square::PaymentMethod

--- a/app/models/pay/webhook.rb
+++ b/app/models/pay/webhook.rb
@@ -25,6 +25,8 @@ module Pay
         Pay::LemonSqueezy.construct_from_webhook_event(event)
       when "stripe"
         ::Stripe::Event.construct_from(event)
+      when "square"
+        Pay::Square.construct_from_webhook_event(event)
       else
         event
       end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,5 @@ Pay::Engine.routes.draw do
   post "webhooks/paddle_billing", to: "pay/webhooks/paddle_billing#create" if Pay::PaddleBilling.enabled?
   post "webhooks/paddle_classic", to: "pay/webhooks/paddle_classic#create" if Pay::PaddleClassic.enabled?
   post "webhooks/lemon_squeezy", to: "pay/webhooks/lemon_squeezy#create" if Pay::LemonSqueezy.enabled?
+  post "webhooks/square", to: "pay/webhooks/square#create" if Pay::Square.enabled?
 end

--- a/db/migrate/20250901000001_add_square_account_to_pay_models.rb
+++ b/db/migrate/20250901000001_add_square_account_to_pay_models.rb
@@ -1,0 +1,9 @@
+class AddSquareAccountToPayModels < ActiveRecord::Migration[6.0]
+  # Scopes a Pay::Customer / PaymentMethod / Charge to a Square merchant (mirrors
+  # stripe_account). Existing apps: run `bin/rails pay:install:migrations && db:migrate`.
+  def change
+    add_column :pay_customers, :square_account, :string
+    add_column :pay_payment_methods, :square_account, :string
+    add_column :pay_charges, :square_account, :string
+  end
+end

--- a/docs/square/1_overview.md
+++ b/docs/square/1_overview.md
@@ -1,0 +1,109 @@
+# Using Pay with Square
+
+Square works differently from the other processors in one important way: it is a
+**marketplace** processor. Instead of one platform API key, Square issues a **distinct
+OAuth access token per merchant**, and you charge on behalf of each merchant's own
+connected Square account (you are not the merchant of record).
+
+Because of that, Pay does not hold a global Square key. You give Pay a resolver that
+returns a fresh access token for a given customer's merchant, and Pay builds a
+`Square::Client` per operation.
+
+This processor covers **card payments, card-on-file, and refunds**. It does not implement
+Square subscriptions, catalog, payouts, or the OAuth authorize/callback flow — those stay
+in your app.
+
+## Configuring the access token resolver
+
+Set a callable that returns a fresh Square OAuth access token for a `Pay::Customer`. It
+receives `(pay_customer, force_refresh = false)`; when `force_refresh` is true (after a
+`401`), return a freshly refreshed token.
+
+```ruby
+# config/initializers/pay.rb
+Pay::Square.access_token_provider = ->(pay_customer, force_refresh = false) do
+  account = ConnectedAccount.find_by!(owner: pay_customer.owner, provider: "square")
+  account.refresh! if force_refresh
+  account.access_token
+end
+```
+
+Your app owns storing and refreshing the token (Square access tokens expire ~30 days).
+See [Credentials](2_credentials.md) for environment and webhook configuration.
+
+## Creating customers
+
+Tell Pay to use Square, passing the merchant id as `square_account` so the customer is
+scoped to that merchant:
+
+```ruby
+@user.set_payment_processor :square, square_account: "MLXXXXXXXXXXXX"
+```
+
+`square_account` is part of the customer lookup key, so the same user transacting with two
+different Square merchants gets two isolated `Pay::Customer` records. Customers are lazily
+created; you can force it with `@user.payment_processor.api_record`.
+
+## Payment methods (card-on-file)
+
+Card capture happens client-side in Square's Web Payments SDK, which mints a single-use
+`source_id` (nonce). Pass that nonce to attach a card on file:
+
+```ruby
+@user.payment_processor.add_payment_method("cnon:card-nonce-from-web-payments-sdk", default: true)
+```
+
+The app never handles raw card data (PCI SAQ A); Pay stores only Square's card token and
+display metadata (`brand`, `last4`, `exp_month`, `exp_year`). The access token is never
+persisted or logged.
+
+## Charges
+
+```ruby
+# Charge the default card on file
+@user.payment_processor.charge(10_00)
+
+# Or a specific nonce, with an application fee and an app-supplied idempotency key
+@user.payment_processor.charge(
+  10_00,
+  source_id: "cnon:...",
+  currency: "usd",
+  application_fee_amount: 1_00,
+  idempotency_key: "appointment-42"
+)
+```
+
+Square requires an idempotency key. If you pass `idempotency_key:`, resubmits of the same
+logical payment (a double-clicked button, a retried request) dedupe. If you omit it, Pay
+generates one that is safe within a single call and its automatic `401` retry, but not
+across separate requests — pass a stable key derived from your order/appointment to be
+safe.
+
+The Square `payment_id`, `order_id`, and status are available on the charge:
+
+```ruby
+charge = @user.payment_processor.charge(10_00, source_id: "cnon:...")
+charge.processor_id      # Square payment id
+charge.square_order_id
+charge.square_status
+charge.application_fee_amount
+```
+
+## Refunds
+
+```ruby
+charge.refund!              # full
+charge.refund!(5_00)        # partial
+```
+
+Square refunds are asynchronous (`PENDING` → `COMPLETED`, and can fail), so `amount_refunded`
+is synced from Square's authoritative state rather than incremented optimistically; the
+`refund.updated` webhook updates it again when the refund settles.
+
+## No server-side SCA/strong-customer-authentication step
+
+Unlike Stripe, Square has no server-side PaymentIntent/`requires_action` flow — 3-D Secure
+buyer verification happens client-side in the Web Payments SDK before you receive a nonce.
+So `Pay::Payment`, `Pay::Customer#has_incomplete_payment?`, and the
+`payment_action_required` email do not apply to Square. A Square charge either succeeds or
+raises `Pay::Square::Error`.

--- a/docs/square/2_credentials.md
+++ b/docs/square/2_credentials.md
@@ -1,0 +1,42 @@
+# Square Credentials
+
+Square does not use a single platform API key in Pay. The per-merchant OAuth access token
+is supplied at runtime by `Pay::Square.access_token_provider` (see
+[Overview](1_overview.md)). The values below are app-level configuration, resolved like
+every other Pay credential: `ENV`, then env-scoped Rails credentials, then unscoped Rails
+credentials.
+
+## Environment
+
+Selects the Square API host (`production` or `sandbox`). Defaults to `production`.
+
+```yaml
+# rails credentials
+square:
+  environment: sandbox
+```
+
+```bash
+export SQUARE_ENVIRONMENT=sandbox
+```
+
+## Webhook signing secret
+
+The app-level signature key from your Square webhook subscription. This is **not** a
+merchant OAuth token — it is a single app-level secret used to verify inbound webhooks.
+
+```bash
+export SQUARE_SIGNING_SECRET=...
+```
+
+## Webhook notification URL
+
+Square computes the webhook HMAC over `notification_url + body`, so verification needs the
+exact public URL registered with your Square webhook subscription. Behind a proxy or load
+balancer `request.original_url` may not match, so set it explicitly:
+
+```bash
+export SQUARE_WEBHOOK_NOTIFICATION_URL=https://example.com/pay/webhooks/square
+```
+
+If unset, Pay falls back to the request URL.

--- a/docs/square/3_webhooks.md
+++ b/docs/square/3_webhooks.md
@@ -1,0 +1,40 @@
+# Square Webhooks
+
+Pay mounts a Square webhook endpoint at `/pay/webhooks/square` (like the other
+processors). Point your Square webhook subscription at it and set the signing secret and
+notification URL (see [Credentials](2_credentials.md)).
+
+Requests are verified with Square's `x-square-hmacsha256-signature` header (HMAC-SHA256 over
+`notification_url + raw body`, base64) before anything is processed. Invalid signatures get
+a `400`.
+
+## Handled events
+
+Pay handles the payment/refund/card/customer events for this slice:
+
+* `payment.created`, `payment.updated`
+* `refund.created`, `refund.updated`
+* `card.created`, `card.updated`, `card.disabled`
+* `customer.created`, `customer.updated`, `customer.deleted`
+
+Payout events are intentionally not handled here — settlement/reconciliation is app-side.
+
+## Ordering and idempotency
+
+Square webhook delivery is unordered and at-least-once. Rather than trusting the snapshot in
+the payload (which could be stale relative to a later event), the handlers take the object
+id from the verified event and **re-fetch authoritative state** from the Square API via the
+merchant's token, then upsert. This makes duplicate and out-of-order deliveries safe.
+
+## Subscribing your own handlers
+
+Pay uses `ActiveSupport::Notifications` under the hood. Subscribe to any event with the
+`square.` prefix:
+
+```ruby
+Pay::Webhooks.configure do |events|
+  events.subscribe "square.payment.updated" do |event|
+    # ...
+  end
+end
+```

--- a/lib/pay.rb
+++ b/lib/pay.rb
@@ -20,6 +20,7 @@ module Pay
   autoload :PaddleBilling, "pay/paddle_billing"
   autoload :PaddleClassic, "pay/paddle_classic"
   autoload :LemonSqueezy, "pay/lemon_squeezy"
+  autoload :Square, "pay/square"
   autoload :Stripe, "pay/stripe"
 
   autoload :Webhooks, "pay/webhooks"
@@ -57,7 +58,7 @@ module Pay
   @@routes_path = "/pay"
 
   mattr_accessor :enabled_processors
-  @@enabled_processors = [:stripe, :braintree, :paddle_billing, :paddle_classic, :lemon_squeezy]
+  @@enabled_processors = [:stripe, :braintree, :paddle_billing, :paddle_classic, :lemon_squeezy, :square]
 
   mattr_accessor :send_emails
   @@send_emails = true

--- a/lib/pay/attributes.rb
+++ b/lib/pay/attributes.rb
@@ -11,6 +11,7 @@ module Pay
         cattr_accessor :pay_default_payment_processor
         cattr_accessor :pay_stripe_customer_attributes
         cattr_accessor :pay_braintree_customer_attributes
+        cattr_accessor :pay_square_customer_attributes
 
         has_many :pay_customers, class_name: "Pay::Customer", as: :owner, inverse_of: :owner
         has_many :pay_charges, through: :pay_customers, class_name: "Pay::Charge", source: :charges
@@ -20,6 +21,7 @@ module Pay
         after_commit :cancel_active_pay_subscriptions!, on: [:destroy]
 
         Pay::Stripe.model_names << name if Pay::Stripe.enabled?
+        Pay::Square.model_names << name if Pay::Square.enabled?
       end
 
       # Changes a user's payment processor
@@ -28,7 +30,7 @@ module Pay
       # - Finds or creates a Pay::Customer for the process and marks it as default
       # - Removes the default flag from all other Pay::Customers
       # - Removes the default flag from all Pay::PaymentMethods
-      def set_payment_processor(processor_name, allow_fake: false, stripe_account: nil, **attributes)
+      def set_payment_processor(processor_name, allow_fake: false, stripe_account: nil, square_account: nil, **attributes)
         raise Pay::Error, "Processor `#{processor_name}` is not allowed" if processor_name.to_s == "fake_processor" && !allow_fake
 
         # Safety check to make sure this is a valid Pay processor
@@ -40,7 +42,8 @@ module Pay
           pay_customer = pay_customers.active.where(
             Pay::Customer.inheritance_column => klass.name,
             :processor => processor_name,
-            :stripe_account => stripe_account
+            :stripe_account => stripe_account,
+            :square_account => square_account
           ).first_or_initialize
           pay_customer.update!(attributes.merge(default: true))
         end
@@ -49,7 +52,7 @@ module Pay
         reload_payment_processor
       end
 
-      def add_payment_processor(processor_name, allow_fake: false, stripe_account: nil, **attributes)
+      def add_payment_processor(processor_name, allow_fake: false, stripe_account: nil, square_account: nil, **attributes)
         raise Pay::Error, "Processor `#{processor_name}` is not allowed" if processor_name.to_s == "fake_processor" && !allow_fake
 
         # Safety check to make sure this is a valid Pay processor
@@ -59,7 +62,8 @@ module Pay
         pay_customer = pay_customers.active.where(
           Pay::Customer.inheritance_column => klass.name,
           :processor => processor_name,
-          :stripe_account => stripe_account
+          :stripe_account => stripe_account,
+          :square_account => square_account
         ).first_or_initialize
         pay_customer.update!(attributes)
         pay_customer
@@ -111,6 +115,7 @@ module Pay
         self.pay_default_payment_processor = options[:default_payment_processor]
         self.pay_stripe_customer_attributes = options[:stripe_attributes]
         self.pay_braintree_customer_attributes = options[:braintree_attributes]
+        self.pay_square_customer_attributes = options[:square_attributes]
       end
 
       def pay_merchant(options = {})

--- a/lib/pay/engine.rb
+++ b/lib/pay/engine.rb
@@ -39,6 +39,7 @@ module Pay
       Pay::PaddleBilling.configure_webhooks if Pay::PaddleBilling.enabled?
       Pay::PaddleClassic.configure_webhooks if Pay::PaddleClassic.enabled?
       Pay::LemonSqueezy.configure_webhooks if Pay::LemonSqueezy.enabled?
+      Pay::Square.configure_webhooks if Pay::Square.enabled?
     end
 
     config.to_prepare do
@@ -46,6 +47,7 @@ module Pay
       Pay::Braintree.setup if Pay::Braintree.enabled?
       Pay::PaddleBilling.setup if Pay::PaddleBilling.enabled?
       Pay::LemonSqueezy.setup if Pay::LemonSqueezy.enabled?
+      Pay::Square.setup if Pay::Square.enabled?
     end
 
     # Determines if a gem version matches requirements

--- a/lib/pay/square.rb
+++ b/lib/pay/square.rb
@@ -1,0 +1,121 @@
+module Pay
+  module Square
+    # Unlike Stripe Connect (one platform key + a stripe_account header), Square issues a
+    # distinct OAuth access token per merchant, so the processor builds a Square::Client
+    # per operation from a token supplied by access_token_provider.
+    class Error < Pay::Error
+    end
+
+    module Webhooks
+      autoload :Payment, "pay/webhooks/square/payment"
+      autoload :Refund, "pay/webhooks/square/refund"
+      autoload :Card, "pay/webhooks/square/card"
+      autoload :Customer, "pay/webhooks/square/customer"
+    end
+
+    extend Env
+
+    REQUIRED_VERSION = "~> 44"
+
+    # A callable accepting (pay_customer, force_refresh = false) that returns a fresh
+    # per-merchant OAuth access token. force_refresh is set true on the retry after a 401.
+    mattr_accessor :access_token_provider, default: nil
+
+    mattr_accessor :model_names, default: Set.new
+
+    def self.enabled?
+      return false unless Pay.enabled_processors.include?(:square) && defined?(::Square)
+
+      # square.rb does not autoload Square::VERSION on `require "square"`.
+      current = ::Gem.loaded_specs["square.rb"]&.version&.to_s
+      return true if current.nil?
+      Pay::Engine.version_matches?(required: REQUIRED_VERSION, current: current) || (raise "[Pay] square.rb gem must be version #{REQUIRED_VERSION}")
+    end
+
+    # No global API key: Square authenticates per-merchant via access_token_provider.
+    def self.setup
+    end
+
+    def self.environment
+      find_value_by_name(:square, :environment).presence || "production"
+    end
+
+    def self.base_url
+      (environment.to_s == "sandbox") ? ::Square::Environment::SANDBOX : ::Square::Environment::PRODUCTION
+    end
+
+    def self.signing_secret
+      find_value_by_name(:square, :signing_secret)
+    end
+
+    # Square's HMAC covers (notification_url + body), so this must match the URL registered
+    # with Square; behind a proxy request.original_url may not.
+    def self.webhook_notification_url
+      find_value_by_name(:square, :webhook_notification_url)
+    end
+
+    def self.access_token(pay_customer, force_refresh: false)
+      unless access_token_provider.respond_to?(:call)
+        raise Pay::Square::Error, "Pay::Square.access_token_provider is not configured. Set it to a callable that returns a fresh Square OAuth access token for a Pay::Customer."
+      end
+
+      token = if access_token_provider.arity == 1 || access_token_provider.arity.zero?
+        access_token_provider.call(pay_customer)
+      else
+        access_token_provider.call(pay_customer, force_refresh)
+      end
+
+      raise Pay::Square::Error, "Pay::Square.access_token_provider returned a blank token for pay_customer #{pay_customer&.id}" if token.blank?
+      token
+    end
+
+    def self.client(pay_customer, force_refresh: false)
+      ::Square::Client.new(base_url: base_url, token: access_token(pay_customer, force_refresh: force_refresh))
+    end
+
+    # Retries ONCE with a force-refreshed token on a 401 and maps Square errors to
+    # Pay::Square::Error. Callers MUST build any idempotency_key outside this block so the
+    # retry reuses the same key and cannot double-charge.
+    def self.with_client(pay_customer)
+      attempts = 0
+      begin
+        attempts += 1
+        yield client(pay_customer, force_refresh: attempts > 1)
+      rescue ::Square::Errors::UnauthorizedError => e
+        if attempts < 2
+          Rails.logger.info { "[Pay::Square] access token rejected (401) for pay_customer #{pay_customer&.id}; forcing refresh and retrying" }
+          retry
+        end
+        raise Pay::Square::Error, e
+      rescue ::Square::Errors::ApiError => e
+        raise Pay::Square::Error, e
+      end
+    end
+
+    def self.construct_from_webhook_event(event)
+      case event
+      when Hash
+        ActiveSupport::InheritableOptions.new(event.map { |key, value| [key.to_sym, construct_from_webhook_event(value)] }.to_h)
+      when Array
+        event.map { |value| construct_from_webhook_event(value) }
+      else
+        event
+      end
+    end
+
+    def self.configure_webhooks
+      Pay::Webhooks.configure do |events|
+        events.subscribe "square.payment.created", Pay::Square::Webhooks::Payment.new
+        events.subscribe "square.payment.updated", Pay::Square::Webhooks::Payment.new
+        events.subscribe "square.refund.created", Pay::Square::Webhooks::Refund.new
+        events.subscribe "square.refund.updated", Pay::Square::Webhooks::Refund.new
+        events.subscribe "square.card.created", Pay::Square::Webhooks::Card.new
+        events.subscribe "square.card.updated", Pay::Square::Webhooks::Card.new
+        events.subscribe "square.card.disabled", Pay::Square::Webhooks::Card.new
+        events.subscribe "square.customer.created", Pay::Square::Webhooks::Customer.new
+        events.subscribe "square.customer.updated", Pay::Square::Webhooks::Customer.new
+        events.subscribe "square.customer.deleted", Pay::Square::Webhooks::Customer.new
+      end
+    end
+  end
+end

--- a/lib/pay/webhooks/square/card.rb
+++ b/lib/pay/webhooks/square/card.rb
@@ -1,0 +1,21 @@
+module Pay
+  module Square
+    module Webhooks
+      class Card
+        def call(event)
+          object = event.data&.object&.card
+          return unless object&.id
+
+          pay_customer = object.customer_id.present? ? Pay::Customer.find_by(processor: :square, processor_id: object.customer_id) : nil
+          return unless pay_customer
+
+          if event.type.to_s == "card.disabled"
+            Pay::PaymentMethod.find_by_processor_and_id(:square, object.id)&.destroy
+          else
+            Pay::Square::PaymentMethod.sync(object.id, pay_customer: pay_customer)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pay/webhooks/square/customer.rb
+++ b/lib/pay/webhooks/square/customer.rb
@@ -1,0 +1,19 @@
+module Pay
+  module Square
+    module Webhooks
+      class Customer
+        def call(event)
+          object = event.data&.object&.customer
+          return unless object&.id
+
+          pay_customer = Pay::Customer.find_by(processor: :square, processor_id: object.id)
+          return unless pay_customer
+
+          if event.type.to_s == "customer.deleted"
+            pay_customer.update(deleted_at: Time.current) if pay_customer.respond_to?(:deleted_at)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pay/webhooks/square/payment.rb
+++ b/lib/pay/webhooks/square/payment.rb
@@ -1,0 +1,21 @@
+module Pay
+  module Square
+    module Webhooks
+      class Payment
+        def call(event)
+          object = event.data&.object&.payment
+          return unless object&.id
+
+          pay_customer = object.customer_id.present? ? Pay::Customer.find_by(processor: :square, processor_id: object.customer_id) : nil
+          return unless pay_customer
+
+          pay_charge = Pay::Square::Charge.sync(object.id, pay_customer: pay_customer)
+
+          if pay_charge && Pay.send_email?(:receipt, pay_charge)
+            Pay.mailer.with(pay_customer: pay_charge.customer, pay_charge: pay_charge).receipt.deliver_later
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/pay/webhooks/square/refund.rb
+++ b/lib/pay/webhooks/square/refund.rb
@@ -1,0 +1,22 @@
+module Pay
+  module Square
+    module Webhooks
+      class Refund
+        def call(event)
+          object = event.data&.object&.refund
+          return unless object&.payment_id
+
+          pay_charge = Pay::Charge.find_by(processor_id: object.payment_id)
+          pay_customer = pay_charge&.customer || ((object.respond_to?(:customer_id) && object.customer_id.present?) ? Pay::Customer.find_by(processor: :square, processor_id: object.customer_id) : nil)
+          return unless pay_customer
+
+          pay_charge = Pay::Square::Charge.sync(object.payment_id, pay_customer: pay_customer)
+
+          if pay_charge && Pay.send_email?(:refund, pay_charge)
+            Pay.mailer.with(pay_customer: pay_charge.customer, pay_charge: pay_charge).refund.deliver_later
+          end
+        end
+      end
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2025_04_15_151129) do
+ActiveRecord::Schema.define(version: 2025_09_01_000001) do
   create_table "accounts", force: :cascade do |t|
     t.string "email"
     t.string "merchant_processor"
@@ -28,6 +28,7 @@ ActiveRecord::Schema.define(version: 2025_04_15_151129) do
     t.json "metadata"
     t.json "data"
     t.string "stripe_account"
+    t.string "square_account"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "type"
@@ -44,6 +45,7 @@ ActiveRecord::Schema.define(version: 2025_04_15_151129) do
     t.boolean "default"
     t.json "data"
     t.string "stripe_account"
+    t.string "square_account"
     t.datetime "deleted_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -73,6 +75,7 @@ ActiveRecord::Schema.define(version: 2025_04_15_151129) do
     t.string "payment_method_type"
     t.json "data"
     t.string "stripe_account"
+    t.string "square_account"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "type"

--- a/test/pay/square/charge_test.rb
+++ b/test/pay/square/charge_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+class Pay::Square::ChargeTest < Pay::Square::TestCase
+  setup do
+    @user = users(:none)
+    @pay_customer = @user.set_payment_processor(:square, square_account: "MERCHANT_1")
+    @pay_customer.update!(processor_id: "sqcust_test")
+    @charge = @pay_customer.charges.create!(processor_id: "pmt_test", amount: 10_00, currency: "usd", square_account: "MERCHANT_1")
+  end
+
+  test "sync re-fetches authoritative payment state from the API" do
+    @charge.destroy
+    stub_square(:get, "payments/pmt_test", response: {payment: square_payment_json})
+
+    charge = Pay::Square::Charge.sync("pmt_test", pay_customer: @pay_customer)
+    assert_equal 10_00, charge.amount
+    assert_equal "usd", charge.currency
+    assert_equal 1_00, charge.application_fee_amount
+    assert_equal "MERCHANT_1", charge.square_account
+    assert_equal "VISA", charge.brand
+  end
+
+  test "refund issues a refund then re-syncs amount_refunded from authoritative state" do
+    stub_square(:post, "refunds", response: {refund: {id: "ref_1", status: "PENDING", payment_id: "pmt_test", amount_money: {amount: 5_00, currency: "USD"}}})
+    stub_square(:get, "payments/pmt_test", response: {payment: square_payment_json(refunded_money: {amount: 5_00, currency: "USD"})})
+
+    @charge.refund!(5_00)
+    assert_equal 5_00, @charge.reload.amount_refunded
+  end
+
+  test "refund does not optimistically increment when the API rejects" do
+    stub_square(:post, "refunds", status: 422, response: {errors: [{category: "INVALID_REQUEST_ERROR", code: "REFUND_AMOUNT_INVALID"}]})
+
+    assert_raises(Pay::Square::Error) { @charge.refund!(50_00) }
+    assert_equal 0, @charge.reload.amount_refunded.to_i
+  end
+end

--- a/test/pay/square/customer_test.rb
+++ b/test/pay/square/customer_test.rb
@@ -1,0 +1,102 @@
+require "test_helper"
+
+class Pay::Square::CustomerTest < Pay::Square::TestCase
+  setup do
+    @user = users(:none)
+    @pay_customer = @user.set_payment_processor(:square, square_account: "MERCHANT_1")
+    @pay_customer.update!(processor_id: "sqcust_test")
+  end
+
+  test "creates a Square customer and assigns processor_id" do
+    @pay_customer.update!(processor_id: nil)
+    stub_square(:post, "customers", response: {customer: {id: "sqcust_new"}})
+
+    record = @pay_customer.api_record
+    assert_equal "sqcust_new", record.id
+    assert_equal "sqcust_new", @pay_customer.reload.processor_id
+  end
+
+  test "adds a card on file" do
+    stub_square(:post, "cards", response: {card: square_card_json})
+
+    pay_payment_method = @pay_customer.add_payment_method("cnon:card-nonce-ok", default: true)
+    assert_equal "card_test", pay_payment_method.processor_id
+    assert_equal "card", pay_payment_method.payment_method_type
+    assert_equal "VISA", pay_payment_method.brand
+    assert_equal "4242", pay_payment_method.last4
+    assert_equal "MERCHANT_1", pay_payment_method.square_account
+    assert pay_payment_method.default?
+  end
+
+  test "creates a charge with an application fee and exposes Square ids" do
+    stub_square(:post, "payments", response: {payment: square_payment_json})
+
+    charge = @pay_customer.charge(10_00, source_id: "cnon:card-nonce-ok", application_fee_amount: 1_00)
+
+    assert_instance_of Pay::Square::Charge, charge
+    assert_equal 10_00, charge.amount
+    assert_equal 1_00, charge.application_fee_amount
+    assert_equal "pmt_test", charge.processor_id
+    assert_equal "ord_test", charge.square_order_id
+    assert_equal "COMPLETED", charge.square_status
+    assert_equal "MERCHANT_1", charge.square_account
+  end
+
+  test "charge reuses a caller-provided idempotency key" do
+    stub_square(:post, "payments", response: {payment: square_payment_json})
+      .with { |req| JSON.parse(req.body)["idempotency_key"] == "appointment-42" }
+
+    charge = @pay_customer.charge(10_00, source_id: "cnon:x", idempotency_key: "appointment-42")
+    assert_equal "pmt_test", charge.processor_id
+  end
+
+  test "charge retries once with a refreshed token on 401" do
+    stub_request(:post, square_url("payments")).to_return(
+      {status: 401, body: {errors: [{category: "AUTHENTICATION_ERROR", code: "UNAUTHORIZED"}]}.to_json, headers: {"Content-Type" => "application/json"}},
+      {status: 200, body: {payment: square_payment_json}.to_json, headers: {"Content-Type" => "application/json"}}
+    )
+
+    charge = @pay_customer.charge(10_00, source_id: "cnon:x")
+
+    assert_equal "pmt_test", charge.processor_id
+    assert_equal 2, @square_token_calls.size
+    assert_equal false, @square_token_calls[0][:force_refresh]
+    assert_equal true, @square_token_calls[1][:force_refresh], "expected the retry to force-refresh the token"
+  end
+
+  test "maps Square API errors to Pay::Square::Error" do
+    stub_square(:post, "payments", status: 422, response: {errors: [{category: "INVALID_REQUEST_ERROR", code: "BAD_REQUEST"}]})
+
+    assert_raises(Pay::Square::Error) do
+      @pay_customer.charge(10_00, source_id: "cnon:x")
+    end
+  end
+
+  test "raises when the access token provider is not configured" do
+    Pay::Square.access_token_provider = nil
+    assert_raises(Pay::Square::Error) do
+      @pay_customer.charge(10_00, source_id: "cnon:x")
+    end
+  end
+
+  test "raises when the resolver returns a blank token" do
+    Pay::Square.access_token_provider = ->(pay_customer, force_refresh = false) { "" }
+    assert_raises(Pay::Square::Error) do
+      @pay_customer.charge(10_00, source_id: "cnon:x")
+    end
+  end
+
+  test "never persists the access token on any record" do
+    stub_square(:post, "cards", response: {card: square_card_json})
+    stub_square(:post, "payments", response: {payment: square_payment_json})
+
+    pay_payment_method = @pay_customer.add_payment_method("cnon:x", default: true)
+    charge = @pay_customer.charge(10_00, source_id: "cnon:x")
+
+    [@pay_customer.reload, pay_payment_method.reload, charge.reload].each do |record|
+      dump = record.attributes.to_json
+      refute_includes dump, "test-token", "#{record.class} must not persist the access token"
+      refute_includes dump, "fresh-token", "#{record.class} must not persist the access token"
+    end
+  end
+end

--- a/test/pay/square/isolation_test.rb
+++ b/test/pay/square/isolation_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+# Cross-merchant isolation: one owner + two square_accounts must yield two distinct
+# Pay::Customers (mirrors the Stripe Connect fix in #1198).
+class Pay::Square::IsolationTest < Pay::Square::TestCase
+  setup do
+    @user = users(:none)
+  end
+
+  test "same owner with two square_accounts gets two isolated pay_customers" do
+    c1 = @user.add_payment_processor(:square, square_account: "MERCHANT_1")
+    c2 = @user.add_payment_processor(:square, square_account: "MERCHANT_2")
+
+    assert_not_equal c1.id, c2.id
+    assert_equal "MERCHANT_1", c1.square_account
+    assert_equal "MERCHANT_2", c2.square_account
+    assert_equal 2, @user.pay_customers.where(processor: "square").count
+  end
+
+  test "same owner + same square_account reuses the pay_customer" do
+    c1 = @user.add_payment_processor(:square, square_account: "MERCHANT_1")
+    c2 = @user.add_payment_processor(:square, square_account: "MERCHANT_1")
+
+    assert_equal c1.id, c2.id
+    assert_equal 1, @user.pay_customers.where(processor: "square").count
+  end
+end

--- a/test/pay/square/payment_method_test.rb
+++ b/test/pay/square/payment_method_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class Pay::Square::PaymentMethodTest < Pay::Square::TestCase
+  setup do
+    @user = users(:none)
+    @pay_customer = @user.set_payment_processor(:square, square_account: "MERCHANT_1")
+    @pay_customer.update!(processor_id: "sqcust_test")
+  end
+
+  test "sync persists a Square card on file" do
+    stub_square(:get, "cards/card_test", response: {card: square_card_json})
+
+    pay_payment_method = Pay::Square::PaymentMethod.sync("card_test", pay_customer: @pay_customer)
+    assert_equal "card_test", pay_payment_method.processor_id
+    assert_equal "card", pay_payment_method.payment_method_type
+    assert_equal "VISA", pay_payment_method.brand
+    assert_equal "4242", pay_payment_method.last4
+    assert_equal "4", pay_payment_method.exp_month
+    assert_equal "2031", pay_payment_method.exp_year
+    assert_equal "MERCHANT_1", pay_payment_method.square_account
+  end
+end

--- a/test/pay/square/webhooks_controller_test.rb
+++ b/test/pay/square/webhooks_controller_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+class Pay::Square::WebhooksControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    VCR.eject_cassette while VCR.current_cassette
+    WebMock.reset!
+    WebMock.disable_net_connect!
+  end
+
+  teardown do
+    WebMock.allow_net_connect!
+  end
+
+  def body
+    {
+      merchant_id: "MERCHANT_1",
+      type: "payment.created",
+      event_id: "evt_test_1",
+      data: {type: "payment", id: "pmt_test", object: {payment: {id: "pmt_test", customer_id: "sqcust_test"}}}
+    }.to_json
+  end
+
+  def signature_for(raw, url: Pay::Square.webhook_notification_url, key: Pay::Square.signing_secret)
+    Base64.strict_encode64(OpenSSL::HMAC.digest(OpenSSL::Digest.new("sha256"), key, url + raw))
+  end
+
+  test "accepts a correctly signed webhook and enqueues processing" do
+    raw = body
+    assert_difference -> { Pay::Webhook.count }, +1 do
+      post "/pay/webhooks/square", params: raw, headers: {
+        "CONTENT_TYPE" => "application/json",
+        "x-square-hmacsha256-signature" => signature_for(raw)
+      }
+    end
+    assert_response :ok
+  end
+
+  test "rejects a webhook with an invalid signature" do
+    raw = body
+    assert_no_difference -> { Pay::Webhook.count } do
+      post "/pay/webhooks/square", params: raw, headers: {
+        "CONTENT_TYPE" => "application/json",
+        "x-square-hmacsha256-signature" => "obviously-wrong-signature"
+      }
+    end
+    assert_response :bad_request
+  end
+
+  test "rejects a webhook whose body was tampered after signing" do
+    signed = body
+    signature = signature_for(signed)
+    tampered = body.sub("pmt_test", "pmt_attacker")
+
+    assert_no_difference -> { Pay::Webhook.count } do
+      post "/pay/webhooks/square", params: tampered, headers: {
+        "CONTENT_TYPE" => "application/json",
+        "x-square-hmacsha256-signature" => signature
+      }
+    end
+    assert_response :bad_request
+  end
+end

--- a/test/support/square.rb
+++ b/test/support/square.rb
@@ -1,0 +1,68 @@
+require "webmock/minitest"
+
+# Square has no VCR cassettes; we WebMock the API directly and eject the per-test
+# cassette that support/vcr.rb inserts.
+module Pay
+  module Square
+    class TestCase < ActiveSupport::TestCase
+      setup do
+        VCR.eject_cassette while VCR.current_cassette
+        WebMock.reset!
+        WebMock.disable_net_connect!
+
+        # @square_token_calls lets tests assert the 401 force-refresh retry.
+        @square_token_calls = []
+        Pay::Square.access_token_provider = ->(pay_customer, force_refresh = false) do
+          @square_token_calls << {customer: pay_customer, force_refresh: force_refresh}
+          force_refresh ? "fresh-token" : "test-token"
+        end
+      end
+
+      teardown do
+        Pay::Square.access_token_provider = nil
+        WebMock.reset!
+        WebMock.allow_net_connect!
+      end
+
+      # https://connect.squareupsandbox.com/v2/<path>
+      def square_url(path)
+        "#{Pay::Square.base_url}/v2/#{path}"
+      end
+
+      def stub_square(method, path, status: 200, response: {}, request_body: nil)
+        stub = stub_request(method, square_url(path))
+        stub = stub.with(body: request_body) if request_body
+        stub.to_return(
+          status: status,
+          body: response.to_json,
+          headers: {"Content-Type" => "application/json"}
+        )
+      end
+
+      def square_payment_json(overrides = {})
+        {
+          id: "pmt_test",
+          order_id: "ord_test",
+          status: "COMPLETED",
+          customer_id: "sqcust_test",
+          amount_money: {amount: 10_00, currency: "USD"},
+          app_fee_money: {amount: 1_00, currency: "USD"},
+          refunded_money: {amount: 0, currency: "USD"},
+          created_at: "2026-09-01T00:00:00Z",
+          card_details: {card: {last_4: "1111", card_brand: "VISA", exp_month: 12, exp_year: 2030}}
+        }.merge(overrides)
+      end
+
+      def square_card_json(overrides = {})
+        {
+          id: "card_test",
+          customer_id: "sqcust_test",
+          last_4: "4242",
+          card_brand: "VISA",
+          exp_month: 4,
+          exp_year: 2031
+        }.merge(overrides)
+      end
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -18,9 +18,16 @@ ENV["PADDLE_BILLING_ENVIRONMENT"] ||= "sandbox"
 ENV["PADDLE_BILLING_SELLER_ID"] ||= "111"
 ENV["PADDLE_BILLING_API_KEY"] ||= "secret"
 
+# Square configuration (per-merchant OAuth token is supplied via the resolver in
+# test/support/square.rb; these are app-level config values)
+ENV["SQUARE_ENVIRONMENT"] ||= "sandbox"
+ENV["SQUARE_SIGNING_SECRET"] ||= "test_square_signing_secret"
+ENV["SQUARE_WEBHOOK_NOTIFICATION_URL"] ||= "https://example.com/pay/webhooks/square"
+
 require "braintree"
 require "stripe"
 require "paddle"
+require "square"
 require "receipts"
 
 require File.expand_path("dummy/config/environment.rb", __dir__)
@@ -31,6 +38,7 @@ require "mocha/minitest"
 require_relative "support/braintree"
 require_relative "support/stripe"
 require_relative "support/vcr"
+require_relative "support/square"
 require_relative "support/payment_method_tests"
 
 # Uncomment to view the stacktrace for debugging tests


### PR DESCRIPTION
## What this adds

A **Square** payment processor covering the payment/card/refund slice, following the existing processor structure (`Pay::Square::Customer` / `PaymentMethod` / `Charge`, `Pay::Webhooks::Square::*`, `lib/pay/square.rb`, `docs/square/*`).

The use case: charge on behalf of a tenant's **own connected Square account** (not merchant of record) with an optional application fee.

> 🙏 **I'm opening this early specifically to get your feedback** — especially on the per-merchant credential approach and the `square_account` naming (below). Heads up: we have **not fully wired this into our own app yet**, so I'm keeping it a draft. We'll be consuming it shortly and will confirm everything is clean and functioning end-to-end, then mark it ready. Happy to adjust anything to match how you'd like it built.

## The one novel design point (feedback wanted)

Unlike Stripe Connect (one platform key + a `stripe_account` request header), Square issues a **distinct OAuth access token per merchant**. There's no shared key, so this cannot reuse the `stripe_context`-style mechanism from #1236 (that's a single-key + selector model). Instead:

- A configurable resolver — `Pay::Square.access_token_provider = ->(pay_customer, force_refresh = false) { ... }` — returns a fresh per-merchant token.
- The processor builds a `Square::Client` **per operation** from that token (a first for the gem; every existing processor sets one global SDK key).
- On a `401` it calls the resolver once with `force_refresh: true` and retries once (the idempotency key is held stable across the retry so it can't double-charge).

The app owns token storage/refresh (tokens expire ~30 days); Pay only asks for one when it needs it. Does this shape work for you, or would you prefer a different seam?

## `square_account` (feedback wanted)

To keep customers isolated per merchant, I added a `square_account` column (customers/charges/payment_methods) and included it in the `set/add_payment_processor` dedup key — mirroring what you did for `stripe_account` in #1198. Kept it processor-specific rather than introducing a generic `account:` param, to match precedent. If you'd rather generalize that, I'm glad to.

## Scope / boundary

In scope: create/find customer, card-on-file (Cards API), charge (`CreatePayment` + `app_fee_money`), refunds, and payment/refund/card/customer webhooks.

Out of scope (deliberately): Square OAuth authorize/callback, token refresh, payouts/reconciliation, catalog, and checkout UI — all app-side. No `Subscription`/`Merchant` classes (Square subscriptions are a separate effort; merchant onboarding is app-side OAuth).

## Notes

- Webhooks are Pay-mounted (`/pay/webhooks/square`), verified via `x-square-hmacsha256-signature` (HMAC over `notification_url + body`). Handlers **re-fetch** authoritative state rather than trusting the payload, since Square delivery is unordered/at-least-once.
- Square refunds are async (`PENDING → COMPLETED`), so `amount_refunded` is synced from the API rather than incremented optimistically.
- No server-side SCA step in Square (3DS is client-side in the Web Payments SDK), so `Pay::Payment`/`has_incomplete_payment?` don't apply — documented in `docs/square/1_overview.md`.
- SDK: `square.rb ~> 44`. Full suite green; new WebMocked suite under `test/pay/square/` covers customer, charge, payment method, cross-merchant isolation, webhook signature (accept/forge/tamper), the 401 refresh-retry, and a token-never-persisted check.

Thanks for the gem — and for any direction here. 🙏
